### PR TITLE
feat(#77): monitoring-request-table-pagination (구현 업데이트)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.90.16",
+    "@tanstack/react-table": "^8.21.3",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.16
         version: 5.90.16(react@19.2.3)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1633,6 +1636,17 @@ packages:
     resolution: {integrity: sha512-bpMGOmV4OPmif7TNMteU/Ehf/hoC0Kf98PDc0F4BZkFrEapRMEqI/V6YS0lyzwSV6PQpY1y4xxArUIfBW5LVxQ==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5172,6 +5186,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.16
       react: 19.2.3
+
+  '@tanstack/react-table@8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/src/app/api/monitoring/requests/route.test.ts
+++ b/src/app/api/monitoring/requests/route.test.ts
@@ -58,4 +58,35 @@ describe("/api/monitoring/requests", () => {
       }),
     );
   });
+
+  it("limit/offset이 없으면 기본 페이지네이션 값을 사용한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockGetMonitoringRequests.mockResolvedValue({
+      updatedAt: "2026-01-03T00:00:00Z",
+      items: [],
+      total: 3,
+      limit: 50,
+      offset: 0,
+    });
+
+    const request = new Request(
+      "http://localhost/api/monitoring/requests?from=2026-01-01&to=2026-01-02",
+    );
+    const response = await GET(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.total).toBe(3);
+    expect(payload.limit).toBe(50);
+    expect(payload.offset).toBe(0);
+    expect(mockGetMonitoringRequests).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 50,
+        offset: 0,
+      }),
+    );
+  });
 });

--- a/src/app/api/monitoring/requests/route.test.ts
+++ b/src/app/api/monitoring/requests/route.test.ts
@@ -36,15 +36,26 @@ describe("/api/monitoring/requests", () => {
     mockGetMonitoringRequests.mockResolvedValue({
       updatedAt: "2026-01-02T00:00:00Z",
       items: [],
+      total: 0,
+      limit: 10,
+      offset: 20,
     });
 
     const request = new Request(
-      "http://localhost/api/monitoring/requests?limit=10&from=2026-01-01&to=2026-01-02",
+      "http://localhost/api/monitoring/requests?limit=10&offset=20&from=2026-01-01&to=2026-01-02",
     );
     const response = await GET(request);
     const payload = await response.json();
 
     expect(response.status).toBe(200);
     expect(payload.updatedAt).toBe("2026-01-02T00:00:00Z");
+    expect(payload.limit).toBe(10);
+    expect(payload.offset).toBe(20);
+    expect(mockGetMonitoringRequests).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 10,
+        offset: 20,
+      }),
+    );
   });
 });

--- a/src/app/api/monitoring/requests/route.ts
+++ b/src/app/api/monitoring/requests/route.ts
@@ -17,6 +17,7 @@ export async function GET(request: Request) {
   const query = parseMonitoringQuery(searchParams, {
     defaultDays: 7,
     defaultLimit: 50,
+    defaultOffset: 0,
   });
 
   try {

--- a/src/features/monitoring-dashboard/api/monitoring-dashboard-api.ts
+++ b/src/features/monitoring-dashboard/api/monitoring-dashboard-api.ts
@@ -84,9 +84,11 @@ export async function fetchMonitoringStats(
 export async function fetchMonitoringRequests(
   filters: MonitoringFilters,
   limit: number,
+  offset: number,
 ): Promise<MonitoringRequestResponse> {
   const params = buildParams(filters);
   params.set("limit", limit.toString());
+  params.set("offset", offset.toString());
   const response = await fetch(
     `/api/monitoring/requests?${params.toString()}`,
     {

--- a/src/features/monitoring-dashboard/hook/use-monitoring-dashboard.ts
+++ b/src/features/monitoring-dashboard/hook/use-monitoring-dashboard.ts
@@ -69,7 +69,8 @@ export function useMonitoringRequests(
     staleTime: 3_000,
     gcTime: 5 * 60_000,
     retry: 1,
-    refetchInterval: POLL_INTERVAL_MS,
+    // Pause polling while browsing older pages to avoid unexpected table jumps.
+    refetchInterval: pagination.offset === 0 ? POLL_INTERVAL_MS : false,
   });
 }
 

--- a/src/features/monitoring-dashboard/hook/use-monitoring-dashboard.ts
+++ b/src/features/monitoring-dashboard/hook/use-monitoring-dashboard.ts
@@ -51,11 +51,21 @@ export function useMonitoringStats(filters: MonitoringFilters) {
   });
 }
 
-export function useMonitoringRequests(filters: MonitoringFilters, limit: number) {
+export function useMonitoringRequests(
+  filters: MonitoringFilters,
+  pagination: { limit: number; offset: number },
+) {
   const key = useMemo(() => buildFilterKey(filters), [filters]);
   return useQuery({
-    queryKey: ["monitoring", "requests", limit, ...key],
-    queryFn: () => fetchMonitoringRequests(filters, limit),
+    queryKey: [
+      "monitoring",
+      "requests",
+      pagination.limit,
+      pagination.offset,
+      ...key,
+    ],
+    queryFn: () =>
+      fetchMonitoringRequests(filters, pagination.limit, pagination.offset),
     staleTime: 3_000,
     gcTime: 5 * 60_000,
     retry: 1,

--- a/src/features/monitoring-dashboard/model/types.ts
+++ b/src/features/monitoring-dashboard/model/types.ts
@@ -67,6 +67,9 @@ export type MonitoringRequestDetail = {
 export type MonitoringRequestResponse = {
   updatedAt: string;
   items: MonitoringRequestItem[];
+  total: number;
+  limit: number;
+  offset: number;
 };
 
 export type MonitoringTopItem = {

--- a/src/features/monitoring-dashboard/ui/monitoring-request-table.test.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-table.test.tsx
@@ -1,0 +1,166 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type {
+  MonitoringRequestDetail,
+  MonitoringRequestItem,
+} from "@/features/monitoring-dashboard/model/types";
+import { MonitoringRequestTable } from "@/features/monitoring-dashboard/ui/monitoring-request-table";
+import { renderWithIntl } from "@/test-utils/intl";
+
+const mockUseMonitoringRequestDetail = vi.hoisted(() => vi.fn());
+
+vi.mock("@/features/monitoring-dashboard/hook/use-monitoring-dashboard", () => ({
+  useMonitoringRequestDetail: mockUseMonitoringRequestDetail,
+}));
+
+function createItems(count: number): MonitoringRequestItem[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `req-${index + 1}`,
+    type: index % 2 === 0 ? "image" : "video",
+    status: index % 3 === 0 ? "completed" : "processing",
+    model: `model-${index + 1}`,
+    createdAt: `2026-01-10T10:${String(index).padStart(2, "0")}:00.000Z`,
+    durationMs: index % 3 === 0 ? 1_000 : null,
+    apiKeyLabel: `key-${index + 1}`,
+  }));
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+beforeAll(() => {
+  const elementProto = HTMLElement.prototype as HTMLElement & {
+    hasPointerCapture?: (pointerId: number) => boolean;
+    setPointerCapture?: (pointerId: number) => void;
+    releasePointerCapture?: (pointerId: number) => void;
+  };
+  const nodeProto = Element.prototype as Element & {
+    scrollIntoView?: (arg?: boolean | ScrollIntoViewOptions) => void;
+  };
+
+  if (!elementProto.hasPointerCapture) {
+    elementProto.hasPointerCapture = () => false;
+  }
+  if (!elementProto.setPointerCapture) {
+    elementProto.setPointerCapture = () => {};
+  }
+  if (!elementProto.releasePointerCapture) {
+    elementProto.releasePointerCapture = () => {};
+  }
+  if (!nodeProto.scrollIntoView) {
+    nodeProto.scrollIntoView = () => {};
+  }
+});
+
+describe("MonitoringRequestTable", () => {
+  it("범위/전체 건수와 페이지 정보를 표시한다", () => {
+    const items = createItems(50);
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithIntl(
+      <MonitoringRequestTable
+        items={items}
+        total={2431}
+        limit={50}
+        offset={50}
+        onLimitChange={vi.fn()}
+        onOffsetChange={vi.fn()}
+        isLoading={false}
+        error={null}
+        updatedAt="2026-01-10T10:00:00.000Z"
+        timeZone="UTC"
+      />,
+    );
+
+    expect(screen.getByText("51-100 / 2,431")).toBeInTheDocument();
+    expect(screen.getByText("2/49")).toBeInTheDocument();
+  });
+
+  it("페이지 이동/행 수 변경 이벤트를 전달한다", async () => {
+    const user = userEvent.setup();
+    const items = createItems(50);
+    const onOffsetChange = vi.fn();
+    const onLimitChange = vi.fn();
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithIntl(
+      <MonitoringRequestTable
+        items={items}
+        total={2431}
+        limit={50}
+        offset={50}
+        onLimitChange={onLimitChange}
+        onOffsetChange={onOffsetChange}
+        isLoading={false}
+        error={null}
+        updatedAt="2026-01-10T10:00:00.000Z"
+        timeZone="UTC"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "이전 페이지" }));
+    await user.click(screen.getByRole("button", { name: "다음 페이지" }));
+    expect(onOffsetChange).toHaveBeenCalledWith(0);
+    expect(onOffsetChange).toHaveBeenCalledWith(100);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "100" }));
+    expect(onLimitChange).toHaveBeenCalledWith(100);
+  });
+
+  it("행 선택 시 상세 모달을 연다", async () => {
+    const user = userEvent.setup();
+    const detail: MonitoringRequestDetail = {
+      id: "req-1",
+      type: "image",
+      status: "completed",
+      model: "flux",
+      prompt: "test prompt",
+      createdAt: "2026-01-10T10:00:00.000Z",
+      updatedAt: "2026-01-10T10:00:01.000Z",
+      durationMs: 1_000,
+      progress: 100,
+      errorMessage: null,
+      inputImages: [],
+      assets: [],
+    };
+    mockUseMonitoringRequestDetail.mockImplementation(
+      (_type: "image" | "video" | null, requestId: string | null) => ({
+        data: requestId ? detail : null,
+        isLoading: false,
+        error: null,
+      }),
+    );
+
+    renderWithIntl(
+      <MonitoringRequestTable
+        items={createItems(1)}
+        total={1}
+        limit={20}
+        offset={0}
+        onLimitChange={vi.fn()}
+        onOffsetChange={vi.fn()}
+        isLoading={false}
+        error={null}
+        updatedAt="2026-01-10T10:00:00.000Z"
+        timeZone="UTC"
+      />,
+    );
+
+    await user.click(screen.getByText("model-1"));
+
+    await waitFor(() => {
+      expect(screen.getByText("요청 상세")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/monitoring-dashboard/ui/monitoring-request-table.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-table.tsx
@@ -50,6 +50,7 @@ export function MonitoringRequestTable({
   const locale = useLocale();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selected, setSelected] = useState<MonitoringRequestItem | null>(null);
+  const numberFormatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
   const formatDateTime = useMemo(() => {
     const formatter = new Intl.DateTimeFormat(locale, {
       dateStyle: "medium",
@@ -79,6 +80,12 @@ export function MonitoringRequestTable({
   const pageCount = limit > 0 ? Math.ceil(total / limit) : 0;
   const canPreviousPage = offset > 0;
   const canNextPage = offset + items.length < total;
+  const rangeStart = total === 0 ? 0 : Math.min(offset + 1, total);
+  const fallbackVisibleCount = total === 0 ? 0 : Math.min(limit, total - offset);
+  const visibleCount = items.length > 0 ? items.length : fallbackVisibleCount;
+  const rangeEnd = total === 0 ? 0 : Math.min(offset + visibleCount, total);
+  const safeCurrentPage = total === 0 ? 0 : pageIndex + 1;
+  const safePageCount = total === 0 ? 0 : Math.max(1, pageCount);
 
   const handleOpenDetail = (item: MonitoringRequestItem) => {
     setSelected(item);
@@ -183,8 +190,15 @@ export function MonitoringRequestTable({
           <div className="text-lg font-semibold text-white">
             {t("requests.title")}
           </div>
-          <div className="text-xs font-mono uppercase tracking-widest text-gray-500">
-            {t("requests.subtitle")}
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-mono uppercase tracking-widest text-gray-500">
+            <span>{t("requests.subtitle")}</span>
+            <span>
+              {t("requests.pagination.range", {
+                start: numberFormatter.format(rangeStart),
+                end: numberFormatter.format(rangeEnd),
+                total: numberFormatter.format(total),
+              })}
+            </span>
           </div>
         </div>
         <div className="flex items-center gap-2 text-xs font-mono text-primary">
@@ -255,7 +269,9 @@ export function MonitoringRequestTable({
             </table>
             <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-white/10 pt-4">
               <div className="flex items-center gap-2 text-xs text-gray-400">
-                <span className="font-mono uppercase tracking-widest">Limit</span>
+                <span className="font-mono uppercase tracking-widest">
+                  {t("requests.pagination.rowsPerPage")}
+                </span>
                 <Select value={String(limit)} onValueChange={handleLimitChange}>
                   <SelectTrigger className="h-8 w-[92px] border-white/10 bg-background-dark/50 text-xs">
                     <SelectValue />
@@ -276,12 +292,15 @@ export function MonitoringRequestTable({
                   variant="surface"
                   onClick={() => onOffsetChange(Math.max(0, offset - limit))}
                   disabled={!canPreviousPage}
-                  aria-label="Previous page"
+                  aria-label={t("requests.pagination.previous")}
                 >
                   <ChevronLeft className="h-4 w-4" />
                 </Button>
                 <div className="min-w-[84px] text-center text-xs font-mono text-gray-400">
-                  {total === 0 ? "0/0" : `${pageIndex + 1}/${Math.max(1, pageCount)}`}
+                  {t("requests.pagination.page", {
+                    current: safeCurrentPage,
+                    total: safePageCount,
+                  })}
                 </div>
                 <Button
                   type="button"
@@ -289,7 +308,7 @@ export function MonitoringRequestTable({
                   variant="surface"
                   onClick={() => onOffsetChange(offset + limit)}
                   disabled={!canNextPage}
-                  aria-label="Next page"
+                  aria-label={t("requests.pagination.next")}
                 >
                   <ChevronRight className="h-4 w-4" />
                 </Button>

--- a/src/features/monitoring-dashboard/ui/monitoring-request-table.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-table.tsx
@@ -1,13 +1,33 @@
 import { useMemo, useState } from "react";
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+} from "@tanstack/react-table";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import type { MonitoringRequestItem } from "@/features/monitoring-dashboard/model/types";
 import { formatDuration } from "@/features/monitoring-dashboard/lib/format";
 import { cn } from "@/shared/lib/utils";
 import { resolveMonitoringStatus } from "@/features/monitoring-dashboard/lib/monitoring-request-status";
 import { MonitoringRequestDetailDialog } from "@/features/monitoring-dashboard/ui/monitoring-request-detail-dialog";
+import { Button } from "@/shared/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/ui/select";
 
 interface MonitoringRequestTableProps {
   items: MonitoringRequestItem[];
+  total: number;
+  limit: number;
+  offset: number;
+  onLimitChange: (limit: number) => void;
+  onOffsetChange: (offset: number) => void;
   isLoading: boolean;
   error: string | null;
   updatedAt: string | null;
@@ -16,6 +36,11 @@ interface MonitoringRequestTableProps {
 
 export function MonitoringRequestTable({
   items,
+  total,
+  limit,
+  offset,
+  onLimitChange,
+  onOffsetChange,
   isLoading,
   error,
   updatedAt,
@@ -43,6 +68,17 @@ export function MonitoringRequestTable({
     completed: t("statuses.completed"),
     failed: t("statuses.failed"),
   };
+  const pageSizeOptions = useMemo(
+    () =>
+      Array.from(new Set([20, 50, 100, limit]))
+        .filter((value) => value > 0)
+        .sort((a, b) => a - b),
+    [limit],
+  );
+  const pageIndex = limit > 0 ? Math.floor(offset / limit) : 0;
+  const pageCount = limit > 0 ? Math.ceil(total / limit) : 0;
+  const canPreviousPage = offset > 0;
+  const canNextPage = offset + items.length < total;
 
   const handleOpenDetail = (item: MonitoringRequestItem) => {
     setSelected(item);
@@ -53,6 +89,92 @@ export function MonitoringRequestTable({
     setDialogOpen(open);
     if (!open) setSelected(null);
   };
+
+  const handleLimitChange = (value: string) => {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return;
+    onLimitChange(parsed);
+  };
+
+  const columns = useMemo<ColumnDef<MonitoringRequestItem>[]>(
+    () => [
+      {
+        id: "apiKey",
+        header: t("requests.columns.apiKey"),
+        cell: ({ row }) => (
+          <span className="text-gray-400">{row.original.apiKeyLabel}</span>
+        ),
+      },
+      {
+        id: "model",
+        header: t("requests.columns.model"),
+        cell: ({ row }) => (
+          <div className="flex items-center gap-2 font-semibold text-white">
+            <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] font-mono uppercase text-gray-400">
+              {row.original.type}
+            </span>
+            <span>{row.original.model ?? "-"}</span>
+          </div>
+        ),
+      },
+      {
+        id: "timestamp",
+        header: t("requests.columns.timestamp"),
+        cell: ({ row }) => (
+          <span className="text-gray-500">
+            {formatDateTime(row.original.createdAt)}
+          </span>
+        ),
+      },
+      {
+        id: "duration",
+        header: t("requests.columns.duration"),
+        cell: ({ row }) => (
+          <span className="text-primary">
+            {formatDuration(row.original.durationMs)}
+          </span>
+        ),
+      },
+      {
+        id: "status",
+        header: () => (
+          <div className="text-right">{t("requests.columns.status")}</div>
+        ),
+        cell: ({ row }) => {
+          const status = resolveMonitoringStatus(row.original.status, statusLabels);
+          const Icon = status.icon;
+          return (
+            <div className="text-right">
+              <span
+                className={cn(
+                  "inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-semibold",
+                  status.className,
+                )}
+              >
+                <Icon className="h-4 w-4" />
+                {status.label}
+              </span>
+            </div>
+          );
+        },
+      },
+    ],
+    [formatDateTime, statusLabels, t],
+  );
+
+  const table = useReactTable({
+    data: items,
+    columns,
+    manualPagination: true,
+    pageCount,
+    getCoreRowModel: getCoreRowModel(),
+    state: {
+      pagination: {
+        pageIndex,
+        pageSize: limit,
+      },
+    },
+  });
 
   return (
     <div className="rounded-2xl border border-white/5 bg-surface-dark/80 p-6 shadow-2xl">
@@ -83,67 +205,97 @@ export function MonitoringRequestTable({
             {t("requests.empty")}
           </div>
         ) : (
-          <table className="w-full min-w-[720px] text-left text-sm">
-            <thead>
-              <tr className="border-b border-white/10 text-xs font-mono uppercase tracking-widest text-gray-500">
-                <th className="px-4 py-3">{t("requests.columns.apiKey")}</th>
-                <th className="px-4 py-3">{t("requests.columns.model")}</th>
-                <th className="px-4 py-3">{t("requests.columns.timestamp")}</th>
-                <th className="px-4 py-3">{t("requests.columns.duration")}</th>
-                <th className="px-4 py-3 text-right">{t("requests.columns.status")}</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-white/5">
-              {items.map((item) => {
-                const status = resolveMonitoringStatus(item.status, statusLabels);
-                const Icon = status.icon;
-                return (
+          <>
+            <table className="w-full min-w-[720px] text-left text-sm">
+              <thead>
+                {table.getHeaderGroups().map((headerGroup) => (
                   <tr
-                    key={item.id}
+                    key={headerGroup.id}
+                    className="border-b border-white/10 text-xs font-mono uppercase tracking-widest text-gray-500"
+                  >
+                    {headerGroup.headers.map((header) => (
+                      <th
+                        key={header.id}
+                        className={cn("px-4 py-3", header.id === "status" && "text-right")}
+                      >
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                      </th>
+                    ))}
+                  </tr>
+                ))}
+              </thead>
+              <tbody className="divide-y divide-white/5">
+                {table.getRowModel().rows.map((row) => (
+                  <tr
+                    key={row.id}
                     className="group cursor-pointer transition-colors hover:bg-white/5 focus-within:bg-white/5"
                     role="button"
                     tabIndex={0}
-                    onClick={() => handleOpenDetail(item)}
+                    onClick={() => handleOpenDetail(row.original)}
                     onKeyDown={(event) => {
                       if (event.key === "Enter" || event.key === " ") {
                         event.preventDefault();
-                        handleOpenDetail(item);
+                        handleOpenDetail(row.original);
                       }
                     }}
                   >
-                    <td className="px-4 py-3 text-gray-400">
-                      {item.apiKeyLabel}
-                    </td>
-                    <td className="px-4 py-3 font-semibold text-white">
-                      <div className="flex items-center gap-2">
-                        <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] font-mono uppercase text-gray-400">
-                          {item.type}
-                        </span>
-                        <span>{item.model ?? "-"}</span>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-gray-500">
-                      {formatDateTime(item.createdAt)}
-                    </td>
-                    <td className="px-4 py-3 text-primary">
-                      {formatDuration(item.durationMs)}
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <span
-                        className={cn(
-                          "inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-semibold",
-                          status.className,
-                        )}
-                      >
-                        <Icon className="h-4 w-4" />
-                        {status.label}
-                      </span>
-                    </td>
+                    {row.getVisibleCells().map((cell) => (
+                      <td key={cell.id} className="px-4 py-3">
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    ))}
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                ))}
+              </tbody>
+            </table>
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-white/10 pt-4">
+              <div className="flex items-center gap-2 text-xs text-gray-400">
+                <span className="font-mono uppercase tracking-widest">Limit</span>
+                <Select value={String(limit)} onValueChange={handleLimitChange}>
+                  <SelectTrigger className="h-8 w-[92px] border-white/10 bg-background-dark/50 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {pageSizeOptions.map((option) => (
+                      <SelectItem key={option} value={String(option)}>
+                        {option}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="surface"
+                  onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+                  disabled={!canPreviousPage}
+                  aria-label="Previous page"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <div className="min-w-[84px] text-center text-xs font-mono text-gray-400">
+                  {total === 0 ? "0/0" : `${pageIndex + 1}/${Math.max(1, pageCount)}`}
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="surface"
+                  onClick={() => onOffsetChange(offset + limit)}
+                  disabled={!canNextPage}
+                  aria-label="Next page"
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          </>
         )}
       </div>
       <MonitoringRequestDetailDialog

--- a/src/screens/monitoring-dashboard/ui/monitoring-dashboard-screen.tsx
+++ b/src/screens/monitoring-dashboard/ui/monitoring-dashboard-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { PageHeader, PageHeaderSearchInput } from "@/shared/ui/page-header";
 import { useDebouncedValue } from "@/shared/lib/hooks/use-debounced-value";
@@ -29,7 +29,7 @@ import {
   useMonitoringTop,
 } from "@/features/monitoring-dashboard/hook/use-monitoring-dashboard";
 
-const REQUEST_LIMIT = 50;
+const DEFAULT_REQUEST_LIMIT = 50;
 const TOP_LIMIT = 5;
 
 export function MonitoringDashboardScreen() {
@@ -43,6 +43,8 @@ export function MonitoringDashboardScreen() {
   const [range, setRange] = useState(() => createRangeFromDays(7));
   const [metric, setMetric] = useState<MonitoringMetric>("requests");
   const [searchInput, setSearchInput] = useState("");
+  const [requestLimit, setRequestLimit] = useState(DEFAULT_REQUEST_LIMIT);
+  const [requestOffset, setRequestOffset] = useState(0);
 
   const debouncedQuery = useDebouncedValue(searchInput, 350).trim();
   const tz = useMemo(
@@ -66,7 +68,22 @@ export function MonitoringDashboardScreen() {
 
   const overviewQuery = useMonitoringOverview(filters);
   const statsQuery = useMonitoringStats(filters);
-  const requestsQuery = useMonitoringRequests(filters, REQUEST_LIMIT);
+  useEffect(() => {
+    setRequestOffset(0);
+  }, [
+    type,
+    status,
+    model,
+    apiKeyId,
+    range.from.getTime(),
+    range.to.getTime(),
+    debouncedQuery,
+  ]);
+
+  const requestsQuery = useMonitoringRequests(filters, {
+    limit: requestLimit,
+    offset: requestOffset,
+  });
   const topQuery = useMonitoringTop(filters, metric, TOP_LIMIT);
   const apiKeysQuery = useMonitoringApiKeys();
   const modelCatalog = useRuntimeModelCatalog();
@@ -160,6 +177,14 @@ export function MonitoringDashboardScreen() {
 
         <MonitoringRequestTable
           items={requestsQuery.data?.items ?? []}
+          total={requestsQuery.data?.total ?? 0}
+          limit={requestsQuery.data?.limit ?? requestLimit}
+          offset={requestsQuery.data?.offset ?? requestOffset}
+          onLimitChange={(nextLimit) => {
+            setRequestLimit(nextLimit);
+            setRequestOffset(0);
+          }}
+          onOffsetChange={setRequestOffset}
           isLoading={requestsQuery.isLoading}
           error={requestsError}
           updatedAt={updatedAt}

--- a/src/server/monitoring/monitoring-query.test.ts
+++ b/src/server/monitoring/monitoring-query.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseMonitoringQuery } from "@/server/monitoring/monitoring-query";
+
+describe("parseMonitoringQuery", () => {
+  it("offset이 음수면 0으로 보정한다", () => {
+    const params = new URLSearchParams(
+      "from=2026-01-01&to=2026-01-02&offset=-10",
+    );
+
+    const query = parseMonitoringQuery(params, {
+      defaultLimit: 50,
+      defaultOffset: 0,
+    });
+
+    expect(query.offset).toBe(0);
+  });
+
+  it("offset이 과도하면 상한으로 제한한다", () => {
+    const params = new URLSearchParams(
+      "from=2026-01-01&to=2026-01-02&offset=9999999",
+    );
+
+    const query = parseMonitoringQuery(params, {
+      defaultLimit: 50,
+      defaultOffset: 0,
+    });
+
+    expect(query.offset).toBe(10_000);
+  });
+
+  it("offset이 숫자가 아니면 기본값을 사용한다", () => {
+    const params = new URLSearchParams(
+      "from=2026-01-01&to=2026-01-02&offset=invalid",
+    );
+
+    const query = parseMonitoringQuery(params, {
+      defaultLimit: 50,
+      defaultOffset: 123,
+    });
+
+    expect(query.offset).toBe(123);
+  });
+});

--- a/src/server/monitoring/monitoring-query.ts
+++ b/src/server/monitoring/monitoring-query.ts
@@ -25,6 +25,7 @@ const DEFAULT_DAYS = 7;
 const DEFAULT_LIMIT = 50;
 const DEFAULT_OFFSET = 0;
 const MAX_LIMIT = 200;
+const MAX_OFFSET = 10_000;
 const DEFAULT_TOP_LIMIT = 5;
 
 const TYPES = new Set<MonitoringType>(["image", "video", "all"]);
@@ -144,7 +145,7 @@ function resolveOffset(value: string | null, fallback: number) {
   if (!value) return fallback;
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed)) return fallback;
-  return Math.max(parsed, 0);
+  return clamp(parsed, 0, MAX_OFFSET);
 }
 
 function resolveMetric(value: string | null) {

--- a/src/server/monitoring/monitoring-query.ts
+++ b/src/server/monitoring/monitoring-query.ts
@@ -17,11 +17,13 @@ export type MonitoringQuery = {
   to: Date;
   tz: string;
   limit: number;
+  offset: number;
   metric: MonitoringMetric;
 };
 
 const DEFAULT_DAYS = 7;
 const DEFAULT_LIMIT = 50;
+const DEFAULT_OFFSET = 0;
 const MAX_LIMIT = 200;
 const DEFAULT_TOP_LIMIT = 5;
 
@@ -138,6 +140,13 @@ function resolveLimit(value: string | null, fallback: number) {
   return clamp(parsed, 1, MAX_LIMIT);
 }
 
+function resolveOffset(value: string | null, fallback: number) {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(parsed, 0);
+}
+
 function resolveMetric(value: string | null) {
   if (!value) return "requests";
   const normalized = value.toLowerCase();
@@ -150,6 +159,7 @@ export function parseMonitoringQuery(
   searchParams: URLSearchParams,
   options?: {
     defaultLimit?: number;
+    defaultOffset?: number;
     defaultDays?: number;
     defaultMetric?: MonitoringMetric;
   },
@@ -172,6 +182,10 @@ export function parseMonitoringQuery(
     searchParams.get("limit"),
     options?.defaultLimit ?? DEFAULT_LIMIT,
   );
+  const offset = resolveOffset(
+    searchParams.get("offset"),
+    options?.defaultOffset ?? DEFAULT_OFFSET,
+  );
 
   const rawMetric = searchParams.get("metric");
   const metric = rawMetric
@@ -188,6 +202,7 @@ export function parseMonitoringQuery(
     to,
     tz,
     limit,
+    offset,
     metric,
   };
 }

--- a/src/server/monitoring/overview.test.ts
+++ b/src/server/monitoring/overview.test.ts
@@ -25,6 +25,7 @@ const baseQuery: MonitoringQuery = {
   to: new Date("2026-01-08T00:00:00Z"),
   tz: "UTC",
   limit: 50,
+  offset: 0,
   metric: "requests",
 };
 

--- a/src/server/monitoring/requests.test.ts
+++ b/src/server/monitoring/requests.test.ts
@@ -184,4 +184,32 @@ describe("getMonitoringRequests", () => {
     expect(result.items[1].apiKeyLabel).toBe("UI");
     expect(result.items[1].durationMs).toBeNull();
   });
+
+  it("offset이 total 이상이면 빈 items를 반환하고 total은 유지한다", async () => {
+    const query: MonitoringQuery = {
+      ...baseQuery,
+      type: "all",
+      limit: 5,
+      offset: 10,
+    };
+    const createdAt = new Date("2026-01-05T10:00:00Z");
+    (prisma.imageGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+    (prisma.videoGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+    (prisma.imageGeneration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      createRecord({ requestId: "img-1", createdAt }),
+    ]);
+    (prisma.videoGeneration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      createRecord({
+        requestId: "vid-1",
+        createdAt: new Date("2026-01-05T09:00:00Z"),
+      }),
+    ]);
+
+    const result = await getMonitoringRequests(query);
+
+    expect(result.total).toBe(2);
+    expect(result.limit).toBe(5);
+    expect(result.offset).toBe(10);
+    expect(result.items).toEqual([]);
+  });
 });

--- a/src/server/monitoring/requests.test.ts
+++ b/src/server/monitoring/requests.test.ts
@@ -7,6 +7,11 @@ vi.mock("@/server/db/prisma", () => ({
   prisma: {
     imageGeneration: {
       findMany: vi.fn(),
+      count: vi.fn(),
+    },
+    videoGeneration: {
+      findMany: vi.fn(),
+      count: vi.fn(),
     },
   },
 }));
@@ -21,6 +26,7 @@ const baseQuery: MonitoringQuery = {
   to: new Date("2026-01-08T00:00:00Z"),
   tz: "UTC",
   limit: 50,
+  offset: 10,
   metric: "requests",
 };
 
@@ -32,6 +38,7 @@ describe("getMonitoringRequests", () => {
   it("API Key 표시와 duration을 계산한다", async () => {
     const createdAt = new Date("2026-01-02T10:00:00Z");
     const updatedAt = new Date("2026-01-02T10:00:02Z");
+    (prisma.imageGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(120);
     (prisma.imageGeneration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
       {
         requestId: "req-1",
@@ -56,9 +63,18 @@ describe("getMonitoringRequests", () => {
     const result = await getMonitoringRequests(baseQuery);
 
     expect(result.items).toHaveLength(2);
+    expect(result.total).toBe(120);
+    expect(result.limit).toBe(50);
+    expect(result.offset).toBe(10);
     expect(result.items[0].apiKeyLabel).toBe("lf_live_aaaa...bbbb");
     expect(result.items[0].durationMs).toBe(2000);
     expect(result.items[1].apiKeyLabel).toBe("UI");
     expect(result.items[1].durationMs).toBeNull();
+    expect(prisma.imageGeneration.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 10,
+        take: 50,
+      }),
+    );
   });
 });

--- a/src/server/monitoring/requests.test.ts
+++ b/src/server/monitoring/requests.test.ts
@@ -30,6 +30,33 @@ const baseQuery: MonitoringQuery = {
   metric: "requests",
 };
 
+function createRecord(params: {
+  requestId: string;
+  status?: string;
+  modelKey?: string | null;
+  createdAt: Date;
+  updatedAt?: Date;
+  apiKeyId?: string | null;
+  maskedKey?: string | null;
+}) {
+  const apiKeyId = params.apiKeyId === undefined ? "key-1" : params.apiKeyId;
+
+  return {
+    requestId: params.requestId,
+    status: params.status ?? "completed",
+    modelKey: params.modelKey ?? "flux",
+    createdAt: params.createdAt,
+    updatedAt: params.updatedAt ?? params.createdAt,
+    apiKeyId,
+    apiKey:
+      apiKeyId === null
+        ? null
+        : {
+            maskedKey: params.maskedKey ?? "lf_live_aaaa...bbbb",
+          },
+  };
+}
+
 describe("getMonitoringRequests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -72,9 +99,89 @@ describe("getMonitoringRequests", () => {
     expect(result.items[1].durationMs).toBeNull();
     expect(prisma.imageGeneration.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
+        orderBy: [{ createdAt: "desc" }, { requestId: "desc" }],
         skip: 10,
         take: 50,
       }),
     );
+  });
+
+  it("type=all에서 동률 정렬 시에도 페이지 경계가 고정된다", async () => {
+    const query: MonitoringQuery = {
+      ...baseQuery,
+      type: "all",
+      limit: 2,
+      offset: 1,
+    };
+    const sameCreatedAt = new Date("2026-01-03T10:00:00Z");
+    const olderCreatedAt = new Date("2026-01-03T09:00:00Z");
+    (prisma.imageGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(2);
+    (prisma.videoGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(2);
+    (prisma.imageGeneration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      createRecord({ requestId: "b", createdAt: sameCreatedAt }),
+      createRecord({ requestId: "a", createdAt: sameCreatedAt }),
+    ]);
+    (prisma.videoGeneration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      createRecord({ requestId: "c", createdAt: sameCreatedAt }),
+      createRecord({ requestId: "d", createdAt: olderCreatedAt }),
+    ]);
+
+    const result = await getMonitoringRequests(query);
+
+    expect(result.total).toBe(4);
+    expect(result.items.map((item) => item.id)).toEqual(["b", "a"]);
+    expect(prisma.imageGeneration.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ createdAt: "desc" }, { requestId: "desc" }],
+        take: 3,
+      }),
+    );
+    expect(prisma.videoGeneration.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ createdAt: "desc" }, { requestId: "desc" }],
+        take: 3,
+      }),
+    );
+  });
+
+  it("type=all에서도 API Key 라벨과 duration 규칙을 유지한다", async () => {
+    const query: MonitoringQuery = {
+      ...baseQuery,
+      type: "all",
+      limit: 10,
+      offset: 0,
+    };
+    const createdAt = new Date("2026-01-04T10:00:00Z");
+    const completedUpdatedAt = new Date("2026-01-04T10:00:03Z");
+    const processingUpdatedAt = new Date("2026-01-04T10:00:05Z");
+    (prisma.imageGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+    (prisma.videoGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+    (prisma.imageGeneration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      createRecord({
+        requestId: "img-1",
+        status: "completed",
+        createdAt,
+        updatedAt: completedUpdatedAt,
+      }),
+    ]);
+    (prisma.videoGeneration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      createRecord({
+        requestId: "vid-1",
+        status: "processing",
+        createdAt: new Date("2026-01-04T09:59:00Z"),
+        updatedAt: processingUpdatedAt,
+        apiKeyId: null,
+      }),
+    ]);
+
+    const result = await getMonitoringRequests(query);
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].id).toBe("img-1");
+    expect(result.items[0].apiKeyLabel).toBe("lf_live_aaaa...bbbb");
+    expect(result.items[0].durationMs).toBe(3000);
+    expect(result.items[1].id).toBe("vid-1");
+    expect(result.items[1].apiKeyLabel).toBe("UI");
+    expect(result.items[1].durationMs).toBeNull();
   });
 });

--- a/src/server/monitoring/requests.ts
+++ b/src/server/monitoring/requests.ts
@@ -21,18 +21,21 @@ export type MonitoringRequestResponse = {
 };
 
 const FINISHED_STATUSES = new Set(["completed", "failed"]);
-const ORDER_BY = [{ createdAt: "desc" }, { requestId: "desc" }] as const;
+const ORDER_BY = [
+  { createdAt: "desc" as const },
+  { requestId: "desc" as const },
+];
 
 type RequestType = "image" | "video";
 
-type RequestRecord = {
+type RequestRecordBase = {
   requestId: string;
   status: string;
   modelKey: string | null;
   createdAt: Date;
   updatedAt: Date;
   apiKeyId: string | null;
-  apiKey: {
+  apiKey?: {
     maskedKey: string | null;
   } | null;
 };
@@ -47,7 +50,10 @@ function toDurationMs(createdAt: Date, updatedAt: Date, status: string) {
   return Math.max(0, updatedAt.getTime() - createdAt.getTime());
 }
 
-function compareRecords(a: RequestRecord & { type: RequestType }, b: RequestRecord & { type: RequestType }) {
+function compareRecords(
+  a: RequestRecordBase & { type: RequestType },
+  b: RequestRecordBase & { type: RequestType },
+) {
   const createdAtDiff = b.createdAt.getTime() - a.createdAt.getTime();
   if (createdAtDiff !== 0) return createdAtDiff;
 
@@ -57,7 +63,9 @@ function compareRecords(a: RequestRecord & { type: RequestType }, b: RequestReco
   return b.type.localeCompare(a.type);
 }
 
-function toMonitoringRequestItem(record: RequestRecord & { type: RequestType }): MonitoringRequestItem {
+function toMonitoringRequestItem(
+  record: RequestRecordBase & { type: RequestType },
+): MonitoringRequestItem {
   return {
     id: record.requestId,
     type: record.type,
@@ -115,7 +123,7 @@ export async function getMonitoringRequests(
       }),
     ]);
 
-    const items = (records as RequestRecord[]).map((record) =>
+    const items = records.map((record) =>
       toMonitoringRequestItem({ ...record, type: "image" }),
     );
 
@@ -145,7 +153,7 @@ export async function getMonitoringRequests(
       }),
     ]);
 
-    const items = (records as RequestRecord[]).map((record) =>
+    const items = records.map((record) =>
       toMonitoringRequestItem({ ...record, type: "video" }),
     );
 
@@ -188,11 +196,11 @@ export async function getMonitoringRequests(
   ]);
 
   const mergedRecords = [
-    ...(imageRecords as RequestRecord[]).map((record) => ({
+    ...imageRecords.map((record) => ({
       ...record,
       type: "image" as const,
     })),
-    ...(videoRecords as RequestRecord[]).map((record) => ({
+    ...videoRecords.map((record) => ({
       ...record,
       type: "video" as const,
     })),

--- a/src/server/monitoring/requests.ts
+++ b/src/server/monitoring/requests.ts
@@ -21,6 +21,21 @@ export type MonitoringRequestResponse = {
 };
 
 const FINISHED_STATUSES = new Set(["completed", "failed"]);
+const ORDER_BY = [{ createdAt: "desc" }, { requestId: "desc" }] as const;
+
+type RequestType = "image" | "video";
+
+type RequestRecord = {
+  requestId: string;
+  status: string;
+  modelKey: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  apiKeyId: string | null;
+  apiKey: {
+    maskedKey: string | null;
+  } | null;
+};
 
 function resolveApiKeyLabel(maskedKey: string | null, apiKeyId: string | null) {
   if (!apiKeyId) return "UI";
@@ -30,6 +45,28 @@ function resolveApiKeyLabel(maskedKey: string | null, apiKeyId: string | null) {
 function toDurationMs(createdAt: Date, updatedAt: Date, status: string) {
   if (!FINISHED_STATUSES.has(status)) return null;
   return Math.max(0, updatedAt.getTime() - createdAt.getTime());
+}
+
+function compareRecords(a: RequestRecord & { type: RequestType }, b: RequestRecord & { type: RequestType }) {
+  const createdAtDiff = b.createdAt.getTime() - a.createdAt.getTime();
+  if (createdAtDiff !== 0) return createdAtDiff;
+
+  const requestIdDiff = b.requestId.localeCompare(a.requestId);
+  if (requestIdDiff !== 0) return requestIdDiff;
+
+  return b.type.localeCompare(a.type);
+}
+
+function toMonitoringRequestItem(record: RequestRecord & { type: RequestType }): MonitoringRequestItem {
+  return {
+    id: record.requestId,
+    type: record.type,
+    status: record.status,
+    model: record.modelKey ?? null,
+    createdAt: record.createdAt.toISOString(),
+    durationMs: toDurationMs(record.createdAt, record.updatedAt, record.status),
+    apiKeyLabel: resolveApiKeyLabel(record.apiKey?.maskedKey ?? null, record.apiKeyId),
+  };
 }
 
 export async function getMonitoringRequests(
@@ -61,8 +98,6 @@ export async function getMonitoringRequests(
     },
   } as const;
 
-  const orderBy = { createdAt: "desc" } as const;
-
   if (query.type === "image") {
     const where = buildImageWhere(filters, {
       includeDate: true,
@@ -73,25 +108,16 @@ export async function getMonitoringRequests(
       prisma.imageGeneration.count({ where }),
       prisma.imageGeneration.findMany({
         where,
-        orderBy,
+        orderBy: ORDER_BY,
         skip: offset,
         take: limit,
         select,
       }),
     ]);
 
-    const items = records.map((record) => ({
-      id: record.requestId,
-      type: "image" as const,
-      status: record.status,
-      model: record.modelKey ?? null,
-      createdAt: record.createdAt.toISOString(),
-      durationMs: toDurationMs(record.createdAt, record.updatedAt, record.status),
-      apiKeyLabel: resolveApiKeyLabel(
-        record.apiKey?.maskedKey ?? null,
-        record.apiKeyId,
-      ),
-    }));
+    const items = (records as RequestRecord[]).map((record) =>
+      toMonitoringRequestItem({ ...record, type: "image" }),
+    );
 
     return {
       updatedAt: new Date().toISOString(),
@@ -112,25 +138,16 @@ export async function getMonitoringRequests(
       prisma.videoGeneration.count({ where }),
       prisma.videoGeneration.findMany({
         where,
-        orderBy,
+        orderBy: ORDER_BY,
         skip: offset,
         take: limit,
         select,
       }),
     ]);
 
-    const items = records.map((record) => ({
-      id: record.requestId,
-      type: "video" as const,
-      status: record.status,
-      model: record.modelKey ?? null,
-      createdAt: record.createdAt.toISOString(),
-      durationMs: toDurationMs(record.createdAt, record.updatedAt, record.status),
-      apiKeyLabel: resolveApiKeyLabel(
-        record.apiKey?.maskedKey ?? null,
-        record.apiKeyId,
-      ),
-    }));
+    const items = (records as RequestRecord[]).map((record) =>
+      toMonitoringRequestItem({ ...record, type: "video" }),
+    );
 
     return {
       updatedAt: new Date().toISOString(),
@@ -158,48 +175,36 @@ export async function getMonitoringRequests(
     prisma.videoGeneration.count({ where: videoWhere }),
     prisma.imageGeneration.findMany({
       where: imageWhere,
-      orderBy,
+      orderBy: ORDER_BY,
       take,
       select,
     }),
     prisma.videoGeneration.findMany({
       where: videoWhere,
-      orderBy,
+      orderBy: ORDER_BY,
       take,
       select,
     }),
   ]);
 
-  const items = [
-    ...imageRecords.map((record) => ({
-      id: record.requestId,
+  const mergedRecords = [
+    ...(imageRecords as RequestRecord[]).map((record) => ({
+      ...record,
       type: "image" as const,
-      status: record.status,
-      model: record.modelKey ?? null,
-      createdAt: record.createdAt.toISOString(),
-      durationMs: toDurationMs(record.createdAt, record.updatedAt, record.status),
-      apiKeyLabel: resolveApiKeyLabel(
-        record.apiKey?.maskedKey ?? null,
-        record.apiKeyId,
-      ),
     })),
-    ...videoRecords.map((record) => ({
-      id: record.requestId,
+    ...(videoRecords as RequestRecord[]).map((record) => ({
+      ...record,
       type: "video" as const,
-      status: record.status,
-      model: record.modelKey ?? null,
-      createdAt: record.createdAt.toISOString(),
-      durationMs: toDurationMs(record.createdAt, record.updatedAt, record.status),
-      apiKeyLabel: resolveApiKeyLabel(
-        record.apiKey?.maskedKey ?? null,
-        record.apiKeyId,
-      ),
     })),
-  ].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  ].sort(compareRecords);
+
+  const items = mergedRecords
+    .slice(offset, offset + limit)
+    .map(toMonitoringRequestItem);
 
   return {
     updatedAt: new Date().toISOString(),
-    items: items.slice(offset, offset + limit),
+    items,
     total: imageTotal + videoTotal,
     limit,
     offset,

--- a/src/server/monitoring/requests.ts
+++ b/src/server/monitoring/requests.ts
@@ -15,6 +15,9 @@ export type MonitoringRequestItem = {
 export type MonitoringRequestResponse = {
   updatedAt: string;
   items: MonitoringRequestItem[];
+  total: number;
+  limit: number;
+  offset: number;
 };
 
 const FINISHED_STATUSES = new Set(["completed", "failed"]);
@@ -42,6 +45,7 @@ export async function getMonitoringRequests(
   };
 
   const limit = query.limit;
+  const offset = query.offset;
 
   const select = {
     requestId: true,
@@ -60,16 +64,21 @@ export async function getMonitoringRequests(
   const orderBy = { createdAt: "desc" } as const;
 
   if (query.type === "image") {
-    const records = await prisma.imageGeneration.findMany({
-      where: buildImageWhere(filters, {
-        includeDate: true,
-        includeStatus: true,
-        includeQuery: true,
-      }),
-      orderBy,
-      take: limit,
-      select,
+    const where = buildImageWhere(filters, {
+      includeDate: true,
+      includeStatus: true,
+      includeQuery: true,
     });
+    const [total, records] = await Promise.all([
+      prisma.imageGeneration.count({ where }),
+      prisma.imageGeneration.findMany({
+        where,
+        orderBy,
+        skip: offset,
+        take: limit,
+        select,
+      }),
+    ]);
 
     const items = records.map((record) => ({
       id: record.requestId,
@@ -84,20 +93,31 @@ export async function getMonitoringRequests(
       ),
     }));
 
-    return { updatedAt: new Date().toISOString(), items };
+    return {
+      updatedAt: new Date().toISOString(),
+      items,
+      total,
+      limit,
+      offset,
+    };
   }
 
   if (query.type === "video") {
-    const records = await prisma.videoGeneration.findMany({
-      where: buildVideoWhere(filters, {
-        includeDate: true,
-        includeStatus: true,
-        includeQuery: true,
-      }),
-      orderBy,
-      take: limit,
-      select,
+    const where = buildVideoWhere(filters, {
+      includeDate: true,
+      includeStatus: true,
+      includeQuery: true,
     });
+    const [total, records] = await Promise.all([
+      prisma.videoGeneration.count({ where }),
+      prisma.videoGeneration.findMany({
+        where,
+        orderBy,
+        skip: offset,
+        take: limit,
+        select,
+      }),
+    ]);
 
     const items = records.map((record) => ({
       id: record.requestId,
@@ -112,28 +132,40 @@ export async function getMonitoringRequests(
       ),
     }));
 
-    return { updatedAt: new Date().toISOString(), items };
+    return {
+      updatedAt: new Date().toISOString(),
+      items,
+      total,
+      limit,
+      offset,
+    };
   }
 
-  const [imageRecords, videoRecords] = await Promise.all([
+  const imageWhere = buildImageWhere(filters, {
+    includeDate: true,
+    includeStatus: true,
+    includeQuery: true,
+  });
+  const videoWhere = buildVideoWhere(filters, {
+    includeDate: true,
+    includeStatus: true,
+    includeQuery: true,
+  });
+  const take = limit + offset;
+
+  const [imageTotal, videoTotal, imageRecords, videoRecords] = await Promise.all([
+    prisma.imageGeneration.count({ where: imageWhere }),
+    prisma.videoGeneration.count({ where: videoWhere }),
     prisma.imageGeneration.findMany({
-      where: buildImageWhere(filters, {
-        includeDate: true,
-        includeStatus: true,
-        includeQuery: true,
-      }),
+      where: imageWhere,
       orderBy,
-      take: limit,
+      take,
       select,
     }),
     prisma.videoGeneration.findMany({
-      where: buildVideoWhere(filters, {
-        includeDate: true,
-        includeStatus: true,
-        includeQuery: true,
-      }),
+      where: videoWhere,
       orderBy,
-      take: limit,
+      take,
       select,
     }),
   ]);
@@ -167,6 +199,9 @@ export async function getMonitoringRequests(
 
   return {
     updatedAt: new Date().toISOString(),
-    items: items.slice(0, limit),
+    items: items.slice(offset, offset + limit),
+    total: imageTotal + videoTotal,
+    limit,
+    offset,
   };
 }

--- a/src/server/monitoring/stats.test.ts
+++ b/src/server/monitoring/stats.test.ts
@@ -19,6 +19,7 @@ const baseQuery: MonitoringQuery = {
   to: new Date("2026-01-08T00:00:00Z"),
   tz: "UTC",
   limit: 50,
+  offset: 0,
   metric: "requests",
 };
 

--- a/src/server/monitoring/top.test.ts
+++ b/src/server/monitoring/top.test.ts
@@ -22,6 +22,7 @@ const baseQuery: MonitoringQuery = {
   to: new Date("2026-01-08T00:00:00Z"),
   tz: "UTC",
   limit: 50,
+  offset: 0,
   metric: "requests",
 };
 

--- a/src/shared/i18n/messages/en.json
+++ b/src/shared/i18n/messages/en.json
@@ -422,6 +422,13 @@
         "timestamp": "Timestamp",
         "duration": "Duration",
         "status": "Status"
+      },
+      "pagination": {
+        "rowsPerPage": "Rows",
+        "previous": "Previous page",
+        "next": "Next page",
+        "page": "{current}/{total}",
+        "range": "{start}-{end} / {total}"
       }
     }
   },

--- a/src/shared/i18n/messages/ko.json
+++ b/src/shared/i18n/messages/ko.json
@@ -422,6 +422,13 @@
         "timestamp": "시간",
         "duration": "소요 시간",
         "status": "상태"
+      },
+      "pagination": {
+        "rowsPerPage": "행 수",
+        "previous": "이전 페이지",
+        "next": "다음 페이지",
+        "page": "{current}/{total}",
+        "range": "{start}-{end} / {total}"
       }
     }
   },


### PR DESCRIPTION
## 개요

- 모니터링 요청 로그에 서버 페이지네이션을 도입해 대량 데이터 탐색성을 개선했습니다.
- 요청 테이블을 TanStack Table 기반으로 전환해 페이지 이동/행 수 변경을 안정적으로 처리합니다.
- 필터 맥락에서 전체 건수와 현재 범위를 표시해 운영 확인성을 높였습니다.

## 변경 사항

- `/api/monitoring/requests`에 `offset` 파라미터와 `total/limit/offset` 응답 메타데이터를 추가했습니다.
- `image/video/all` 조회에서 count + 목록 조회를 정합성 있게 맞추고, `type=all`의 페이지 경계 정렬/슬라이싱을 보강했습니다.
- 요청 로그 UI를 TanStack Table의 manual pagination으로 전환하고, 하단 페이지네이션 컨트롤과 행 수 선택을 추가했습니다.
- 페이지가 1페이지(`offset=0`)가 아닐 때는 폴링을 중지해 테이블 점프를 방지했습니다.
- 페이지네이션 라벨(`rowsPerPage`, `previous`, `next`, `page`, `range`)을 ko/en i18n에 추가했습니다.
- API/서버/UI 테스트를 보강하고 회귀 검증을 완료했습니다.

## 테스트

### 실행한 테스트

- [x] `pnpm -C leesfield-fe typecheck` — PASS (2026-02-13 20-19)
- [x] `pnpm -C leesfield-fe test` — PASS (40 files, 128 tests) (2026-02-13 20-19)
- [x] `pnpm -C leesfield-fe build` — PASS (2026-02-13 20-19)

## 관련 문서

- **Spec**: `docs/features/F040-monitoring-request-table-pagination/spec.md`
- **Tasks**: `docs/features/F040-monitoring-request-table-pagination/tasks.md`

Closes #77


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 모니터링 대시보드에 서버-연동 페이지네이션 추가(총합, 한 페이지 항목수, 오프셋)
  * 요청 테이블에 페이지 크기 선택, 이전/다음 네비게이션, 현재 페이지 범위 및 전체 항목 수 표시
  * 테이블 행 클릭 시 상세 모달 열기 지원 및 페이지 변경 시 오프셋 초기화

* **Chores**
  * 테이블 관련 런타임 의존성 추가

* **Localization**
  * 페이지네이션 관련 한국어/영문 문구 추가

* **Tests**
  * 페이지네이션 및 오프셋 동작 검증 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->