### PR TITLE
feat(#79): audio-generation-hf-space (HF Space 기반 오디오 생성 기능 추가)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,9 @@ IMAGE_STORAGE_PROVIDER=leemage
 # 비디오 저장 어댑터 선택 (기본: leemage)
 VIDEO_STORAGE_PROVIDER=leemage
 
+# 오디오 저장 어댑터 선택 (기본: leemage)
+AUDIO_STORAGE_PROVIDER=leemage
+
 # Leemage 업로드용 API 키
 LEEMAGE_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ docker compose up -d
 pnpm dev
 ```
 
-### 4) 이미지/비디오 저장 어댑터
+### 4) 이미지/비디오/오디오 저장 어댑터
 
 현재 지원 어댑터:
 
@@ -136,8 +136,10 @@ pnpm dev
 설정:
 
 - `IMAGE_STORAGE_PROVIDER`로 저장 어댑터를 선택합니다.
+- `VIDEO_STORAGE_PROVIDER`, `AUDIO_STORAGE_PROVIDER`도 동일하게 저장 어댑터를 선택합니다.
 - `leemage`를 사용하는 경우 `LEEMAGE_API_KEY`, `LEEMAGE_PROJECT_ID`가 필수입니다.
-- 저장소 설정이 없거나 지원되지 않는 경우: 결과는 즉시 응답되지만 히스토리(DB) 저장은 생략됩니다.
+- 이미지/비디오에서 저장소 설정이 없거나 지원되지 않는 경우: 결과는 즉시 응답되지만 히스토리(DB) 저장은 생략됩니다.
+- 오디오에서 저장소 설정이 없거나 지원되지 않는 경우: 외부 저장소 업로드를 건너뛰고 inline 결과를 DB에 저장합니다.
 
 ### 5) 어댑터 구현 방식
 
@@ -165,7 +167,7 @@ pnpm dev
 4. 모델 카탈로그(DB) 갱신
 5. 필요 시 `.env.example`에 새 제공자 설정 추가
 
-#### 2) 저장소 어댑터 (이미지/비디오 업로드)
+#### 2) 저장소 어댑터 (이미지/비디오/오디오 업로드)
 
 기본 제공자:
 
@@ -175,16 +177,19 @@ pnpm dev
 
 - 이미지: `IMAGE_STORAGE_PROVIDER`로 선택합니다. (기본: `leemage`)
 - 비디오: `VIDEO_STORAGE_PROVIDER`로 선택합니다. (기본: `leemage`)
+- 오디오: `AUDIO_STORAGE_PROVIDER`로 선택합니다. (기본: `leemage`)
 - `leemage` 사용 시 `LEEMAGE_API_KEY`, `LEEMAGE_PROJECT_ID`가 필수입니다.
 - Leemage 업로드/삭제 클라이언트는 공식 npm 패키지 `leemage-sdk`를 사용합니다.
 - 과거 내부 경로(`src/shared/lib/leemage-sdk`)는 제거되었으며, 현재 런타임에서는 사용하지 않습니다.
-- 설정이 없거나 지원되지 않으면 **결과는 응답되지만 히스토리(DB) 저장은 생략**됩니다.
+- 이미지/비디오는 설정이 없거나 지원되지 않으면 **결과는 응답되지만 히스토리(DB) 저장은 생략**됩니다.
+- 오디오는 설정이 없거나 지원되지 않으면 **외부 저장소 업로드를 건너뛰고 inline 결과를 히스토리(DB)에 저장**합니다.
 
 추가 방법:
 
 1. 저장 어댑터 구현 추가
    - 이미지: `src/server/image-generation/storage/adapters/`
    - 비디오: `src/server/video-generation/storage/adapters/`
+   - 오디오: `src/server/audio-generation/storage/adapters/`
 2. `storage-adapter.ts` 인터페이스 구현
 3. `storage-selector.ts`에 선택 규칙 추가
 4. 필요 시 `.env.example`에 새 저장소 설정 추가

--- a/prisma/migrations/20260305143000_add_audio_generation/migration.sql
+++ b/prisma/migrations/20260305143000_add_audio_generation/migration.sql
@@ -1,0 +1,65 @@
+-- CreateEnum
+CREATE TYPE "AudioGenerationStatus" AS ENUM ('pending', 'processing', 'completed', 'failed');
+
+-- AlterEnum
+ALTER TYPE "ModelCatalogType" ADD VALUE 'audio';
+
+-- CreateTable
+CREATE TABLE "AudioGeneration" (
+    "id" TEXT NOT NULL,
+    "requestId" TEXT NOT NULL,
+    "ownerEmail" TEXT,
+    "apiKeyId" TEXT,
+    "prompt" TEXT NOT NULL,
+    "requestParams" JSONB,
+    "modelKey" TEXT,
+    "status" "AudioGenerationStatus" NOT NULL,
+    "progress" INTEGER NOT NULL,
+    "errorMessage" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AudioGeneration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AudioGenerationAudio" (
+    "id" TEXT NOT NULL,
+    "generationId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "durationSec" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AudioGenerationAudio_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AudioGeneration_requestId_key" ON "AudioGeneration"("requestId");
+
+-- CreateIndex
+CREATE INDEX "AudioGeneration_ownerEmail_idx" ON "AudioGeneration"("ownerEmail");
+
+-- CreateIndex
+CREATE INDEX "AudioGeneration_status_createdAt_idx" ON "AudioGeneration"("status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "AudioGeneration_status_updatedAt_idx" ON "AudioGeneration"("status", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "AudioGeneration_status_modelKey_idx" ON "AudioGeneration"("status", "modelKey");
+
+-- CreateIndex
+CREATE INDEX "AudioGeneration_apiKeyId_createdAt_idx" ON "AudioGeneration"("apiKeyId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "AudioGenerationAudio_generationId_idx" ON "AudioGenerationAudio"("generationId");
+
+-- AddForeignKey
+ALTER TABLE "AudioGeneration"
+ADD CONSTRAINT "AudioGeneration_apiKeyId_fkey"
+FOREIGN KEY ("apiKeyId") REFERENCES "ApiKey"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AudioGenerationAudio"
+ADD CONSTRAINT "AudioGenerationAudio_generationId_fkey"
+FOREIGN KEY ("generationId") REFERENCES "AudioGeneration"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,13 @@ enum VideoGenerationStatus {
   failed
 }
 
+enum AudioGenerationStatus {
+  pending
+  processing
+  completed
+  failed
+}
+
 enum ApiKeyStatus {
   active
   revoked
@@ -36,6 +43,7 @@ enum ApiKeyStatus {
 enum ModelCatalogType {
   image
   video
+  audio
 }
 
 model ImageGeneration {
@@ -113,6 +121,40 @@ model VideoGenerationVideo {
   @@index([generationId])
 }
 
+model AudioGeneration {
+  id            String                @id @default(cuid())
+  requestId     String                @unique
+  ownerEmail    String?
+  apiKeyId      String?
+  apiKey        ApiKey?               @relation(fields: [apiKeyId], references: [id], onDelete: SetNull)
+  prompt        String
+  requestParams Json?
+  modelKey      String?
+  status        AudioGenerationStatus
+  progress      Int
+  errorMessage  String?
+  createdAt     DateTime              @default(now())
+  updatedAt     DateTime              @updatedAt
+  audios        AudioGenerationAudio[]
+
+  @@index([ownerEmail])
+  @@index([status, createdAt])
+  @@index([status, updatedAt])
+  @@index([status, modelKey])
+  @@index([apiKeyId, createdAt])
+}
+
+model AudioGenerationAudio {
+  id           String          @id @default(cuid())
+  generationId String
+  url          String
+  durationSec  Int?
+  createdAt    DateTime        @default(now())
+  generation   AudioGeneration @relation(fields: [generationId], references: [id], onDelete: Cascade)
+
+  @@index([generationId])
+}
+
 model ModelCatalog {
   id             String           @id @default(cuid())
   type           ModelCatalogType
@@ -145,6 +187,7 @@ model ApiKey {
   updatedAt  DateTime     @updatedAt
   imageGenerations ImageGeneration[]
   videoGenerations VideoGeneration[]
+  audioGenerations AudioGeneration[]
 
   @@index([ownerEmail])
   @@index([status])

--- a/src/app/(public)/audio/page.tsx
+++ b/src/app/(public)/audio/page.tsx
@@ -1,0 +1,8 @@
+import { AudioGenerationScreen } from "@/screens/audio-generation/ui/audio-generation-screen";
+import { getSession } from "@/server/auth/session";
+
+export default async function AudioGenerationPage() {
+  const session = await getSession();
+
+  return <AudioGenerationScreen isAuthenticated={session.isLoggedIn} />;
+}

--- a/src/app/api/admin/models/route.test.ts
+++ b/src/app/api/admin/models/route.test.ts
@@ -70,8 +70,8 @@ const videoModel: ModelCatalogItem = {
     steps: { ui: "range", min: 1, max: 50, step: 1 },
     guidanceScale: { ui: "range", min: 0, max: 10, step: 0.5 },
     seed: { ui: "input" },
-    aspectRatio: { ui: "select", options: ["16:9"] },
-    resolution: { ui: "select", options: [720] },
+    aspectRatio: { ui: "select", options: [{ label: "16:9", value: "16:9" }] },
+    resolution: { ui: "select", options: [{ label: "720", value: 720 }] },
     fps: { ui: "range", min: 1, max: 60, step: 1 },
   },
   meta: {

--- a/src/app/api/audio-generation/[requestId]/route.delete.test.ts
+++ b/src/app/api/audio-generation/[requestId]/route.delete.test.ts
@@ -1,0 +1,112 @@
+import { DELETE } from "@/app/api/audio-generation/[requestId]/route";
+
+const mockGetSession = vi.hoisted(() => vi.fn());
+const mockFindFirst = vi.hoisted(() => vi.fn());
+const mockDelete = vi.hoisted(() => vi.fn());
+const mockDeleteLeemageFilesByPrefix = vi.hoisted(() => vi.fn());
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+vi.mock("@/server/auth/session", () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock("@/server/db/prisma", () => ({
+  prisma: {
+    audioGeneration: {
+      findFirst: mockFindFirst,
+      delete: mockDelete,
+    },
+  },
+}));
+
+vi.mock("@/server/shared/leemage-file-deleter", () => ({
+  deleteLeemageFilesByPrefix: mockDeleteLeemageFilesByPrefix,
+}));
+
+describe("DELETE /api/audio-generation/[requestId]", () => {
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockGetSession.mockReset();
+    mockFindFirst.mockReset();
+    mockDelete.mockReset();
+    mockDeleteLeemageFilesByPrefix.mockReset();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("로그인하지 않은 경우 401을 반환한다", async () => {
+    mockGetSession.mockResolvedValue({ isLoggedIn: false });
+
+    const response = await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "request-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.message).toBe("UNAUTHORIZED");
+  });
+
+  it("요청이 없으면 404를 반환한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockFindFirst.mockResolvedValue(null);
+
+    const response = await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "missing-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(payload.message).toBe("NOT_FOUND");
+  });
+
+  it("진행 중인 요청이면 400을 반환한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockFindFirst.mockResolvedValue({
+      id: "db-id",
+      status: "processing",
+      requestId: "request-id",
+    });
+
+    const response = await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "request-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.message).toBe("IN_PROGRESS");
+  });
+
+  it("스토리지 삭제 후 DB 레코드를 삭제한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockFindFirst.mockResolvedValue({
+      id: "db-id",
+      status: "completed",
+      requestId: "request-id",
+    });
+    mockDeleteLeemageFilesByPrefix.mockResolvedValue({
+      matchedCount: 1,
+      deletedCount: 1,
+    });
+
+    const response = await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "request-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.message).toBe("DELETED");
+    expect(mockDeleteLeemageFilesByPrefix).toHaveBeenCalledWith("request-id-");
+    expect(mockDelete).toHaveBeenCalledWith({ where: { id: "db-id" } });
+  });
+});

--- a/src/app/api/audio-generation/[requestId]/route.delete.test.ts
+++ b/src/app/api/audio-generation/[requestId]/route.delete.test.ts
@@ -84,6 +84,26 @@ describe("DELETE /api/audio-generation/[requestId]", () => {
     expect(payload.message).toBe("IN_PROGRESS");
   });
 
+  it("대기 중인 요청이면 400을 반환한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockFindFirst.mockResolvedValue({
+      id: "db-id",
+      status: "pending",
+      requestId: "request-id",
+    });
+
+    const response = await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "request-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.message).toBe("IN_PROGRESS");
+  });
+
   it("스토리지 삭제 후 DB 레코드를 삭제한다", async () => {
     mockGetSession.mockResolvedValue({
       isLoggedIn: true,

--- a/src/app/api/audio-generation/[requestId]/route.test.ts
+++ b/src/app/api/audio-generation/[requestId]/route.test.ts
@@ -1,0 +1,95 @@
+import { GET } from "@/app/api/audio-generation/[requestId]/route";
+
+const mockGetSession = vi.hoisted(() => vi.fn());
+const mockGetAudioGeneration = vi.hoisted(() => vi.fn());
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+vi.mock("@/server/auth/session", () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock("@/server/audio-generation/audio-generation-store", () => ({
+  getAudioGeneration: mockGetAudioGeneration,
+}));
+
+describe("GET /api/audio-generation/[requestId]", () => {
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockGetSession.mockReset();
+    mockGetAudioGeneration.mockReset();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("로그인하지 않은 경우 401을 반환한다", async () => {
+    mockGetSession.mockResolvedValue({ isLoggedIn: false });
+
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "request-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.message).toBe("UNAUTHORIZED");
+  });
+
+  it("요청이 없으면 404를 반환한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockGetAudioGeneration.mockResolvedValue(null);
+
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "missing-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(payload.message).toBe("NOT_FOUND");
+  });
+
+  it("요청이 존재하면 상태를 반환한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockGetAudioGeneration.mockResolvedValue({
+      id: "request-id",
+      status: "completed",
+      progress: 100,
+      result: { audios: [{ url: "https://example.com/1.mp3" }] },
+      errorMessage: "warn",
+    });
+
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "request-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.requestId).toBe("request-id");
+    expect(payload.status).toBe("completed");
+    expect(payload.progress).toBe(100);
+    expect(payload.result?.audios).toHaveLength(1);
+    expect(payload.errorMessage).toBe("warn");
+  });
+
+  it("조회 중 예외가 발생하면 500을 반환한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockGetAudioGeneration.mockRejectedValue(new Error("db fail"));
+
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "request-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload.message).toBe("INTERNAL_SERVER_ERROR");
+  });
+});

--- a/src/app/api/audio-generation/[requestId]/route.ts
+++ b/src/app/api/audio-generation/[requestId]/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/server/auth/session";
+import { getAudioGeneration } from "@/server/audio-generation/audio-generation-store";
+import { prisma } from "@/server/db/prisma";
+import { deleteLeemageFilesByPrefix } from "@/server/shared/leemage-file-deleter";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type RouteContext = {
+  params: Promise<{
+    requestId: string;
+  }>;
+};
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const session = await getSession();
+
+  if (!session.isLoggedIn || !session.adminEmail) {
+    return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  const { requestId } = await params;
+  let record = null;
+
+  try {
+    record = await getAudioGeneration(requestId, session.adminEmail);
+  } catch (error) {
+    console.error("[audio-generation] status failed", error);
+    return NextResponse.json({ message: "INTERNAL_SERVER_ERROR" }, { status: 500 });
+  }
+
+  if (!record) {
+    return NextResponse.json({ message: "NOT_FOUND" }, { status: 404 });
+  }
+
+  return NextResponse.json(
+    {
+      requestId: record.id,
+      status: record.status,
+      progress: record.progress,
+      result: record.result,
+      errorMessage: record.errorMessage,
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}
+
+export async function DELETE(_request: Request, { params }: RouteContext) {
+  const session = await getSession();
+
+  if (!session.isLoggedIn || !session.adminEmail) {
+    return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  const { requestId } = await params;
+  const record = await prisma.audioGeneration.findFirst({
+    where: { requestId, ownerEmail: session.adminEmail },
+    select: {
+      id: true,
+      status: true,
+      requestId: true,
+    },
+  });
+
+  if (!record) {
+    return NextResponse.json({ message: "NOT_FOUND" }, { status: 404 });
+  }
+
+  if (record.status === "pending" || record.status === "processing") {
+    return NextResponse.json({ message: "IN_PROGRESS" }, { status: 400 });
+  }
+
+  try {
+    await deleteLeemageFilesByPrefix(`${record.requestId}-`);
+  } catch (error) {
+    console.error("[audio-generation] storage delete failed", error);
+    return NextResponse.json({ message: "STORAGE_DELETE_FAILED" }, { status: 500 });
+  }
+
+  try {
+    await prisma.audioGeneration.delete({
+      where: { id: record.id },
+    });
+  } catch (error) {
+    console.error("[audio-generation] db delete failed", error);
+    return NextResponse.json({ message: "DB_DELETE_FAILED" }, { status: 500 });
+  }
+
+  return NextResponse.json({ message: "DELETED" });
+}

--- a/src/app/api/audio-generation/route.test.ts
+++ b/src/app/api/audio-generation/route.test.ts
@@ -143,4 +143,42 @@ describe("POST /api/audio-generation", () => {
     expect(response.status).toBe(500);
     expect(payload.message).toBe("DB_SAVE_FAILED");
   });
+
+  it("multipart reference audio와 reference text를 파싱한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockValidatePayload.mockResolvedValue({
+      success: false,
+      error: { flatten: () => ({}) },
+    });
+
+    const formData = new FormData();
+    formData.set("prompt", "hello");
+    formData.set("model", "qwen-tts");
+    formData.set("referenceText", "reference words");
+    formData.set(
+      "inputAudio",
+      new File([Uint8Array.from([82, 73, 70, 70])], "ref.wav", {
+        type: "audio/wav",
+      }),
+    );
+
+    await POST(
+      new Request("http://localhost/api/audio-generation", {
+        method: "POST",
+        body: formData,
+      }),
+    );
+
+    expect(mockValidatePayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "hello",
+        model: "qwen-tts",
+        referenceText: "reference words",
+        inputAudio: expect.stringMatching(/^data:audio\/wav;base64,/),
+      }),
+    );
+  });
 });

--- a/src/app/api/audio-generation/route.test.ts
+++ b/src/app/api/audio-generation/route.test.ts
@@ -1,0 +1,146 @@
+import { audioGenerationDefaults } from "@/features/audio-generation/model/audio-generation-schema";
+import { POST } from "@/app/api/audio-generation/route";
+
+const mockGetSession = vi.hoisted(() => vi.fn());
+const mockCreateWithLimit = vi.hoisted(() => vi.fn());
+const mockStartWorker = vi.hoisted(() => vi.fn());
+const mockValidatePayload = vi.hoisted(() => vi.fn());
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+vi.mock("@/server/auth/session", () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock("@/server/audio-generation/audio-generation-store", () => ({
+  createMockAudioGenerationWithLimit: mockCreateWithLimit,
+}));
+
+vi.mock("@/server/generation-worker/generation-worker", () => ({
+  startGenerationWorker: mockStartWorker,
+}));
+
+vi.mock("@/server/model-catalog/generation-validation", () => ({
+  validateAudioGenerationPayload: mockValidatePayload,
+}));
+
+describe("POST /api/audio-generation", () => {
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockGetSession.mockReset();
+    mockCreateWithLimit.mockReset();
+    mockStartWorker.mockReset();
+    mockValidatePayload.mockReset();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("로그인하지 않은 경우 401을 반환한다", async () => {
+    mockGetSession.mockResolvedValue({ isLoggedIn: false });
+
+    const request = new Request("http://localhost/api/audio-generation", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.message).toBe("UNAUTHORIZED");
+  });
+
+  it("유효하지 않은 요청이면 400을 반환한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockValidatePayload.mockResolvedValue({
+      success: false,
+      error: { flatten: () => ({}) },
+    });
+
+    const request = new Request("http://localhost/api/audio-generation", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "" }),
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.message).toBe("INVALID_REQUEST");
+  });
+
+  it("정상 요청이면 생성 정보를 반환한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockValidatePayload.mockResolvedValue({
+      success: true,
+      data: {
+        ...audioGenerationDefaults,
+        prompt: "hello",
+        model: "qwen-tts",
+      },
+    });
+    mockCreateWithLimit.mockResolvedValue({
+      record: { id: "request-id", status: "pending", progress: 0 },
+      latest: null,
+    });
+
+    const request = new Request("http://localhost/api/audio-generation", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...audioGenerationDefaults,
+        prompt: "hello",
+        model: "qwen-tts",
+      }),
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.requestId).toBe("request-id");
+    expect(payload.status).toBe("pending");
+    expect(payload.progress).toBe(0);
+  });
+
+  it("저장 실패 시 500을 반환한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockValidatePayload.mockResolvedValue({
+      success: true,
+      data: {
+        ...audioGenerationDefaults,
+        prompt: "hello",
+        model: "qwen-tts",
+      },
+    });
+    mockCreateWithLimit.mockRejectedValue(new Error("db fail"));
+
+    const request = new Request("http://localhost/api/audio-generation", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...audioGenerationDefaults,
+        prompt: "hello",
+        model: "qwen-tts",
+      }),
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload.message).toBe("DB_SAVE_FAILED");
+  });
+});

--- a/src/app/api/audio-generation/route.test.ts
+++ b/src/app/api/audio-generation/route.test.ts
@@ -110,6 +110,7 @@ describe("POST /api/audio-generation", () => {
     expect(payload.requestId).toBe("request-id");
     expect(payload.status).toBe("pending");
     expect(payload.progress).toBe(0);
+    expect(mockStartWorker).toHaveBeenCalled();
   });
 
   it("저장 실패 시 500을 반환한다", async () => {

--- a/src/app/api/audio-generation/route.ts
+++ b/src/app/api/audio-generation/route.ts
@@ -1,0 +1,40 @@
+import { getSession } from "@/server/auth/session";
+import { createMockAudioGenerationWithLimit } from "@/server/audio-generation/audio-generation-store";
+import {
+  buildErrorResponse,
+  buildGenerationSuccessResponse,
+  buildInvalidRequestResponse,
+} from "@/server/http/response";
+import { startGenerationWorker } from "@/server/generation-worker/generation-worker";
+import { validateAudioGenerationPayload } from "@/server/model-catalog/generation-validation";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function POST(request: Request) {
+  const session = await getSession();
+
+  if (!session.isLoggedIn || !session.adminEmail) {
+    return buildErrorResponse("UNAUTHORIZED", 401);
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = await validateAudioGenerationPayload(body);
+
+  if (!parsed.success) {
+    return buildInvalidRequestResponse(parsed.error.flatten());
+  }
+
+  try {
+    startGenerationWorker();
+    const { record } = await createMockAudioGenerationWithLimit(
+      parsed.data,
+      session.adminEmail,
+    );
+
+    return buildGenerationSuccessResponse(record);
+  } catch (error) {
+    console.error("[audio-generation] create failed", error);
+    return buildErrorResponse("DB_SAVE_FAILED", 500);
+  }
+}

--- a/src/app/api/audio-generation/route.ts
+++ b/src/app/api/audio-generation/route.ts
@@ -6,6 +6,7 @@ import {
   buildInvalidRequestResponse,
 } from "@/server/http/response";
 import {
+  getBoolean,
   getNumber,
   getOptionalDataUrl,
   getString,
@@ -35,6 +36,20 @@ export async function POST(request: Request) {
           seed: getString(formData, "seed") || undefined,
           inputAudio: await getOptionalDataUrl(formData, "inputAudio"),
           referenceText: getString(formData, "referenceText") || undefined,
+          modeChoice: getString(formData, "modeChoice") || undefined,
+          language: getString(formData, "language") || undefined,
+          speaker: getString(formData, "speaker") || undefined,
+          streamMode: getBoolean(formData, "streamMode"),
+          referencePreset: getString(formData, "referencePreset") || undefined,
+          customInstruction:
+            getString(formData, "customInstruction") || undefined,
+          voiceInstruction:
+            getString(formData, "voiceInstruction") || undefined,
+          xvecOnly: getBoolean(formData, "xvecOnly"),
+          chunkSize: getNumber(formData, "chunkSize"),
+          temperature: getNumber(formData, "temperature"),
+          topK: getNumber(formData, "topK"),
+          repetitionPenalty: getNumber(formData, "repetitionPenalty"),
         }))
         .catch(() => null)
     : await request.json().catch(() => null);

--- a/src/app/api/audio-generation/route.ts
+++ b/src/app/api/audio-generation/route.ts
@@ -5,6 +5,11 @@ import {
   buildGenerationSuccessResponse,
   buildInvalidRequestResponse,
 } from "@/server/http/response";
+import {
+  getNumber,
+  getOptionalDataUrl,
+  getString,
+} from "@/server/http/form-data-utils";
 import { startGenerationWorker } from "@/server/generation-worker/generation-worker";
 import { validateAudioGenerationPayload } from "@/server/model-catalog/generation-validation";
 
@@ -18,7 +23,21 @@ export async function POST(request: Request) {
     return buildErrorResponse("UNAUTHORIZED", 401);
   }
 
-  const body = await request.json().catch(() => null);
+  const contentType = request.headers.get("content-type")?.toLowerCase() ?? "";
+  const body = contentType.includes("multipart/form-data")
+    ? await request
+        .formData()
+        .then(async (formData) => ({
+          prompt: getString(formData, "prompt"),
+          model: getString(formData, "model"),
+          voice: getString(formData, "voice") || undefined,
+          speed: getNumber(formData, "speed"),
+          seed: getString(formData, "seed") || undefined,
+          inputAudio: await getOptionalDataUrl(formData, "inputAudio"),
+          referenceText: getString(formData, "referenceText") || undefined,
+        }))
+        .catch(() => null)
+    : await request.json().catch(() => null);
   const parsed = await validateAudioGenerationPayload(body);
 
   if (!parsed.success) {

--- a/src/app/api/external/audio-generation/[requestId]/route.test.ts
+++ b/src/app/api/external/audio-generation/[requestId]/route.test.ts
@@ -1,0 +1,76 @@
+import { GET } from "@/app/api/external/audio-generation/[requestId]/route";
+import { NextResponse } from "next/server";
+
+const mockRequireApiKey = vi.hoisted(() => vi.fn());
+const mockGetAudioGeneration = vi.hoisted(() => vi.fn());
+
+vi.mock("@/server/auth/api-key-guard", () => ({
+  requireApiKey: mockRequireApiKey,
+}));
+
+vi.mock("@/server/audio-generation/audio-generation-store", () => ({
+  getAudioGeneration: mockGetAudioGeneration,
+}));
+
+describe("GET /api/external/audio-generation/[requestId]", () => {
+  beforeEach(() => {
+    mockRequireApiKey.mockReset();
+    mockGetAudioGeneration.mockReset();
+  });
+
+  it("API 키가 없으면 인증 응답을 그대로 반환한다", async () => {
+    mockRequireApiKey.mockResolvedValue(
+      NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 }),
+    );
+
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "request-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.message).toBe("UNAUTHORIZED");
+  });
+
+  it("요청이 없으면 404를 반환한다", async () => {
+    mockRequireApiKey.mockResolvedValue({
+      ownerEmail: "api@example.com",
+      apiKeyId: "key-id",
+    });
+    mockGetAudioGeneration.mockResolvedValue(null);
+
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "missing-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(payload.message).toBe("NOT_FOUND");
+  });
+
+  it("요청이 존재하면 상태를 반환한다", async () => {
+    mockRequireApiKey.mockResolvedValue({
+      ownerEmail: "api@example.com",
+      apiKeyId: "key-id",
+    });
+    mockGetAudioGeneration.mockResolvedValue({
+      id: "request-id",
+      status: "completed",
+      progress: 100,
+      result: { audios: [{ url: "https://example.com/1.mp3" }] },
+      errorMessage: "warn",
+    });
+
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "request-id" }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.requestId).toBe("request-id");
+    expect(payload.status).toBe("completed");
+    expect(payload.progress).toBe(100);
+    expect(payload.result?.audios).toHaveLength(1);
+    expect(payload.errorMessage).toBe("warn");
+  });
+});

--- a/src/app/api/external/audio-generation/[requestId]/route.ts
+++ b/src/app/api/external/audio-generation/[requestId]/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { requireApiKey } from "@/server/auth/api-key-guard";
+import { getAudioGeneration } from "@/server/audio-generation/audio-generation-store";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type RouteContext = {
+  params: Promise<{
+    requestId: string;
+  }>;
+};
+
+export async function GET(request: Request, { params }: RouteContext) {
+  const auth = await requireApiKey(request);
+  if (auth instanceof NextResponse) {
+    return auth;
+  }
+
+  const { requestId } = await params;
+  const record = await getAudioGeneration(requestId, auth.ownerEmail);
+
+  if (!record) {
+    return NextResponse.json({ message: "NOT_FOUND" }, { status: 404 });
+  }
+
+  return NextResponse.json(
+    {
+      requestId: record.id,
+      status: record.status,
+      progress: record.progress,
+      result: record.result,
+      errorMessage: record.errorMessage,
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/src/app/api/external/audio-generation/route.test.ts
+++ b/src/app/api/external/audio-generation/route.test.ts
@@ -145,4 +145,42 @@ describe("POST /api/external/audio-generation", () => {
     expect(response.status).toBe(500);
     expect(payload.message).toBe("DB_SAVE_FAILED");
   });
+
+  it("multipart reference audio와 reference text를 파싱한다", async () => {
+    mockRequireApiKey.mockResolvedValue({
+      ownerEmail: "api@example.com",
+      apiKeyId: "key-id",
+    });
+    mockValidatePayload.mockResolvedValue({
+      success: false,
+      error: { flatten: () => ({}) },
+    });
+
+    const formData = new FormData();
+    formData.set("prompt", "hello");
+    formData.set("model", "qwen-tts");
+    formData.set("referenceText", "reference words");
+    formData.set(
+      "inputAudio",
+      new File([Uint8Array.from([82, 73, 70, 70])], "ref.wav", {
+        type: "audio/wav",
+      }),
+    );
+
+    await POST(
+      new Request("http://localhost/api/external/audio-generation", {
+        method: "POST",
+        body: formData,
+      }),
+    );
+
+    expect(mockValidatePayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "hello",
+        model: "qwen-tts",
+        referenceText: "reference words",
+        inputAudio: expect.stringMatching(/^data:audio\/wav;base64,/),
+      }),
+    );
+  });
 });

--- a/src/app/api/external/audio-generation/route.test.ts
+++ b/src/app/api/external/audio-generation/route.test.ts
@@ -1,0 +1,148 @@
+import { audioGenerationDefaults } from "@/features/audio-generation/model/audio-generation-schema";
+import { POST } from "@/app/api/external/audio-generation/route";
+import { NextResponse } from "next/server";
+
+const mockRequireApiKey = vi.hoisted(() => vi.fn());
+const mockCreateWithLimit = vi.hoisted(() => vi.fn());
+const mockStartWorker = vi.hoisted(() => vi.fn());
+const mockValidatePayload = vi.hoisted(() => vi.fn());
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+vi.mock("@/server/auth/api-key-guard", () => ({
+  requireApiKey: mockRequireApiKey,
+}));
+
+vi.mock("@/server/audio-generation/audio-generation-store", () => ({
+  createMockAudioGenerationWithLimit: mockCreateWithLimit,
+}));
+
+vi.mock("@/server/generation-worker/generation-worker", () => ({
+  startGenerationWorker: mockStartWorker,
+}));
+
+vi.mock("@/server/model-catalog/generation-validation", () => ({
+  validateAudioGenerationPayload: mockValidatePayload,
+}));
+
+describe("POST /api/external/audio-generation", () => {
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockRequireApiKey.mockReset();
+    mockCreateWithLimit.mockReset();
+    mockStartWorker.mockReset();
+    mockValidatePayload.mockReset();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("API 키가 없으면 인증 응답을 그대로 반환한다", async () => {
+    mockRequireApiKey.mockResolvedValue(
+      NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 }),
+    );
+
+    const request = new Request("http://localhost/api/external/audio-generation", {
+      method: "POST",
+      body: new FormData(),
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.message).toBe("UNAUTHORIZED");
+  });
+
+  it("유효하지 않은 요청이면 400을 반환한다", async () => {
+    mockRequireApiKey.mockResolvedValue({
+      ownerEmail: "api@example.com",
+      apiKeyId: "key-id",
+    });
+    mockValidatePayload.mockResolvedValue({
+      success: false,
+      error: { flatten: () => ({}) },
+    });
+
+    const formData = new FormData();
+    formData.set("prompt", "");
+
+    const response = await POST(
+      new Request("http://localhost/api/external/audio-generation", {
+        method: "POST",
+        body: formData,
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.message).toBe("INVALID_REQUEST");
+  });
+
+  it("정상 요청이면 생성 정보를 반환한다", async () => {
+    mockRequireApiKey.mockResolvedValue({
+      ownerEmail: "api@example.com",
+      apiKeyId: "key-id",
+    });
+    mockValidatePayload.mockResolvedValue({
+      success: true,
+      data: {
+        ...audioGenerationDefaults,
+        prompt: "hello",
+        model: "qwen-tts",
+      },
+    });
+    mockCreateWithLimit.mockResolvedValue({
+      record: { id: "request-id", status: "pending", progress: 0 },
+      latest: null,
+    });
+
+    const formData = new FormData();
+    formData.set("prompt", "hello");
+    formData.set("model", "qwen-tts");
+
+    const response = await POST(
+      new Request("http://localhost/api/external/audio-generation", {
+        method: "POST",
+        body: formData,
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.requestId).toBe("request-id");
+    expect(payload.status).toBe("pending");
+    expect(payload.progress).toBe(0);
+  });
+
+  it("저장 실패 시 500을 반환한다", async () => {
+    mockRequireApiKey.mockResolvedValue({
+      ownerEmail: "api@example.com",
+      apiKeyId: "key-id",
+    });
+    mockValidatePayload.mockResolvedValue({
+      success: true,
+      data: {
+        ...audioGenerationDefaults,
+        prompt: "hello",
+        model: "qwen-tts",
+      },
+    });
+    mockCreateWithLimit.mockRejectedValue(new Error("db fail"));
+
+    const formData = new FormData();
+    formData.set("prompt", "hello");
+    formData.set("model", "qwen-tts");
+
+    const response = await POST(
+      new Request("http://localhost/api/external/audio-generation", {
+        method: "POST",
+        body: formData,
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload.message).toBe("DB_SAVE_FAILED");
+  });
+});

--- a/src/app/api/external/audio-generation/route.test.ts
+++ b/src/app/api/external/audio-generation/route.test.ts
@@ -6,7 +6,6 @@ const mockRequireApiKey = vi.hoisted(() => vi.fn());
 const mockCreateWithLimit = vi.hoisted(() => vi.fn());
 const mockStartWorker = vi.hoisted(() => vi.fn());
 const mockValidatePayload = vi.hoisted(() => vi.fn());
-let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
 vi.mock("@/server/auth/api-key-guard", () => ({
   requireApiKey: mockRequireApiKey,
@@ -26,15 +25,10 @@ vi.mock("@/server/model-catalog/generation-validation", () => ({
 
 describe("POST /api/external/audio-generation", () => {
   beforeEach(() => {
-    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     mockRequireApiKey.mockReset();
     mockCreateWithLimit.mockReset();
     mockStartWorker.mockReset();
     mockValidatePayload.mockReset();
-  });
-
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
   });
 
   it("API 키가 없으면 인증 응답을 그대로 반환한다", async () => {

--- a/src/app/api/external/audio-generation/route.ts
+++ b/src/app/api/external/audio-generation/route.ts
@@ -8,6 +8,7 @@ import {
 import { startGenerationWorker } from "@/server/generation-worker/generation-worker";
 import { validateAudioGenerationPayload } from "@/server/model-catalog/generation-validation";
 import {
+  getOptionalDataUrl,
   getNumber,
   getString,
 } from "@/server/http/form-data-utils";
@@ -33,6 +34,8 @@ export async function POST(request: Request) {
     voice: getString(formData, "voice") || undefined,
     speed: getNumber(formData, "speed"),
     seed: getString(formData, "seed") || undefined,
+    inputAudio: await getOptionalDataUrl(formData, "inputAudio"),
+    referenceText: getString(formData, "referenceText") || undefined,
   };
 
   const parsed = await validateAudioGenerationPayload(body);

--- a/src/app/api/external/audio-generation/route.ts
+++ b/src/app/api/external/audio-generation/route.ts
@@ -8,6 +8,7 @@ import {
 import { startGenerationWorker } from "@/server/generation-worker/generation-worker";
 import { validateAudioGenerationPayload } from "@/server/model-catalog/generation-validation";
 import {
+  getBoolean,
   getOptionalDataUrl,
   getNumber,
   getString,
@@ -36,6 +37,18 @@ export async function POST(request: Request) {
     seed: getString(formData, "seed") || undefined,
     inputAudio: await getOptionalDataUrl(formData, "inputAudio"),
     referenceText: getString(formData, "referenceText") || undefined,
+    modeChoice: getString(formData, "modeChoice") || undefined,
+    language: getString(formData, "language") || undefined,
+    speaker: getString(formData, "speaker") || undefined,
+    streamMode: getBoolean(formData, "streamMode"),
+    referencePreset: getString(formData, "referencePreset") || undefined,
+    customInstruction: getString(formData, "customInstruction") || undefined,
+    voiceInstruction: getString(formData, "voiceInstruction") || undefined,
+    xvecOnly: getBoolean(formData, "xvecOnly"),
+    chunkSize: getNumber(formData, "chunkSize"),
+    temperature: getNumber(formData, "temperature"),
+    topK: getNumber(formData, "topK"),
+    repetitionPenalty: getNumber(formData, "repetitionPenalty"),
   };
 
   const parsed = await validateAudioGenerationPayload(body);

--- a/src/app/api/external/audio-generation/route.ts
+++ b/src/app/api/external/audio-generation/route.ts
@@ -1,0 +1,57 @@
+import { requireApiKey } from "@/server/auth/api-key-guard";
+import { createMockAudioGenerationWithLimit } from "@/server/audio-generation/audio-generation-store";
+import {
+  buildErrorResponse,
+  buildGenerationSuccessResponse,
+  buildInvalidRequestResponse,
+} from "@/server/http/response";
+import { startGenerationWorker } from "@/server/generation-worker/generation-worker";
+import { validateAudioGenerationPayload } from "@/server/model-catalog/generation-validation";
+import {
+  getNumber,
+  getString,
+} from "@/server/http/form-data-utils";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  const auth = await requireApiKey(request);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const formData = await request.formData().catch(() => null);
+  if (!formData) {
+    return buildErrorResponse("INVALID_FORM_DATA", 400);
+  }
+
+  const body = {
+    prompt: getString(formData, "prompt"),
+    model: getString(formData, "model"),
+    voice: getString(formData, "voice") || undefined,
+    speed: getNumber(formData, "speed"),
+    seed: getString(formData, "seed") || undefined,
+  };
+
+  const parsed = await validateAudioGenerationPayload(body);
+
+  if (!parsed.success) {
+    return buildInvalidRequestResponse(parsed.error.flatten());
+  }
+
+  try {
+    startGenerationWorker();
+    const { record } = await createMockAudioGenerationWithLimit(
+      parsed.data,
+      auth.ownerEmail,
+      auth.apiKeyId,
+    );
+
+    return buildGenerationSuccessResponse(record);
+  } catch (error) {
+    console.error("[audio-generation] create failed", error);
+    return buildErrorResponse("DB_SAVE_FAILED", 500);
+  }
+}

--- a/src/app/api/models/route.test.ts
+++ b/src/app/api/models/route.test.ts
@@ -65,8 +65,8 @@ const videoModel: ModelCatalogItem = {
     steps: { ui: "range", min: 1, max: 10, step: 1 },
     guidanceScale: { ui: "range", min: 0, max: 10, step: 0.5 },
     seed: { ui: "input" },
-    aspectRatio: { ui: "select", options: ["16:9"] },
-    resolution: { ui: "select", options: [720] },
+    aspectRatio: { ui: "select", options: [{ label: "16:9", value: "16:9" }] },
+    resolution: { ui: "select", options: [{ label: "720", value: 720 }] },
     fps: { ui: "range", min: 1, max: 60, step: 1 },
   },
   meta: {
@@ -126,4 +126,3 @@ describe("/api/models", () => {
     expect(payload.items[0]?.key).toBe("flux2-klein-9b");
   });
 });
-

--- a/src/app/api/monitoring/requests/detail/route.ts
+++ b/src/app/api/monitoring/requests/detail/route.ts
@@ -5,7 +5,7 @@ import { getMonitoringRequestDetail } from "@/server/monitoring/request-detail";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-const VALID_TYPES = new Set(["image", "video"]);
+const VALID_TYPES = new Set(["image", "video", "audio"]);
 
 export async function GET(request: Request) {
   const session = await getSession();
@@ -24,7 +24,7 @@ export async function GET(request: Request) {
 
   try {
     const detail = await getMonitoringRequestDetail(
-      type as "image" | "video",
+      type as "image" | "video" | "audio",
       requestId,
     );
 

--- a/src/entities/generation/model/types.ts
+++ b/src/entities/generation/model/types.ts
@@ -12,6 +12,8 @@ export interface GenerationHistoryItem {
   resultUrl: string | null;
   thumbnailUrl: string | null;
   inputImages?: string[];
+  inputAudios?: string[];
+  referenceText?: string | null;
   errorMessage: string | null;
 }
 

--- a/src/entities/generation/model/types.ts
+++ b/src/entities/generation/model/types.ts
@@ -1,10 +1,10 @@
-export type GenerationHistoryType = "image" | "video" | "all";
+export type GenerationHistoryType = "image" | "video" | "audio" | "all";
 export type GenerationHistorySort = "date_desc" | "date_asc";
 export type GenerationHistoryStatus = "pending" | "processing" | "completed" | "failed";
 
 export interface GenerationHistoryItem {
   id: string;
-  type: "image" | "video";
+  type: "image" | "video" | "audio";
   status: GenerationHistoryStatus;
   prompt: string;
   model: string | null;

--- a/src/features/api-docs/model/openapi-helpers.ts
+++ b/src/features/api-docs/model/openapi-helpers.ts
@@ -173,6 +173,7 @@ export function buildExampleFromSchema(
   if (resolved.format === "binary") {
     const key = hintKey?.toLowerCase() ?? "";
     if (key.includes("video")) return "sample.mp4";
+    if (key.includes("audio")) return "sample.mp3";
     if (key.includes("image") || key.includes("init")) return "sample.png";
     return "sample.bin";
   }
@@ -237,10 +238,15 @@ function buildStringExample(hintKey?: string, examples?: ExampleStrings) {
   if (key.includes("email")) return "admin@leesfield.ai";
   if (key.includes("model")) return "image-core";
   if (key.includes("prompt")) return examples?.samplePrompt ?? "Sample prompt";
-  if (key.includes("url")) return "https://cdn.leesfield.ai/sample.png";
+  if (key.includes("audio")) return "sample.mp3";
+  if (key.includes("url")) {
+    return key.includes("audio")
+      ? "https://cdn.leesfield.ai/sample.mp3"
+      : "https://cdn.leesfield.ai/sample.png";
+  }
   if (key.includes("label")) return examples?.sampleLabel ?? "Sample";
   if (key.includes("name")) return examples?.sampleName ?? "Sample";
-  if (key.includes("type")) return "image";
+  if (key.includes("type")) return key.includes("audio") ? "audio" : "image";
   if (key.includes("version")) return "v1";
   if (key.includes("message")) return examples?.sampleMessage ?? "OK";
   if (key.includes("token") || key.includes("key")) return "lf_live_****";

--- a/src/features/api-docs/model/openapi-translations.ts
+++ b/src/features/api-docs/model/openapi-translations.ts
@@ -25,6 +25,9 @@ export function getOpenApiTranslations(
       videos:
         (getMessage(messages, "apiDocs.openapi.tags.videos") as string | null) ??
         undefined,
+      audio:
+        (getMessage(messages, "apiDocs.openapi.tags.audio") as string | null) ??
+        undefined,
       models:
         (getMessage(messages, "apiDocs.openapi.tags.models") as string | null) ??
         undefined,
@@ -40,6 +43,11 @@ export function getOpenApiTranslations(
           messages,
           "apiDocs.openapi.paths.videoGeneration",
         ) as string | null) ?? undefined,
+      audioGeneration:
+        (getMessage(
+          messages,
+          "apiDocs.openapi.paths.audioGeneration",
+        ) as string | null) ?? undefined,
       imageStatus:
         (getMessage(
           messages,
@@ -49,6 +57,11 @@ export function getOpenApiTranslations(
         (getMessage(
           messages,
           "apiDocs.openapi.paths.videoStatus",
+        ) as string | null) ?? undefined,
+      audioStatus:
+        (getMessage(
+          messages,
+          "apiDocs.openapi.paths.audioStatus",
         ) as string | null) ?? undefined,
       models:
         (getMessage(messages, "apiDocs.openapi.paths.models") as string | null) ??

--- a/src/features/api-docs/model/openapi.test.ts
+++ b/src/features/api-docs/model/openapi.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getOpenApiDocument } from "@/features/api-docs/model/openapi";
+
+describe("getOpenApiDocument", () => {
+  it("audio generation 외부 API 경로와 태그를 포함한다", () => {
+    const document = getOpenApiDocument();
+
+    expect(document.tags?.some((tag) => tag.name === "Audio")).toBe(true);
+    expect(document.paths["/api/external/audio-generation"]?.post).toBeTruthy();
+    expect(
+      document.paths["/api/external/audio-generation/{requestId}"]?.get,
+    ).toBeTruthy();
+  });
+});

--- a/src/features/api-docs/model/openapi.test.ts
+++ b/src/features/api-docs/model/openapi.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { RequestBodyObject, SchemaObject } from "openapi3-ts/oas31";
 import { getOpenApiDocument } from "@/features/api-docs/model/openapi";
 
 describe("getOpenApiDocument", () => {
@@ -14,9 +15,12 @@ describe("getOpenApiDocument", () => {
 
   it("audio generation 요청 스키마에 reference audio/reference text를 노출한다", () => {
     const document = getOpenApiDocument();
+    const requestBody = document.paths["/api/external/audio-generation"]?.post
+      ?.requestBody as RequestBodyObject | undefined;
     const schema =
-      document.paths["/api/external/audio-generation"]?.post?.requestBody
-        ?.content?.["multipart/form-data"]?.schema;
+      requestBody?.content?.["multipart/form-data"]?.schema as
+        | SchemaObject
+        | undefined;
 
     expect(schema?.properties?.inputAudio).toMatchObject({
       type: "string",

--- a/src/features/api-docs/model/openapi.test.ts
+++ b/src/features/api-docs/model/openapi.test.ts
@@ -11,4 +11,19 @@ describe("getOpenApiDocument", () => {
       document.paths["/api/external/audio-generation/{requestId}"]?.get,
     ).toBeTruthy();
   });
+
+  it("audio generation 요청 스키마에 reference audio/reference text를 노출한다", () => {
+    const document = getOpenApiDocument();
+    const schema =
+      document.paths["/api/external/audio-generation"]?.post?.requestBody
+        ?.content?.["multipart/form-data"]?.schema;
+
+    expect(schema?.properties?.inputAudio).toMatchObject({
+      type: "string",
+      format: "binary",
+    });
+    expect(schema?.properties?.referenceText).toMatchObject({
+      type: "string",
+    });
+  });
 });

--- a/src/features/api-docs/model/openapi.ts
+++ b/src/features/api-docs/model/openapi.ts
@@ -4,7 +4,6 @@ import {
   extendZodWithOpenApi,
 } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
-import { audioGenerationOpenApiSchema } from "@/features/audio-generation/model/audio-generation-schema";
 import { modelCatalog } from "@/features/model-management/model/model-catalog";
 
 extendZodWithOpenApi(z);
@@ -146,6 +145,23 @@ const videoGenerationFormDataSchema = z.object({
   seed: z.string().optional(),
 });
 
+const audioGenerationFormDataSchema = z.object({
+  prompt: z.string(),
+  model: z
+    .string()
+    .openapi({
+      description: "Use /api/external/models to fetch available model keys.",
+    }),
+  voice: z.string().optional(),
+  speed: z.number().optional(),
+  seed: z.string().optional(),
+  inputAudio: z
+    .string()
+    .optional()
+    .openapi({ type: "string", format: "binary" }),
+  referenceText: z.string().optional(),
+});
+
 registry.register("ErrorResponse", errorResponseSchema);
 registry.register("GenerationResponse", generationResponseSchema);
 registry.register("ModelResponse", modelResponseSchema);
@@ -269,7 +285,7 @@ registry.registerPath({
       required: true,
       content: {
         "multipart/form-data": {
-          schema: audioGenerationOpenApiSchema,
+          schema: audioGenerationFormDataSchema,
         },
       },
     },

--- a/src/features/api-docs/model/openapi.ts
+++ b/src/features/api-docs/model/openapi.ts
@@ -4,6 +4,7 @@ import {
   extendZodWithOpenApi,
 } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
+import { audioGenerationOpenApiSchema } from "@/features/audio-generation/model/audio-generation-schema";
 import { modelCatalog } from "@/features/model-management/model/model-catalog";
 
 extendZodWithOpenApi(z);
@@ -65,6 +66,23 @@ const videoStatusResponseSchema = z.object({
   errorMessage: z.string().optional(),
 });
 
+const audioResultSchema = z.object({
+  audios: z.array(
+    z.object({
+      url: z.string(),
+      durationSec: z.number().optional(),
+    }),
+  ),
+});
+
+const audioStatusResponseSchema = z.object({
+  requestId: z.string(),
+  status: z.enum(["pending", "processing", "completed", "failed"]),
+  progress: z.number(),
+  result: audioResultSchema.optional(),
+  errorMessage: z.string().optional(),
+});
+
 const modelResponseSchema = z.object({
   items: z.array(z.unknown()),
 });
@@ -74,13 +92,16 @@ export type OpenApiTranslations = {
   tags?: {
     images?: string;
     videos?: string;
+    audio?: string;
     models?: string;
   };
   paths?: {
     imageGeneration?: string;
     videoGeneration?: string;
+    audioGeneration?: string;
     imageStatus?: string;
     videoStatus?: string;
+    audioStatus?: string;
     models?: string;
   };
 };
@@ -195,6 +216,60 @@ registry.registerPath({
       content: {
         "multipart/form-data": {
           schema: videoGenerationFormDataSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "OK",
+      content: {
+        "application/json": {
+          schema: generationResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: "Invalid request",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema,
+          examples: {
+            invalidRequest: {
+              value: {
+                message: "INVALID_REQUEST",
+                errors: {
+                  formErrors: [],
+                  fieldErrors: {
+                    prompt: ["프롬프트를 입력해주세요."],
+                  },
+                },
+              },
+            },
+            invalidFormData: {
+              value: {
+                message: "INVALID_FORM_DATA",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/api/external/audio-generation",
+  tags: ["Audio"],
+  description: "Creates an audio generation request.",
+  security: [{ ApiKeyAuth: [] }],
+  request: {
+    body: {
+      required: true,
+      content: {
+        "multipart/form-data": {
+          schema: audioGenerationOpenApiSchema,
         },
       },
     },
@@ -353,6 +428,76 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/api/external/audio-generation/{requestId}",
+  tags: ["Audio"],
+  description: "Fetches audio generation status.",
+  security: [{ ApiKeyAuth: [] }],
+  request: {
+    params: z.object({
+      requestId: z.string(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "OK",
+      content: {
+        "application/json": {
+          schema: audioStatusResponseSchema,
+          example: {
+            requestId: "audio_request_01",
+            status: "completed",
+            progress: 100,
+            result: {
+              audios: [
+                {
+                  url: "https://cdn.leesfield.ai/sample.mp3",
+                  durationSec: 4,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    401: {
+      description: "API key required",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema,
+          example: {
+            message: "API_KEY_REQUIRED",
+          },
+        },
+      },
+    },
+    403: {
+      description: "Invalid or revoked API key",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema,
+          examples: {
+            invalid: { value: { message: "INVALID_API_KEY" } },
+            revoked: { value: { message: "API_KEY_REVOKED" } },
+          },
+        },
+      },
+    },
+    404: {
+      description: "Not found",
+      content: {
+        "application/json": {
+          schema: errorResponseSchema,
+          example: {
+            message: "NOT_FOUND",
+          },
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/api/external/models",
   tags: ["Models"],
   description: "Fetches available generation models.",
@@ -406,6 +551,7 @@ export function getOpenApiDocument(translations?: OpenApiTranslations) {
   const tags = {
     images: translations?.tags?.images ?? "Image generation",
     videos: translations?.tags?.videos ?? "Video generation",
+    audio: translations?.tags?.audio ?? "Audio generation",
     models: translations?.tags?.models ?? "Model catalog",
   };
   const paths = {
@@ -415,12 +561,18 @@ export function getOpenApiDocument(translations?: OpenApiTranslations) {
     videoGeneration:
       translations?.paths?.videoGeneration ??
       "Creates a video generation request. Model keys are available via /api/external/models.",
+    audioGeneration:
+      translations?.paths?.audioGeneration ??
+      "Creates an audio generation request. Model keys are available via /api/external/models.",
     imageStatus:
       translations?.paths?.imageStatus ??
       "Fetches image generation status.",
     videoStatus:
       translations?.paths?.videoStatus ??
       "Fetches video generation status.",
+    audioStatus:
+      translations?.paths?.audioStatus ??
+      "Fetches audio generation status.",
     models:
       translations?.paths?.models ??
       "Fetches available generation models.",
@@ -438,6 +590,7 @@ export function getOpenApiDocument(translations?: OpenApiTranslations) {
     tags: [
       { name: "Images", description: tags.images },
       { name: "Videos", description: tags.videos },
+      { name: "Audio", description: tags.audio },
       { name: "Models", description: tags.models },
     ],
   });
@@ -471,6 +624,11 @@ export function getOpenApiDocument(translations?: OpenApiTranslations) {
     paths.videoGeneration,
   );
   updateDescription(
+    "/api/external/audio-generation",
+    "post",
+    paths.audioGeneration,
+  );
+  updateDescription(
     "/api/external/image-generation/{requestId}",
     "get",
     paths.imageStatus,
@@ -479,6 +637,11 @@ export function getOpenApiDocument(translations?: OpenApiTranslations) {
     "/api/external/video-generation/{requestId}",
     "get",
     paths.videoStatus,
+  );
+  updateDescription(
+    "/api/external/audio-generation/{requestId}",
+    "get",
+    paths.audioStatus,
   );
   updateDescription("/api/external/models", "get", paths.models);
 

--- a/src/features/api-docs/model/snippet-templates.test.ts
+++ b/src/features/api-docs/model/snippet-templates.test.ts
@@ -35,4 +35,23 @@ describe("snippet-templates", () => {
     expect(snippet).toContain("JSON.stringify");
     expect(snippet).toContain("\"prompt\": \"hello\"");
   });
+
+  it("audio multipart 요청은 reference audio와 reference text를 함께 렌더링한다", () => {
+    const snippet = buildCurlSnippet({
+      baseUrl: "https://api.example.com",
+      path: "/api/external/audio-generation",
+      method: "POST",
+      contentType: "multipart/form-data",
+      fileFields: ["inputAudio"],
+      body: {
+        prompt: "hello",
+        model: "qwen-tts",
+        inputAudio: "sample.wav",
+        referenceText: "reference words",
+      },
+    });
+
+    expect(snippet).toContain("-F \"inputAudio=@sample.wav\"");
+    expect(snippet).toContain("-F \"referenceText=reference words\"");
+  });
 });

--- a/src/features/api-docs/model/snippet-templates.ts
+++ b/src/features/api-docs/model/snippet-templates.ts
@@ -20,6 +20,10 @@ const snippetOrder: SnippetLanguage[] = ["curl", "javascript", "python"];
 
 export const snippetLanguages = snippetOrder;
 
+function isMultipartContentType(contentType?: string) {
+  return contentType?.toLowerCase().includes("multipart/form-data") ?? false;
+}
+
 function serializeBody(body: unknown) {
   return body ?? {};
 }
@@ -37,7 +41,7 @@ function getHeaders(headers?: Record<string, string>, contentType?: string) {
     ...defaultHeaders,
     ...headers,
   };
-  if (contentType?.includes("multipart/form-data")) {
+  if (isMultipartContentType(contentType)) {
     delete merged["Content-Type"];
     return merged;
   }
@@ -92,7 +96,7 @@ function buildFormEntries(
 export function buildCurlSnippet(context: SnippetContext) {
   const { baseUrl, path, method, body, headers, contentType, fileFields } =
     context;
-  if (contentType?.includes("multipart/form-data")) {
+  if (isMultipartContentType(contentType)) {
     const headerLines = Object.entries(getHeaders(headers, contentType))
       .map(([key, value]) => `-H "${key}: ${value}"`)
       .join(" \\\n  ");
@@ -128,7 +132,7 @@ export function buildCurlSnippet(context: SnippetContext) {
 export function buildJavascriptSnippet(context: SnippetContext) {
   const { baseUrl, path, method, body, headers, contentType, fileFields } =
     context;
-  if (contentType?.includes("multipart/form-data")) {
+  if (isMultipartContentType(contentType)) {
     const formEntries = buildFormEntries(body, fileFields);
     const fileEntries = formEntries.filter((entry) => entry.isFile);
     const fileDeclarations = fileEntries
@@ -189,7 +193,7 @@ export function buildPythonSnippet(context: SnippetContext) {
     context;
   const combinedHeaders = getHeaders(headers, contentType);
   const methodName = method.toLowerCase();
-  if (contentType?.includes("multipart/form-data")) {
+  if (isMultipartContentType(contentType)) {
     const formEntries = buildFormEntries(body, fileFields);
     const dataEntries = formEntries.filter((entry) => !entry.isFile);
     const fileEntries = formEntries.filter((entry) => entry.isFile);

--- a/src/features/audio-generation/api/audio-generation-api.test.ts
+++ b/src/features/audio-generation/api/audio-generation-api.test.ts
@@ -39,4 +39,53 @@ describe("requestAudioGeneration", () => {
     expect(body.get("inputAudio")).toBe("data:audio/wav;base64,UklGRg==");
     expect(body.get("referenceText")).toBe("reference words");
   });
+
+  it("mode 기반 TTS 추가 파라미터를 form-data에 포함한다", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        requestId: "req-2",
+        status: "pending",
+        progress: 0,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const payload = {
+      prompt: "hello qwen",
+      model: "qwen-tts-mode",
+      voice: "",
+      speed: 1,
+      seed: "7",
+      inputAudio: "",
+      referenceText: "",
+      modeChoice: "voice_clone",
+      language: "English",
+      speaker: "Vivian",
+      streamMode: true,
+      referencePreset: "ref_audio_3",
+      customInstruction: "",
+      voiceInstruction: "",
+      xvecOnly: false,
+      chunkSize: 120,
+      temperature: 0.7,
+      topK: 20,
+      repetitionPenalty: 1.1,
+    };
+
+    await requestAudioGeneration(payload);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = init.body as FormData;
+    expect(body.get("modeChoice")).toBe("voice_clone");
+    expect(body.get("language")).toBe("English");
+    expect(body.get("speaker")).toBe("Vivian");
+    expect(body.get("streamMode")).toBe("true");
+    expect(body.get("referencePreset")).toBe("ref_audio_3");
+    expect(body.get("xvecOnly")).toBe("false");
+    expect(body.get("chunkSize")).toBe("120");
+    expect(body.get("temperature")).toBe("0.7");
+    expect(body.get("topK")).toBe("20");
+    expect(body.get("repetitionPenalty")).toBe("1.1");
+  });
 });

--- a/src/features/audio-generation/api/audio-generation-api.test.ts
+++ b/src/features/audio-generation/api/audio-generation-api.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { requestAudioGeneration } from "@/features/audio-generation/api/audio-generation-api";
 
 describe("requestAudioGeneration", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("audio reference 입력을 multipart form-data로 전송한다", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -87,5 +91,30 @@ describe("requestAudioGeneration", () => {
     expect(body.get("temperature")).toBe("0.7");
     expect(body.get("topK")).toBe("20");
     expect(body.get("repetitionPenalty")).toBe("1.1");
+  });
+
+  it("실패 응답이면 에러를 그대로 노출한다", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        message: "REQUEST_FAILED",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      requestAudioGeneration({
+        prompt: "hello",
+        model: "qwen-tts",
+        voice: "",
+        speed: 1,
+        seed: "",
+        inputAudio: "",
+        referenceText: "",
+      }),
+    ).rejects.toMatchObject({
+      message: "REQUEST_FAILED",
+      code: "REQUEST_FAILED",
+    });
   });
 });

--- a/src/features/audio-generation/api/audio-generation-api.test.ts
+++ b/src/features/audio-generation/api/audio-generation-api.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { requestAudioGeneration } from "@/features/audio-generation/api/audio-generation-api";
+
+describe("requestAudioGeneration", () => {
+  it("audio reference 입력을 multipart form-data로 전송한다", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        requestId: "req-1",
+        status: "pending",
+        progress: 0,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await requestAudioGeneration({
+      prompt: "hello",
+      model: "qwen-tts",
+      voice: "alloy",
+      speed: 1,
+      seed: "",
+      inputAudio: "data:audio/wav;base64,UklGRg==",
+      referenceText: "reference words",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/audio-generation",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(FormData),
+      }),
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toBeUndefined();
+    const body = init.body as FormData;
+    expect(body.get("prompt")).toBe("hello");
+    expect(body.get("model")).toBe("qwen-tts");
+    expect(body.get("inputAudio")).toBe("data:audio/wav;base64,UklGRg==");
+    expect(body.get("referenceText")).toBe("reference words");
+  });
+});

--- a/src/features/audio-generation/api/audio-generation-api.ts
+++ b/src/features/audio-generation/api/audio-generation-api.ts
@@ -25,6 +25,10 @@ function appendIfPresent(formData: FormData, key: string, value: unknown) {
   }
   if (typeof value === "number" && Number.isFinite(value)) {
     formData.append(key, String(value));
+    return;
+  }
+  if (typeof value === "boolean") {
+    formData.append(key, String(value));
   }
 }
 
@@ -32,13 +36,9 @@ export async function requestAudioGeneration(
   payload: AudioGenerationFormValues,
 ): Promise<AudioGenerationResponse> {
   const formData = new FormData();
-  appendIfPresent(formData, "prompt", payload.prompt);
-  appendIfPresent(formData, "model", payload.model);
-  appendIfPresent(formData, "voice", payload.voice);
-  appendIfPresent(formData, "speed", payload.speed);
-  appendIfPresent(formData, "seed", payload.seed);
-  appendIfPresent(formData, "inputAudio", payload.inputAudio);
-  appendIfPresent(formData, "referenceText", payload.referenceText);
+  Object.entries(payload).forEach(([key, value]) => {
+    appendIfPresent(formData, key, value);
+  });
 
   return requestJson("/api/audio-generation", {
     method: "POST",

--- a/src/features/audio-generation/api/audio-generation-api.ts
+++ b/src/features/audio-generation/api/audio-generation-api.ts
@@ -16,15 +16,33 @@ async function requestJson(input: RequestInfo, init?: RequestInit) {
   return result;
 }
 
+function appendIfPresent(formData: FormData, key: string, value: unknown) {
+  if (value === undefined || value === null) return;
+  if (typeof value === "string") {
+    if (!value.length) return;
+    formData.append(key, value);
+    return;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    formData.append(key, String(value));
+  }
+}
+
 export async function requestAudioGeneration(
   payload: AudioGenerationFormValues,
 ): Promise<AudioGenerationResponse> {
+  const formData = new FormData();
+  appendIfPresent(formData, "prompt", payload.prompt);
+  appendIfPresent(formData, "model", payload.model);
+  appendIfPresent(formData, "voice", payload.voice);
+  appendIfPresent(formData, "speed", payload.speed);
+  appendIfPresent(formData, "seed", payload.seed);
+  appendIfPresent(formData, "inputAudio", payload.inputAudio);
+  appendIfPresent(formData, "referenceText", payload.referenceText);
+
   return requestJson("/api/audio-generation", {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(payload),
+    body: formData,
   });
 }
 

--- a/src/features/audio-generation/api/audio-generation-api.ts
+++ b/src/features/audio-generation/api/audio-generation-api.ts
@@ -1,0 +1,38 @@
+import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
+import type { AudioGenerationResponse } from "@/features/audio-generation/model/audio-generation-types";
+
+async function requestJson(input: RequestInfo, init?: RequestInit) {
+  const response = await fetch(input, init);
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    const message = payload?.message ?? "REQUEST_FAILED";
+    const error = new Error(message);
+    (error as Error & { code?: string }).code = payload?.message;
+    throw error;
+  }
+  const result = await response.json().catch(() => {
+    throw new Error("응답 파싱에 실패했습니다.");
+  });
+  return result;
+}
+
+export async function requestAudioGeneration(
+  payload: AudioGenerationFormValues,
+): Promise<AudioGenerationResponse> {
+  return requestJson("/api/audio-generation", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function fetchAudioGenerationStatus(
+  requestId: string,
+): Promise<AudioGenerationResponse> {
+  return requestJson(`/api/audio-generation/${requestId}`, {
+    method: "GET",
+    cache: "no-store",
+  });
+}

--- a/src/features/audio-generation/hook/use-audio-generation.ts
+++ b/src/features/audio-generation/hook/use-audio-generation.ts
@@ -1,0 +1,75 @@
+import { useCallback } from "react";
+import { useTranslations } from "next-intl";
+import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
+import type {
+  AudioGenerationResponse,
+  AudioGenerationStatus,
+} from "@/features/audio-generation/model/audio-generation-types";
+import {
+  fetchAudioGenerationStatus,
+  requestAudioGeneration,
+} from "@/features/audio-generation/api/audio-generation-api";
+import {
+  type GenerationPollingState,
+  useGenerationPolling,
+} from "@/shared/lib/hooks/use-generation-polling";
+
+const POLL_INTERVAL_MS = 1200;
+const DEFAULT_TIMEOUT_MS = 300_000;
+const EXTRA_TIMEOUT_MS = 30_000;
+const configuredTimeoutMs = Number(
+  process.env.NEXT_PUBLIC_AUDIO_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS,
+);
+const pollTimeoutMs =
+  (Number.isFinite(configuredTimeoutMs) && configuredTimeoutMs > 0
+    ? configuredTimeoutMs
+    : DEFAULT_TIMEOUT_MS) + EXTRA_TIMEOUT_MS;
+
+const terminalStatuses = ["completed", "failed"] as const;
+
+export type AudioGenerationState = GenerationPollingState<
+  AudioGenerationStatus,
+  AudioGenerationResponse["result"]
+>;
+
+export function useAudioGeneration() {
+  const tErrors = useTranslations("generation.errors");
+  const request = useCallback(
+    async (values: AudioGenerationFormValues) => {
+      try {
+        return await requestAudioGeneration(values);
+      } catch {
+        throw new Error(tErrors("requestFailed"));
+      }
+    },
+    [tErrors],
+  );
+  const poll = useCallback(
+    async (requestId: string) => {
+      try {
+        return await fetchAudioGenerationStatus(requestId);
+      } catch {
+        throw new Error(tErrors("pollFailed"));
+      }
+    },
+    [tErrors],
+  );
+
+  return useGenerationPolling<
+    AudioGenerationFormValues,
+    AudioGenerationStatus,
+    AudioGenerationResponse["result"]
+  >({
+    request,
+    poll,
+    pollIntervalMs: POLL_INTERVAL_MS,
+    timeoutMs: pollTimeoutMs,
+    startStatus: "pending",
+    errorStatus: "failed",
+    timeoutStatus: "failed",
+    terminalStatuses,
+    requestErrorMessage: tErrors("requestFailed"),
+    pollErrorMessage: tErrors("pollFailed"),
+    timeoutMessage: tErrors("timeout"),
+  });
+}

--- a/src/features/audio-generation/model/audio-generation-schema.test.ts
+++ b/src/features/audio-generation/model/audio-generation-schema.test.ts
@@ -1,0 +1,45 @@
+import { createAudioGenerationSchema } from "@/features/audio-generation/model/audio-generation-schema";
+
+describe("audio-generation-schema", () => {
+  it("공백만 있는 prompt는 허용하지 않는다", () => {
+    const schema = createAudioGenerationSchema();
+
+    const result = schema.safeParse({
+      prompt: "   ",
+      model: "audio-model",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(["prompt"]);
+  });
+
+  it("기본 schema는 speed 범위를 강제하지 않는다", () => {
+    const schema = createAudioGenerationSchema();
+
+    const result = schema.safeParse({
+      prompt: "hello",
+      model: "audio-model",
+      speed: 9,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("speedRange가 주어지면 해당 범위를 검증한다", () => {
+    const schema = createAudioGenerationSchema(undefined, {
+      speedRange: {
+        min: 0.5,
+        max: 2,
+      },
+    });
+
+    const result = schema.safeParse({
+      prompt: "hello",
+      model: "audio-model",
+      speed: 2.5,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(["speed"]);
+  });
+});

--- a/src/features/audio-generation/model/audio-generation-schema.ts
+++ b/src/features/audio-generation/model/audio-generation-schema.ts
@@ -11,6 +11,8 @@ const audioGenerationBaseSchema = z.object({
   voice: z.string().optional().or(z.literal("")),
   speed: z.number().optional(),
   seed: z.string().optional().or(z.literal("")),
+  inputAudio: z.string().optional().or(z.literal("")),
+  referenceText: z.string().optional().or(z.literal("")),
 });
 
 export const audioGenerationOpenApiSchema = audioGenerationBaseSchema;
@@ -50,4 +52,6 @@ export const audioGenerationDefaults: AudioGenerationFormValues = {
   voice: "",
   speed: 1,
   seed: "",
+  inputAudio: "",
+  referenceText: "",
 };

--- a/src/features/audio-generation/model/audio-generation-schema.ts
+++ b/src/features/audio-generation/model/audio-generation-schema.ts
@@ -13,6 +13,18 @@ const audioGenerationBaseSchema = z.object({
   seed: z.string().optional().or(z.literal("")),
   inputAudio: z.string().optional().or(z.literal("")),
   referenceText: z.string().optional().or(z.literal("")),
+  modeChoice: z.string().optional().or(z.literal("")),
+  language: z.string().optional().or(z.literal("")),
+  speaker: z.string().optional().or(z.literal("")),
+  streamMode: z.boolean().optional(),
+  referencePreset: z.string().optional().or(z.literal("")),
+  customInstruction: z.string().optional().or(z.literal("")),
+  voiceInstruction: z.string().optional().or(z.literal("")),
+  xvecOnly: z.boolean().optional(),
+  chunkSize: z.number().optional(),
+  temperature: z.number().optional(),
+  topK: z.number().optional(),
+  repetitionPenalty: z.number().optional(),
 });
 
 export const audioGenerationOpenApiSchema = audioGenerationBaseSchema;
@@ -54,4 +66,12 @@ export const audioGenerationDefaults: AudioGenerationFormValues = {
   seed: "",
   inputAudio: "",
   referenceText: "",
+  modeChoice: "",
+  language: "",
+  speaker: "",
+  streamMode: false,
+  referencePreset: "",
+  customInstruction: "",
+  voiceInstruction: "",
+  xvecOnly: false,
 };

--- a/src/features/audio-generation/model/audio-generation-schema.ts
+++ b/src/features/audio-generation/model/audio-generation-schema.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+type TranslationFn = (
+  key: string,
+  values?: Record<string, string | number | Date>,
+) => string;
+
+const audioGenerationBaseSchema = z.object({
+  prompt: z.string().min(1, "프롬프트를 입력해주세요."),
+  model: z.string().min(1),
+  voice: z.string().optional().or(z.literal("")),
+  speed: z.number().optional(),
+  seed: z.string().optional().or(z.literal("")),
+});
+
+export const audioGenerationOpenApiSchema = audioGenerationBaseSchema;
+
+export const createAudioGenerationSchema = (t?: TranslationFn) => {
+  const promptRequired = t ? t("promptRequired") : "프롬프트를 입력해주세요.";
+  const speedLabel = t ? t("labels.speed") : "속도";
+  const rangeMessage = (label: string, min: number, max: number) =>
+    t
+      ? t("range", { label, min, max })
+      : `${label}는 ${min}~${max} 범위여야 합니다.`;
+
+  return audioGenerationBaseSchema
+    .extend({
+      prompt: z.string().min(1, promptRequired),
+    })
+    .superRefine((data, ctx) => {
+      if (typeof data.speed === "number") {
+        if (!Number.isFinite(data.speed) || data.speed < 0.25 || data.speed > 4) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["speed"],
+            message: rangeMessage(speedLabel, 0.25, 4),
+          });
+        }
+      }
+    });
+};
+
+export const audioGenerationSchema = createAudioGenerationSchema();
+
+export type AudioGenerationFormValues = z.infer<typeof audioGenerationSchema>;
+
+export const audioGenerationDefaults: AudioGenerationFormValues = {
+  prompt: "",
+  model: "",
+  voice: "",
+  speed: 1,
+  seed: "",
+};

--- a/src/features/audio-generation/model/audio-generation-schema.ts
+++ b/src/features/audio-generation/model/audio-generation-schema.ts
@@ -74,4 +74,8 @@ export const audioGenerationDefaults: AudioGenerationFormValues = {
   customInstruction: "",
   voiceInstruction: "",
   xvecOnly: false,
+  chunkSize: undefined,
+  temperature: undefined,
+  topK: undefined,
+  repetitionPenalty: undefined,
 };

--- a/src/features/audio-generation/model/audio-generation-schema.ts
+++ b/src/features/audio-generation/model/audio-generation-schema.ts
@@ -6,7 +6,7 @@ type TranslationFn = (
 ) => string;
 
 const audioGenerationBaseSchema = z.object({
-  prompt: z.string().min(1, "프롬프트를 입력해주세요."),
+  prompt: z.string().trim().min(1, "프롬프트를 입력해주세요."),
   model: z.string().min(1),
   voice: z.string().optional().or(z.literal("")),
   speed: z.number().optional(),
@@ -29,7 +29,17 @@ const audioGenerationBaseSchema = z.object({
 
 export const audioGenerationOpenApiSchema = audioGenerationBaseSchema;
 
-export const createAudioGenerationSchema = (t?: TranslationFn) => {
+type AudioGenerationSchemaOptions = {
+  speedRange?: {
+    min: number;
+    max: number;
+  };
+};
+
+export const createAudioGenerationSchema = (
+  t?: TranslationFn,
+  options?: AudioGenerationSchemaOptions,
+) => {
   const promptRequired = t ? t("promptRequired") : "프롬프트를 입력해주세요.";
   const speedLabel = t ? t("labels.speed") : "속도";
   const rangeMessage = (label: string, min: number, max: number) =>
@@ -39,15 +49,23 @@ export const createAudioGenerationSchema = (t?: TranslationFn) => {
 
   return audioGenerationBaseSchema
     .extend({
-      prompt: z.string().min(1, promptRequired),
+      prompt: z.string().trim().min(1, promptRequired),
     })
     .superRefine((data, ctx) => {
-      if (typeof data.speed === "number") {
-        if (!Number.isFinite(data.speed) || data.speed < 0.25 || data.speed > 4) {
+      if (typeof data.speed === "number" && options?.speedRange) {
+        if (
+          !Number.isFinite(data.speed) ||
+          data.speed < options.speedRange.min ||
+          data.speed > options.speedRange.max
+        ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: ["speed"],
-            message: rangeMessage(speedLabel, 0.25, 4),
+            message: rangeMessage(
+              speedLabel,
+              options.speedRange.min,
+              options.speedRange.max,
+            ),
           });
         }
       }

--- a/src/features/audio-generation/model/audio-generation-types.ts
+++ b/src/features/audio-generation/model/audio-generation-types.ts
@@ -1,0 +1,20 @@
+export type AudioGenerationStatus =
+  | "pending"
+  | "processing"
+  | "completed"
+  | "failed";
+
+export interface AudioGenerationResult {
+  audios: Array<{
+    url: string;
+    durationSec?: number;
+  }>;
+}
+
+export interface AudioGenerationResponse {
+  requestId: string;
+  status: AudioGenerationStatus;
+  progress: number;
+  result?: AudioGenerationResult;
+  errorMessage?: string;
+}

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -49,6 +49,101 @@ const runtimeAudioModelsFixture: RuntimeAudioModel[] = [
   },
 ];
 
+const qwenModeModelFixture: RuntimeAudioModel = {
+  type: "audio",
+  key: "qwen-tts-mode",
+  label: "Qwen 3.5 TTS Mode",
+  vendor: "HF Space",
+  provider: "huggingface-space",
+  providerConfig: {},
+  parameters: {
+    prompt: { ui: "textarea", required: true },
+    modeChoice: {
+      ui: "select",
+      label: "Generation Mode",
+      options: [
+        { label: "Voice Clone", value: "voice_clone" },
+        { label: "Custom Speaker", value: "custom" },
+        { label: "Voice Design", value: "voice_design" },
+      ],
+      default: "voice_clone",
+    },
+    language: {
+      ui: "select",
+      label: "Language",
+      options: [
+        { label: "English", value: "English" },
+        { label: "Korean", value: "Korean" },
+      ],
+      default: "English",
+    },
+    speaker: {
+      ui: "select",
+      label: "Speaker",
+      options: [
+        { label: "Vivian - Chinese - Bright young female", value: "Vivian" },
+        { label: "Serena - Chinese - Warm gentle female", value: "Serena" },
+      ],
+      default: "Vivian",
+    },
+    streamMode: {
+      ui: "toggle",
+      label: "Streaming",
+      default: true,
+    },
+    inputAudio: {
+      ui: "upload",
+      label: "Reference Audio",
+      required: true,
+    },
+    referenceText: {
+      ui: "textarea",
+      label: "Reference Transcript",
+      required: true,
+    },
+    customInstruction: {
+      ui: "textarea",
+      label: "Custom Instruction",
+    },
+    voiceInstruction: {
+      ui: "textarea",
+      label: "Voice Instruction",
+    },
+    temperature: {
+      ui: "range",
+      label: "Temperature",
+      min: 0.1,
+      max: 1.2,
+      step: 0.1,
+      default: 0.7,
+    },
+    topK: {
+      ui: "range",
+      label: "Top K",
+      min: 1,
+      max: 100,
+      step: 1,
+      default: 20,
+    },
+    repetitionPenalty: {
+      ui: "range",
+      label: "Repetition Penalty",
+      min: 1,
+      max: 2,
+      step: 0.1,
+      default: 1.1,
+    },
+    seed: {
+      ui: "text",
+    },
+  },
+  meta: {
+    supports_input_audio: true,
+  },
+  isActive: true,
+  isDefault: true,
+};
+
 async function waitForModels() {
   await screen.findByRole("button", { name: /Qwen 3\.5 TTS/i });
 }
@@ -287,5 +382,83 @@ describe("AudioGenerationForm", () => {
     });
 
     expect(container.querySelector("audio")).not.toBeNull();
+  });
+
+  it("mode 기반 TTS 모델이면 speaker/language/advanced 필드를 렌더링하고 기본값을 제출한다", async () => {
+    const startGeneration = vi.fn();
+    mockUseAudioGeneration.mockReturnValue({
+      state: { status: "idle", progress: 0 },
+      startGeneration,
+      reset: vi.fn(),
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ items: [qwenModeModelFixture] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const fileReaderResult = "data:audio/wav;base64,UklGRg==";
+    class MockFileReader {
+      result: string | ArrayBuffer | null = null;
+      onload: null | (() => void) = null;
+      readAsDataURL() {
+        this.result = fileReaderResult;
+        this.onload?.();
+      }
+    }
+    vi.stubGlobal("FileReader", MockFileReader as unknown as typeof FileReader);
+
+    const user = userEvent.setup();
+    renderWithIntl(<AudioGenerationForm isAuthenticated />);
+    await screen.findByRole("button", { name: /Qwen 3\.5 TTS Mode/i });
+
+    expect(screen.getAllByText("Generation Mode").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Language").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Speaker").length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("combobox", { name: "Speaker" }),
+    ).toHaveTextContent("Vivian - Chinese - Bright young female");
+    expect(screen.getByText("Temperature")).not.toBeNull();
+    expect(screen.getByText("Top K")).not.toBeNull();
+    expect(screen.getByText("Repetition Penalty")).not.toBeNull();
+
+    await user.type(
+      screen.getByPlaceholderText("생성할 음성 내용을 자연스럽게 입력하세요..."),
+      "hello qwen",
+    );
+    await user.upload(
+      screen.getByLabelText("Reference Audio"),
+      new File([Uint8Array.from([82, 73, 70, 70])], "ref.wav", {
+        type: "audio/wav",
+      }),
+    );
+    await user.type(
+      screen.getByPlaceholderText("레퍼런스 오디오의 텍스트를 입력하세요..."),
+      "reference transcript",
+    );
+    await user.click(screen.getByRole("button", { name: "생성" }));
+
+    await waitFor(() => {
+      expect(startGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: "hello qwen",
+          voice: "",
+          modeChoice: "voice_clone",
+          language: "English",
+          speaker: "Vivian",
+          streamMode: true,
+          temperature: 0.7,
+          topK: 20,
+          repetitionPenalty: 1.1,
+          inputAudio: fileReaderResult,
+          referenceText: "reference transcript",
+        }),
+      );
+    });
   });
 });

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { AudioGenerationForm } from "@/features/audio-generation/ui/audio-generation-form";
@@ -210,5 +210,82 @@ describe("AudioGenerationForm", () => {
     await user.click(screen.getByRole("button", { name: /Bark TTS/i }));
 
     expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("reference 입력을 지원하는 모델이면 오디오 업로드와 reference text를 함께 제출한다", async () => {
+    const startGeneration = vi.fn();
+    mockUseAudioGeneration.mockReturnValue({
+      state: { status: "idle", progress: 0 },
+      startGeneration,
+      reset: vi.fn(),
+    });
+
+    const cloneModel: RuntimeAudioModel = {
+      ...runtimeAudioModelsFixture[0],
+      key: "qwen-tts-clone",
+      label: "Qwen TTS Clone",
+      parameters: {
+        ...runtimeAudioModelsFixture[0].parameters,
+        inputAudio: { ui: "upload", required: true },
+        referenceText: { ui: "textarea", required: true },
+      },
+      meta: {
+        supports_input_audio: true,
+      },
+      isDefault: true,
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ items: [cloneModel] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const fileReaderResult = "data:audio/wav;base64,UklGRg==";
+    class MockFileReader {
+      result: string | ArrayBuffer | null = null;
+      onload: null | (() => void) = null;
+      readAsDataURL() {
+        this.result = fileReaderResult;
+        this.onload?.();
+      }
+    }
+    vi.stubGlobal("FileReader", MockFileReader as unknown as typeof FileReader);
+
+    const user = userEvent.setup();
+    const { container } = renderWithIntl(<AudioGenerationForm isAuthenticated />);
+    await screen.findByRole("button", { name: /Qwen TTS Clone/i });
+
+    await user.type(
+      screen.getByPlaceholderText("생성할 음성 내용을 자연스럽게 입력하세요..."),
+      "hello clone",
+    );
+    await user.upload(
+      screen.getByLabelText("Reference Audio"),
+      new File([Uint8Array.from([82, 73, 70, 70])], "ref.wav", {
+        type: "audio/wav",
+      }),
+    );
+    await user.type(
+      screen.getByPlaceholderText("레퍼런스 오디오의 텍스트를 입력하세요..."),
+      "reference words",
+    );
+    await user.click(screen.getByRole("button", { name: "생성" }));
+
+    await waitFor(() => {
+      expect(startGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: "hello clone",
+          inputAudio: fileReaderResult,
+          referenceText: "reference words",
+        }),
+      );
+    });
+
+    expect(container.querySelector("audio")).not.toBeNull();
   });
 });

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -1,0 +1,214 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { AudioGenerationForm } from "@/features/audio-generation/ui/audio-generation-form";
+import { renderWithIntl } from "@/test-utils/intl";
+import type { RuntimeAudioModel } from "@/shared/model-catalog/runtime-utils";
+
+const navigationMocks = vi.hoisted(() => ({
+  searchParams: new URLSearchParams(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => navigationMocks.searchParams,
+}));
+
+const mockUseAudioGeneration = vi.hoisted(() => vi.fn());
+
+vi.mock("@/features/audio-generation/hook/use-audio-generation", () => ({
+  useAudioGeneration: mockUseAudioGeneration,
+}));
+
+const runtimeAudioModelsFixture: RuntimeAudioModel[] = [
+  {
+    type: "audio",
+    key: "qwen-tts",
+    label: "Qwen 3.5 TTS",
+    vendor: "HF Space",
+    provider: "huggingface-space",
+    providerConfig: {},
+    parameters: {
+      voice: {
+        default: "alloy",
+      },
+      speed: {
+        min: 0.25,
+        max: 4,
+        step: 0.05,
+        default: 1,
+      },
+      seed: {
+        ui: "text",
+      },
+    },
+    meta: {
+      supports_input_audio: false,
+    },
+    isActive: true,
+    isDefault: true,
+  },
+];
+
+async function waitForModels() {
+  await screen.findByRole("button", { name: /Qwen 3\.5 TTS/i });
+}
+
+describe("AudioGenerationForm", () => {
+  beforeEach(() => {
+    navigationMocks.searchParams = new URLSearchParams();
+    mockUseAudioGeneration.mockReset();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ items: runtimeAudioModelsFixture }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("쿼리 파라미터로 prompt/model을 초기화한다", async () => {
+    mockUseAudioGeneration.mockReturnValue({
+      state: { status: "idle", progress: 0 },
+      startGeneration: vi.fn(),
+      reset: vi.fn(),
+    });
+
+    navigationMocks.searchParams = new URLSearchParams();
+    navigationMocks.searchParams.set("prompt", "say hello");
+    navigationMocks.searchParams.set("model", "qwen-tts");
+
+    renderWithIntl(<AudioGenerationForm isAuthenticated />);
+    await waitForModels();
+
+    expect(screen.getByDisplayValue("say hello")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: /Qwen 3\.5 TTS/i }),
+    ).not.toBeNull();
+  });
+
+  it("완료된 결과 오디오 플레이어와 액션을 표시한다", async () => {
+    mockUseAudioGeneration.mockReturnValue({
+      state: {
+        status: "completed",
+        progress: 100,
+        requestId: "request-id",
+        result: {
+          audios: [
+            {
+              url: "https://example.com/generated.mp3",
+              durationSec: 7,
+            },
+          ],
+        },
+      },
+      startGeneration: vi.fn(),
+      reset: vi.fn(),
+    });
+
+    const { container } = renderWithIntl(
+      <AudioGenerationForm isAuthenticated />,
+    );
+    await waitForModels();
+
+    expect(container.querySelector("audio")).not.toBeNull();
+    expect(screen.getByText(/#1/i)).not.toBeNull();
+    expect(
+      container.querySelector('a[href="https://example.com/generated.mp3"]'),
+    ).not.toBeNull();
+  });
+
+  it("비로그인 상태에서 로그인 게이트를 표시한다", async () => {
+    mockUseAudioGeneration.mockReturnValue({
+      state: { status: "idle", progress: 0 },
+      startGeneration: vi.fn(),
+      reset: vi.fn(),
+    });
+
+    const user = userEvent.setup();
+
+    renderWithIntl(<AudioGenerationForm isAuthenticated={false} />);
+
+    expect(
+      await screen.findByText("로그인하여 모델 목록을 확인하세요."),
+    ).not.toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "생성" }));
+
+    expect(await screen.findByText("로그인이 필요합니다")).not.toBeNull();
+  });
+
+  it("정상 입력이면 생성 요청을 시작한다", async () => {
+    const startGeneration = vi.fn();
+    mockUseAudioGeneration.mockReturnValue({
+      state: { status: "idle", progress: 0 },
+      startGeneration,
+      reset: vi.fn(),
+    });
+
+    const user = userEvent.setup();
+    renderWithIntl(<AudioGenerationForm isAuthenticated />);
+    await waitForModels();
+
+    await user.type(
+      screen.getByPlaceholderText("생성할 음성 내용을 자연스럽게 입력하세요..."),
+      "hello audio",
+    );
+    await user.click(screen.getByRole("button", { name: "생성" }));
+
+    expect(startGeneration).toHaveBeenCalledTimes(1);
+    expect(startGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "hello audio",
+        model: "qwen-tts",
+        voice: "alloy",
+        speed: 1,
+      }),
+    );
+  });
+
+  it("모델 전환 시 생성 폴링을 리셋한다", async () => {
+    const reset = vi.fn();
+    mockUseAudioGeneration.mockReturnValue({
+      state: {
+        status: "processing",
+        progress: 0,
+        requestId: "request-id",
+      },
+      startGeneration: vi.fn(),
+      reset,
+    });
+
+    const secondModel: RuntimeAudioModel = {
+      ...runtimeAudioModelsFixture[0],
+      key: "bark-tts",
+      label: "Bark TTS",
+      isDefault: false,
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({ items: [...runtimeAudioModelsFixture, secondModel] }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderWithIntl(<AudioGenerationForm isAuthenticated />);
+    await waitForModels();
+
+    await user.click(screen.getByRole("button", { name: /Bark TTS/i }));
+
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -1,0 +1,518 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  AudioLines,
+  Download,
+  ExternalLink,
+  Grid2x2,
+  Maximize2,
+  Sparkles,
+} from "lucide-react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
+import { useSearchParams } from "next/navigation";
+import { useForm, useWatch, type Resolver } from "react-hook-form";
+import {
+  audioGenerationDefaults,
+  createAudioGenerationSchema,
+  type AudioGenerationFormValues,
+} from "@/features/audio-generation/model/audio-generation-schema";
+import { useAudioGeneration } from "@/features/audio-generation/hook/use-audio-generation";
+import { Button } from "@/shared/ui/button";
+import { GenerationCanvas } from "@/shared/ui/generation-canvas";
+import { GenerationModelSection } from "@/shared/ui/generation-model-section";
+import { GenerationPromptField } from "@/shared/ui/generation-prompt-field";
+import { GenerationSettingsPanel } from "@/shared/ui/generation-settings-panel";
+import { LoginGateDialog } from "@/features/auth/ui/login-gate-dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/shared/ui/form";
+import { Input } from "@/shared/ui/input";
+import { Textarea } from "@/shared/ui/textarea";
+import { useTranslations } from "next-intl";
+import { useRuntimeModelCatalog } from "@/shared/lib/hooks/use-runtime-model-catalog";
+import {
+  getRuntimeAudioParamConfig,
+  getRuntimeAudioParamRange,
+  resolveRuntimeAudioDefaults,
+  resolveRuntimeDefaultModelKey,
+} from "@/shared/model-catalog/runtime-utils";
+import { createRuntimeAudioSchema } from "@/shared/model-catalog/runtime-schema";
+import { resolveAudioModalities } from "@/shared/model-catalog/modality";
+
+type AudioGenerationFormProps = {
+  isAuthenticated: boolean;
+};
+
+export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProps) {
+  const searchParams = useSearchParams();
+  const tGeneration = useTranslations("generation");
+  const tAudio = useTranslations("generation.audio");
+  const tActions = useTranslations("common.actions");
+  const tLabels = useTranslations("common.labels");
+  const tGenerationActions = useTranslations("generation.actions");
+  const tValidation = useTranslations("generation.validation.audio");
+  const tLoginGate = useTranslations("auth.loginGate");
+
+  const isGuest = !isAuthenticated;
+  const { audioModels: runtimeAudioModels, isLoading: isModelLoading } =
+    useRuntimeModelCatalog({ enabled: !isGuest });
+  const resolvedAudioModels = runtimeAudioModels;
+  const hasModels = resolvedAudioModels.length > 0;
+  const defaultModelKey = resolveRuntimeDefaultModelKey(resolvedAudioModels) ?? "";
+  const runtimeModelMap = useMemo(
+    () => new Map(resolvedAudioModels.map((model) => [model.key, model])),
+    [resolvedAudioModels],
+  );
+  const modelCards = useMemo(
+    () =>
+      resolvedAudioModels.map((model) => ({
+        id: model.key,
+        name: model.label,
+        vendor: model.vendor,
+        modalities: resolveAudioModalities(model.meta),
+      })),
+    [resolvedAudioModels],
+  );
+
+  const staticSchema = useMemo(
+    () => createAudioGenerationSchema(tValidation),
+    [tValidation],
+  );
+  const runtimeSchema = useMemo(
+    () => createRuntimeAudioSchema(resolvedAudioModels, tValidation),
+    [resolvedAudioModels, tValidation],
+  );
+  const resolverRef = useRef<Resolver<AudioGenerationFormValues>>(
+    zodResolver(staticSchema) as Resolver<AudioGenerationFormValues>,
+  );
+  useEffect(() => {
+    resolverRef.current = zodResolver(runtimeSchema) as Resolver<AudioGenerationFormValues>;
+  }, [runtimeSchema]);
+  const resolver = useMemo<Resolver<AudioGenerationFormValues>>(
+    () => (values, context, options) =>
+      resolverRef.current(values, context, options),
+    [],
+  );
+
+  const form = useForm<AudioGenerationFormValues>({
+    resolver,
+    defaultValues: audioGenerationDefaults,
+    mode: "onChange",
+  });
+  const [isLoginGateOpen, setIsLoginGateOpen] = useState(false);
+
+  const promptFromQuery = searchParams?.get("prompt") ?? "";
+  const modelFromQuery = searchParams?.get("model") ?? "";
+  useEffect(() => {
+    const trimmed = promptFromQuery.trim();
+    if (!trimmed) return;
+    if (form.getValues("prompt") === trimmed) return;
+    form.setValue("prompt", trimmed, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+  }, [promptFromQuery, form]);
+
+  useEffect(() => {
+    const trimmed = modelFromQuery.trim();
+    if (!trimmed) return;
+    if (!hasModels) return;
+    if (!runtimeModelMap.has(trimmed)) return;
+    if (form.getValues("model") === trimmed) return;
+    form.setValue("model", trimmed, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+  }, [form, hasModels, modelFromQuery, runtimeModelMap]);
+
+  const promptValue = useWatch({ control: form.control, name: "prompt" }) ?? "";
+  const speed =
+    useWatch({ control: form.control, name: "speed" }) ??
+    audioGenerationDefaults.speed;
+  const voice = useWatch({ control: form.control, name: "voice" }) ?? "";
+  const watchedModel =
+    useWatch({ control: form.control, name: "model" }) ??
+    audioGenerationDefaults.model;
+
+  const activeModel = hasModels
+    ? runtimeModelMap.has(watchedModel)
+      ? watchedModel
+      : defaultModelKey
+    : "";
+  const activeRuntimeModel = runtimeModelMap.get(activeModel);
+
+  const speedRange = getRuntimeAudioParamRange(activeRuntimeModel, "speed");
+  const speedConfig = getRuntimeAudioParamConfig(activeRuntimeModel, "speed");
+  const voiceConfig = getRuntimeAudioParamConfig(activeRuntimeModel, "voice");
+  const seedConfig = getRuntimeAudioParamConfig(activeRuntimeModel, "seed");
+  const showSpeed = speedConfig?.ui !== "hidden";
+  const showVoice = voiceConfig?.ui !== "hidden";
+  const showSeed = seedConfig?.ui !== "hidden";
+
+  const canSubmit = hasModels && promptValue.trim().length > 0;
+
+  useEffect(() => {
+    if (!hasModels || !defaultModelKey) return;
+    const currentModel = form.getValues("model");
+    if (runtimeModelMap.has(currentModel)) return;
+    form.setValue("model", defaultModelKey, { shouldValidate: true });
+  }, [defaultModelKey, form, hasModels, runtimeModelMap]);
+
+  useEffect(() => {
+    const model = runtimeModelMap.get(activeModel);
+    if (!model) return;
+    const defaults = resolveRuntimeAudioDefaults(model);
+    form.setValue("voice", defaults.voice);
+    form.setValue("speed", defaults.speed);
+
+    if (!showSeed) {
+      form.setValue("seed", "");
+    }
+  }, [activeModel, form, runtimeModelMap, showSeed]);
+
+  const resetModelKey = defaultModelKey || audioGenerationDefaults.model;
+  const resetDefaults = useMemo<AudioGenerationFormValues>(() => {
+    const model = runtimeModelMap.get(resetModelKey);
+    if (!model) return { ...audioGenerationDefaults, model: resetModelKey };
+    const defaults = resolveRuntimeAudioDefaults(model);
+    return {
+      ...audioGenerationDefaults,
+      model: resetModelKey,
+      voice: defaults.voice,
+      speed: defaults.speed,
+    };
+  }, [resetModelKey, runtimeModelMap]);
+
+  const { state, startGeneration, reset } = useAudioGeneration();
+  const isGenerating =
+    state.status === "pending" || state.status === "processing";
+  const resultAudios = state.result?.audios ?? [];
+  const hasResults = state.status === "completed" && resultAudios.length > 0;
+  const primaryAudio = resultAudios[0];
+
+  const handleSelectModel = (modelId: string) => {
+    if (modelId === activeModel) return;
+    if (isGenerating) {
+      reset();
+    }
+    form.setValue("model", modelId, { shouldValidate: true });
+  };
+
+  const handleReset = () => {
+    form.reset(resetDefaults);
+    reset();
+  };
+
+  const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    if (!isAuthenticated) {
+      event.preventDefault();
+      setIsLoginGateOpen(true);
+      return;
+    }
+    if (isModelLoading || !hasModels) {
+      event.preventDefault();
+      return;
+    }
+
+    void form.handleSubmit((values) => startGeneration(values))(event);
+  };
+
+  return (
+    <Form {...form}>
+      <form className="flex flex-col gap-8" onSubmit={handleFormSubmit}>
+        {!isGuest && (
+          <GenerationModelSection
+            items={modelCards}
+            activeId={activeModel}
+            onSelect={handleSelectModel}
+            action={
+              <Button
+                type="button"
+                variant="link"
+                disabled
+                aria-disabled="true"
+                className="h-auto p-0 text-xs font-bold uppercase text-primary hover:underline"
+                title={tActions("comingSoon")}
+              >
+                {tActions("viewAllModels")}
+              </Button>
+            }
+          />
+        )}
+        {isGuest && (
+          <div className="rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-sm text-gray-300">
+            {tGeneration("modelLoginRequired")}
+          </div>
+        )}
+        {!isGuest && isModelLoading && (
+          <div className="rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-sm text-gray-300">
+            {tGeneration("modelLoading")}
+          </div>
+        )}
+        {!isGuest && !isModelLoading && !hasModels && (
+          <div className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-4 py-3 text-sm text-amber-200">
+            {tGeneration("noModels")}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-8 xl:flex-row">
+          <div className="flex flex-1 flex-col gap-6">
+            <GenerationCanvas
+              actions={
+                <>
+                  <Button
+                    type="button"
+                    disabled
+                    aria-disabled="true"
+                    variant="surface"
+                    size="icon"
+                    className="border-white/10 bg-surface-dark/80 text-gray-400 hover:border-white/30 hover:text-white"
+                    title={tGenerationActions("gridDisabled")}
+                  >
+                    <Grid2x2 className="h-5 w-5" />
+                  </Button>
+                  <Button
+                    type="button"
+                    disabled
+                    aria-disabled="true"
+                    variant="surface"
+                    size="icon"
+                    className="border-white/10 bg-surface-dark/80 text-gray-400 hover:border-white/30 hover:text-white"
+                    title={tGenerationActions("fullScreenDisabled")}
+                  >
+                    <Maximize2 className="h-5 w-5" />
+                  </Button>
+                </>
+              }
+              isGenerating={isGenerating}
+              status={state.status}
+              errorMessage={state.errorMessage}
+            >
+              {hasResults && primaryAudio ? (
+                <div className="z-10 flex w-full max-w-3xl flex-col gap-3 px-6">
+                  <audio
+                    src={primaryAudio.url}
+                    controls
+                    className="w-full rounded-lg border border-white/10 bg-black/60"
+                  />
+                </div>
+              ) : (
+                <div className="z-10 flex flex-col items-center px-6 text-center">
+                  <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full border border-white/10 bg-surface-dark shadow-[0_0_30px_rgba(212,240,50,0.05)]">
+                    <AudioLines className="h-8 w-8 text-gray-600" />
+                  </div>
+                  <h3 className="text-xl font-bold text-gray-300">
+                    {tGeneration("canvas.emptyTitle")}
+                  </h3>
+                  <p className="mt-1 text-sm font-mono text-gray-600">
+                    {tGeneration("canvas.emptyDescription")}
+                  </p>
+                </div>
+              )}
+            </GenerationCanvas>
+
+            {hasResults && state.errorMessage && (
+              <div className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs text-amber-200">
+                {state.errorMessage}
+              </div>
+            )}
+
+            {hasResults && resultAudios.length > 0 ? (
+              <div className="flex flex-col gap-2">
+                {resultAudios.map((audio, index) => (
+                  <div
+                    key={`${audio.url}-${index}`}
+                    className="flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-surface-dark/60 px-3 py-2"
+                  >
+                    <div className="text-xs font-mono uppercase tracking-widest text-gray-500">
+                      #{index + 1}
+                      {typeof audio.durationSec === "number"
+                        ? ` • ${audio.durationSec}s`
+                        : ""}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <a
+                        href={audio.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-surface-dark/80 text-gray-200 transition-colors hover:border-primary hover:text-white"
+                        title={tActions("open")}
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                      </a>
+                      <a
+                        href={audio.url}
+                        download
+                        className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-surface-dark/80 text-gray-200 transition-colors hover:border-primary hover:text-white"
+                        title={tActions("download")}
+                      >
+                        <Download className="h-4 w-4" />
+                      </a>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            <div className="flex flex-col gap-4 lg:flex-row">
+              <FormField
+                control={form.control}
+                name="prompt"
+                render={({ field }) => (
+                  <FormItem className="flex-1">
+                    <GenerationPromptField
+                      textarea={
+                        <FormControl>
+                          <Textarea
+                            placeholder={tAudio("promptPlaceholder")}
+                            className="min-h-[120px] border-none bg-transparent px-4 py-4 text-white placeholder:text-gray-600 focus-visible:ring-0"
+                            {...field}
+                          />
+                        </FormControl>
+                      }
+                      footerLeft={
+                        <span className="text-[10px] font-mono text-gray-600">
+                          {voice?.trim() ? `${tAudio("voiceLabel")}: ${voice}` : tAudio("voiceUnset")}
+                        </span>
+                      }
+                      footerRight={
+                        <span className="text-[10px] font-mono text-gray-600">
+                          {tLabels("chars", { count: promptValue.length })}
+                        </span>
+                      }
+                    />
+                    <FormMessage className="text-xs text-red-400" />
+                  </FormItem>
+                )}
+              />
+
+              <Button
+                type={isAuthenticated ? "submit" : "button"}
+                variant="hero"
+                size="hero"
+                disabled={
+                  isGenerating ||
+                  (isAuthenticated && (isModelLoading || !hasModels || !canSubmit))
+                }
+                className="flex-col"
+                onClick={
+                  isAuthenticated ? undefined : () => setIsLoginGateOpen(true)
+                }
+              >
+                <Sparkles className="h-7 w-7" />
+                {isGenerating ? tActions("generating") : tActions("generate")}
+              </Button>
+            </div>
+          </div>
+
+          <GenerationSettingsPanel onReset={handleReset}>
+            <div className="flex flex-col gap-8">
+              {showSpeed ? (
+                <FormField
+                  control={form.control}
+                  name="speed"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-col gap-3">
+                      <div className="flex items-center justify-between">
+                        <span className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                          {tAudio("speedLabel")}
+                        </span>
+                        <span className="rounded border border-white/10 bg-surface-lighter px-2 py-0.5 text-xs font-bold text-white font-mono">
+                          {field.value?.toFixed(2)}x
+                        </span>
+                      </div>
+                      <FormControl>
+                        <input
+                          type="range"
+                          min={speedRange.min}
+                          max={speedRange.max}
+                          step={speedRange.step}
+                          value={field.value ?? speed}
+                          onChange={(event) =>
+                            field.onChange(Number(event.target.value))
+                          }
+                          className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-surface-lighter"
+                        />
+                      </FormControl>
+                      <div className="flex justify-between px-1 text-[10px] font-mono text-gray-600">
+                        <span>{speedRange.min.toFixed(2)}x</span>
+                        <span>{speedRange.max.toFixed(2)}x</span>
+                      </div>
+                      <FormMessage className="text-xs text-red-400" />
+                    </FormItem>
+                  )}
+                />
+              ) : null}
+
+              {showVoice ? (
+                <FormField
+                  control={form.control}
+                  name="voice"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-col gap-2">
+                      <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                        {tAudio("voiceLabel")}
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          value={field.value ?? ""}
+                          placeholder={tAudio("voicePlaceholder")}
+                          className="h-11 rounded-xl border-white/10 bg-black/40 px-4 text-sm text-white"
+                        />
+                      </FormControl>
+                      <FormMessage className="text-xs text-red-400" />
+                    </FormItem>
+                  )}
+                />
+              ) : null}
+
+              {showSeed ? (
+                <FormField
+                  control={form.control}
+                  name="seed"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-col gap-2">
+                      <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                        {tLabels("seed")}
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          value={field.value ?? ""}
+                          placeholder={tAudio("seedPlaceholder")}
+                          className="h-11 rounded-xl border-white/10 bg-black/40 px-4 text-sm text-white"
+                        />
+                      </FormControl>
+                      <FormMessage className="text-xs text-red-400" />
+                    </FormItem>
+                  )}
+                />
+              ) : null}
+            </div>
+          </GenerationSettingsPanel>
+        </div>
+      </form>
+      <LoginGateDialog
+        open={isLoginGateOpen}
+        onOpenChange={setIsLoginGateOpen}
+        title={tLoginGate("title")}
+        description={tLoginGate("description")}
+        actionLabel={tLoginGate("action")}
+        cancelLabel={tLoginGate("cancel")}
+      />
+    </Form>
+  );
+}

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -14,6 +14,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ChangeEvent,
   type FormEvent,
 } from "react";
 import { useSearchParams } from "next/navigation";
@@ -46,6 +47,7 @@ import {
   getRuntimeAudioParamConfig,
   getRuntimeAudioParamRange,
   resolveRuntimeAudioDefaults,
+  resolveRuntimeAudioSupportsInputAudio,
   resolveRuntimeDefaultModelKey,
 } from "@/shared/model-catalog/runtime-utils";
 import { createRuntimeAudioSchema } from "@/shared/model-catalog/runtime-schema";
@@ -115,6 +117,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
 
   const promptFromQuery = searchParams?.get("prompt") ?? "";
   const modelFromQuery = searchParams?.get("model") ?? "";
+  const referenceTextFromQuery = searchParams?.get("referenceText") ?? "";
   useEffect(() => {
     const trimmed = promptFromQuery.trim();
     if (!trimmed) return;
@@ -137,11 +140,27 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
     });
   }, [form, hasModels, modelFromQuery, runtimeModelMap]);
 
+  useEffect(() => {
+    const trimmed = referenceTextFromQuery.trim();
+    if (!trimmed) return;
+    if (form.getValues("referenceText") === trimmed) return;
+    form.setValue("referenceText", trimmed, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+  }, [form, referenceTextFromQuery]);
+
   const promptValue = useWatch({ control: form.control, name: "prompt" }) ?? "";
   const speed =
     useWatch({ control: form.control, name: "speed" }) ??
     audioGenerationDefaults.speed;
   const voice = useWatch({ control: form.control, name: "voice" }) ?? "";
+  const inputAudio =
+    useWatch({ control: form.control, name: "inputAudio" }) ??
+    audioGenerationDefaults.inputAudio;
+  const referenceText =
+    useWatch({ control: form.control, name: "referenceText" }) ??
+    audioGenerationDefaults.referenceText;
   const watchedModel =
     useWatch({ control: form.control, name: "model" }) ??
     audioGenerationDefaults.model;
@@ -157,11 +176,30 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
   const speedConfig = getRuntimeAudioParamConfig(activeRuntimeModel, "speed");
   const voiceConfig = getRuntimeAudioParamConfig(activeRuntimeModel, "voice");
   const seedConfig = getRuntimeAudioParamConfig(activeRuntimeModel, "seed");
+  const inputAudioConfig = getRuntimeAudioParamConfig(
+    activeRuntimeModel,
+    "inputAudio",
+  );
+  const referenceTextConfig = getRuntimeAudioParamConfig(
+    activeRuntimeModel,
+    "referenceText",
+  );
   const showSpeed = speedConfig?.ui !== "hidden";
   const showVoice = voiceConfig?.ui !== "hidden";
   const showSeed = seedConfig?.ui !== "hidden";
+  const showInputAudio =
+    inputAudioConfig?.ui !== "hidden" &&
+    resolveRuntimeAudioSupportsInputAudio(activeRuntimeModel);
+  const showReferenceText = referenceTextConfig?.ui !== "hidden";
 
-  const canSubmit = hasModels && promptValue.trim().length > 0;
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const requiresInputAudio = Boolean(inputAudioConfig?.required);
+  const requiresReferenceText = Boolean(referenceTextConfig?.required);
+  const canSubmit =
+    hasModels &&
+    promptValue.trim().length > 0 &&
+    (!requiresInputAudio || Boolean((inputAudio ?? "").trim())) &&
+    (!requiresReferenceText || Boolean((referenceText ?? "").trim()));
 
   useEffect(() => {
     if (!hasModels || !defaultModelKey) return;
@@ -176,6 +214,13 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
     const defaults = resolveRuntimeAudioDefaults(model);
     form.setValue("voice", defaults.voice);
     form.setValue("speed", defaults.speed);
+    if (!resolveRuntimeAudioSupportsInputAudio(model)) {
+      form.setValue("inputAudio", "", { shouldValidate: true });
+      form.setValue("referenceText", "", { shouldValidate: true });
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
 
     if (!showSeed) {
       form.setValue("seed", "");
@@ -192,6 +237,8 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
       model: resetModelKey,
       voice: defaults.voice,
       speed: defaults.speed,
+      inputAudio: "",
+      referenceText: "",
     };
   }, [resetModelKey, runtimeModelMap]);
 
@@ -212,7 +259,35 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
 
   const handleReset = () => {
     form.reset(resetDefaults);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
     reset();
+  };
+
+  const handleInputAudioSelection = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== "string") {
+        return;
+      }
+      form.setValue("inputAudio", result, { shouldValidate: true });
+      event.target.value = "";
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemoveInputAudio = () => {
+    form.setValue("inputAudio", "", { shouldValidate: true });
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
   };
 
   const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -471,6 +546,72 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
                           value={field.value ?? ""}
                           placeholder={tAudio("voicePlaceholder")}
                           className="h-11 rounded-xl border-white/10 bg-black/40 px-4 text-sm text-white"
+                        />
+                      </FormControl>
+                      <FormMessage className="text-xs text-red-400" />
+                    </FormItem>
+                  )}
+                />
+              ) : null}
+
+              {showInputAudio ? (
+                <FormField
+                  control={form.control}
+                  name="inputAudio"
+                  render={() => (
+                    <FormItem className="flex flex-col gap-3">
+                      <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                        {inputAudioConfig?.label ?? "Reference Audio"}
+                      </FormLabel>
+                      <FormControl>
+                        <input
+                          ref={fileInputRef}
+                          type="file"
+                          accept="audio/*"
+                          aria-label={inputAudioConfig?.label ?? "Reference Audio"}
+                          onChange={handleInputAudioSelection}
+                          className="block w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white file:mr-3 file:rounded-md file:border-0 file:bg-white/10 file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-white"
+                        />
+                      </FormControl>
+                      {inputAudio ? (
+                        <div className="flex flex-col gap-2">
+                          <audio
+                            src={inputAudio}
+                            controls
+                            className="w-full rounded-lg border border-white/10 bg-black/60"
+                          />
+                          <Button
+                            type="button"
+                            variant="surface"
+                            size="sm"
+                            onClick={handleRemoveInputAudio}
+                            className="self-start"
+                          >
+                            {tActions("remove")}
+                          </Button>
+                        </div>
+                      ) : null}
+                      <FormMessage className="text-xs text-red-400" />
+                    </FormItem>
+                  )}
+                />
+              ) : null}
+
+              {showReferenceText ? (
+                <FormField
+                  control={form.control}
+                  name="referenceText"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-col gap-2">
+                      <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                        {referenceTextConfig?.label ?? tAudio("referenceTextLabel")}
+                      </FormLabel>
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          value={field.value ?? ""}
+                          placeholder={tAudio("referenceTextPlaceholder")}
+                          className="min-h-[96px] rounded-xl border-white/10 bg-black/40 px-4 py-3 text-sm text-white"
                         />
                       </FormControl>
                       <FormMessage className="text-xs text-red-400" />

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -40,9 +40,21 @@ import {
   FormMessage,
 } from "@/shared/ui/form";
 import { Input } from "@/shared/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/ui/select";
 import { Textarea } from "@/shared/ui/textarea";
 import { useTranslations } from "next-intl";
 import { useRuntimeModelCatalog } from "@/shared/lib/hooks/use-runtime-model-catalog";
+import { cn } from "@/shared/lib/utils";
+import {
+  getRuntimeParameterOptionLabel,
+  getRuntimeParameterOptionValue,
+} from "@/shared/model-catalog/parameter-options";
 import {
   getRuntimeAudioParamConfig,
   getRuntimeAudioParamRange,
@@ -56,6 +68,40 @@ import { resolveAudioModalities } from "@/shared/model-catalog/modality";
 type AudioGenerationFormProps = {
   isAuthenticated: boolean;
 };
+
+type AudioFieldName = Exclude<keyof AudioGenerationFormValues, "prompt" | "model">;
+
+const audioFieldOrder: Record<AudioFieldName, number> = {
+  modeChoice: 10,
+  language: 20,
+  speaker: 30,
+  voice: 40,
+  speed: 50,
+  inputAudio: 60,
+  referenceText: 70,
+  seed: 80,
+  streamMode: 90,
+  referencePreset: 100,
+  customInstruction: 110,
+  voiceInstruction: 120,
+  xvecOnly: 130,
+  chunkSize: 140,
+  temperature: 150,
+  topK: 160,
+  repetitionPenalty: 170,
+};
+
+const advancedAudioFields = new Set<AudioFieldName>([
+  "streamMode",
+  "referencePreset",
+  "customInstruction",
+  "voiceInstruction",
+  "xvecOnly",
+  "chunkSize",
+  "temperature",
+  "topK",
+  "repetitionPenalty",
+]);
 
 export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProps) {
   const searchParams = useSearchParams();
@@ -151,16 +197,12 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
   }, [form, referenceTextFromQuery]);
 
   const promptValue = useWatch({ control: form.control, name: "prompt" }) ?? "";
-  const speed =
-    useWatch({ control: form.control, name: "speed" }) ??
-    audioGenerationDefaults.speed;
+  const formValues = useWatch({ control: form.control });
   const voice = useWatch({ control: form.control, name: "voice" }) ?? "";
+  const speaker = useWatch({ control: form.control, name: "speaker" }) ?? "";
   const inputAudio =
     useWatch({ control: form.control, name: "inputAudio" }) ??
     audioGenerationDefaults.inputAudio;
-  const referenceText =
-    useWatch({ control: form.control, name: "referenceText" }) ??
-    audioGenerationDefaults.referenceText;
   const watchedModel =
     useWatch({ control: form.control, name: "model" }) ??
     audioGenerationDefaults.model;
@@ -171,35 +213,49 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
       : defaultModelKey
     : "";
   const activeRuntimeModel = runtimeModelMap.get(activeModel);
-
-  const speedRange = getRuntimeAudioParamRange(activeRuntimeModel, "speed");
-  const speedConfig = getRuntimeAudioParamConfig(activeRuntimeModel, "speed");
-  const voiceConfig = getRuntimeAudioParamConfig(activeRuntimeModel, "voice");
-  const seedConfig = getRuntimeAudioParamConfig(activeRuntimeModel, "seed");
-  const inputAudioConfig = getRuntimeAudioParamConfig(
-    activeRuntimeModel,
-    "inputAudio",
+  const activeDefaults = useMemo<Partial<Record<AudioFieldName, string | number | boolean | undefined>>>(
+    () => ({
+      ...audioGenerationDefaults,
+      ...(activeRuntimeModel ? resolveRuntimeAudioDefaults(activeRuntimeModel) : {}),
+    }),
+    [activeRuntimeModel],
   );
-  const referenceTextConfig = getRuntimeAudioParamConfig(
-    activeRuntimeModel,
-    "referenceText",
-  );
-  const showSpeed = speedConfig?.ui !== "hidden";
-  const showVoice = voiceConfig?.ui !== "hidden";
-  const showSeed = seedConfig?.ui !== "hidden";
-  const showInputAudio =
-    inputAudioConfig?.ui !== "hidden" &&
-    resolveRuntimeAudioSupportsInputAudio(activeRuntimeModel);
-  const showReferenceText = referenceTextConfig?.ui !== "hidden";
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const requiresInputAudio = Boolean(inputAudioConfig?.required);
-  const requiresReferenceText = Boolean(referenceTextConfig?.required);
+  const parameterKeys = useMemo(() => {
+    const parameters = activeRuntimeModel?.parameters ?? {};
+    return Object.keys(parameters)
+      .filter((key): key is AudioFieldName => key in audioFieldOrder)
+      .filter((key) => {
+        const config = getRuntimeAudioParamConfig(activeRuntimeModel, key);
+        if (config?.ui === "hidden") return false;
+        if (
+          key === "inputAudio" &&
+          !resolveRuntimeAudioSupportsInputAudio(activeRuntimeModel)
+        ) {
+          return false;
+        }
+        return true;
+      })
+      .sort((left, right) => audioFieldOrder[left] - audioFieldOrder[right]);
+  }, [activeRuntimeModel]);
+  const primaryParameterKeys = parameterKeys.filter(
+    (key) => !advancedAudioFields.has(key),
+  );
+  const advancedParameterKeys = parameterKeys.filter((key) =>
+    advancedAudioFields.has(key),
+  );
   const canSubmit =
     hasModels &&
     promptValue.trim().length > 0 &&
-    (!requiresInputAudio || Boolean((inputAudio ?? "").trim())) &&
-    (!requiresReferenceText || Boolean((referenceText ?? "").trim()));
+    !parameterKeys.some((key) => {
+      const config = getRuntimeAudioParamConfig(activeRuntimeModel, key);
+      if (!config?.required) return false;
+      const value = formValues?.[key];
+      if (typeof value === "string") return !value.trim();
+      if (typeof value === "number") return !Number.isFinite(value);
+      return value === undefined || value === null;
+    });
 
   useEffect(() => {
     if (!hasModels || !defaultModelKey) return;
@@ -212,20 +268,43 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
     const model = runtimeModelMap.get(activeModel);
     if (!model) return;
     const defaults = resolveRuntimeAudioDefaults(model);
-    form.setValue("voice", defaults.voice);
-    form.setValue("speed", defaults.speed);
-    if (!resolveRuntimeAudioSupportsInputAudio(model)) {
+    const currentValues = form.getValues();
+    const supportsInputAudio = resolveRuntimeAudioSupportsInputAudio(model);
+
+    form.reset({
+      ...audioGenerationDefaults,
+      ...currentValues,
+      model: activeModel,
+      prompt: currentValues.prompt ?? "",
+      voice: defaults.voice,
+      speaker: defaults.speaker,
+      speed: defaults.speed,
+      seed: currentValues.seed ?? "",
+      inputAudio: supportsInputAudio ? currentValues.inputAudio ?? "" : "",
+      referenceText: supportsInputAudio
+        ? currentValues.referenceText ?? ""
+        : "",
+      modeChoice: defaults.modeChoice,
+      language: defaults.language,
+      streamMode: defaults.streamMode,
+      referencePreset: defaults.referencePreset,
+      customInstruction: defaults.customInstruction,
+      voiceInstruction: defaults.voiceInstruction,
+      xvecOnly: defaults.xvecOnly,
+      chunkSize: defaults.chunkSize,
+      temperature: defaults.temperature,
+      topK: defaults.topK,
+      repetitionPenalty: defaults.repetitionPenalty,
+    });
+
+    if (!supportsInputAudio) {
       form.setValue("inputAudio", "", { shouldValidate: true });
       form.setValue("referenceText", "", { shouldValidate: true });
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
     }
-
-    if (!showSeed) {
-      form.setValue("seed", "");
-    }
-  }, [activeModel, form, runtimeModelMap, showSeed]);
+  }, [activeModel, form, runtimeModelMap]);
 
   const resetModelKey = defaultModelKey || audioGenerationDefaults.model;
   const resetDefaults = useMemo<AudioGenerationFormValues>(() => {
@@ -236,7 +315,19 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
       ...audioGenerationDefaults,
       model: resetModelKey,
       voice: defaults.voice,
+      speaker: defaults.speaker,
       speed: defaults.speed,
+      modeChoice: defaults.modeChoice,
+      language: defaults.language,
+      streamMode: defaults.streamMode,
+      referencePreset: defaults.referencePreset,
+      customInstruction: defaults.customInstruction,
+      voiceInstruction: defaults.voiceInstruction,
+      xvecOnly: defaults.xvecOnly,
+      chunkSize: defaults.chunkSize,
+      temperature: defaults.temperature,
+      topK: defaults.topK,
+      repetitionPenalty: defaults.repetitionPenalty,
       inputAudio: "",
       referenceText: "",
     };
@@ -301,7 +392,393 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
       return;
     }
 
-    void form.handleSubmit((values) => startGeneration(values))(event);
+    void form.handleSubmit((values) => {
+      const resolvedVoiceDefault = String(getResolvedDefaultValue("voice") ?? "");
+      const shouldSuppressLegacyVoice =
+        parameterKeys.includes("speaker") &&
+        typeof values.speaker === "string" &&
+        Boolean(values.speaker.trim()) &&
+        typeof values.voice === "string" &&
+        values.voice.trim() === resolvedVoiceDefault.trim();
+
+      const resolvedValues: AudioGenerationFormValues = {
+        ...values,
+        voice:
+          shouldSuppressLegacyVoice
+            ? ""
+            : parameterKeys.includes("voice")
+            ? !(values.voice ?? "").trim()
+              ? resolvedVoiceDefault
+              : values.voice
+            : "",
+        speaker:
+          parameterKeys.includes("speaker") && !(values.speaker ?? "").trim()
+            ? String(getResolvedDefaultValue("speaker") ?? "")
+            : values.speaker,
+        modeChoice:
+          parameterKeys.includes("modeChoice") && !(values.modeChoice ?? "").trim()
+            ? String(getResolvedDefaultValue("modeChoice") ?? "")
+            : values.modeChoice,
+        language:
+          parameterKeys.includes("language") && !(values.language ?? "").trim()
+            ? String(getResolvedDefaultValue("language") ?? "")
+            : values.language,
+        referencePreset:
+          parameterKeys.includes("referencePreset") &&
+          !(values.referencePreset ?? "").trim()
+            ? String(getResolvedDefaultValue("referencePreset") ?? "")
+            : values.referencePreset,
+        streamMode:
+          parameterKeys.includes("streamMode") &&
+          typeof values.streamMode !== "boolean"
+            ? Boolean(getResolvedDefaultValue("streamMode"))
+            : values.streamMode,
+        xvecOnly:
+          parameterKeys.includes("xvecOnly") &&
+          typeof values.xvecOnly !== "boolean"
+            ? Boolean(getResolvedDefaultValue("xvecOnly"))
+            : values.xvecOnly,
+        chunkSize:
+          parameterKeys.includes("chunkSize") &&
+          typeof values.chunkSize !== "number"
+            ? Number(getResolvedDefaultValue("chunkSize"))
+            : values.chunkSize,
+        temperature:
+          parameterKeys.includes("temperature") &&
+          typeof values.temperature !== "number"
+            ? Number(getResolvedDefaultValue("temperature"))
+            : values.temperature,
+        topK:
+          parameterKeys.includes("topK") && typeof values.topK !== "number"
+            ? Number(getResolvedDefaultValue("topK"))
+            : values.topK,
+        repetitionPenalty:
+          parameterKeys.includes("repetitionPenalty") &&
+          typeof values.repetitionPenalty !== "number"
+            ? Number(getResolvedDefaultValue("repetitionPenalty"))
+            : values.repetitionPenalty,
+      };
+      startGeneration(resolvedValues);
+    })(event);
+  };
+
+  const getFieldLabel = (key: AudioFieldName) => {
+    const config = getRuntimeAudioParamConfig(activeRuntimeModel, key);
+    if (typeof config?.label === "string" && config.label.trim()) {
+      return config.label;
+    }
+    switch (key) {
+      case "voice":
+        return tAudio("voiceLabel");
+      case "referenceText":
+        return tAudio("referenceTextLabel");
+      case "speed":
+        return tAudio("speedLabel");
+      case "seed":
+        return tLabels("seed");
+      case "modeChoice":
+        return "Generation Mode";
+      case "language":
+        return "Language";
+      case "speaker":
+        return "Speaker";
+      case "streamMode":
+        return "Streaming";
+      case "referencePreset":
+        return "Reference Preset";
+      case "customInstruction":
+        return "Custom Instruction";
+      case "voiceInstruction":
+        return "Voice Instruction";
+      case "xvecOnly":
+        return "xvec only";
+      case "chunkSize":
+        return "Chunk Size";
+      case "temperature":
+        return "Temperature";
+      case "topK":
+        return "Top K";
+      case "repetitionPenalty":
+        return "Repetition Penalty";
+      case "inputAudio":
+        return "Reference Audio";
+      default:
+        return key;
+    }
+  };
+
+  const getFieldTextareaPlaceholder = (key: AudioFieldName) => {
+    if (key === "referenceText") return tAudio("referenceTextPlaceholder");
+    if (key === "customInstruction") return "Describe how the generated voice should behave.";
+    if (key === "voiceInstruction") return "Describe the target voice style.";
+    return "";
+  };
+
+  const getFieldInputPlaceholder = (key: AudioFieldName) => {
+    if (key === "voice") return tAudio("voicePlaceholder");
+    if (key === "seed") return tAudio("seedPlaceholder");
+    return "";
+  };
+
+  const getResolvedDefaultValue = (key: AudioFieldName) => {
+    const config = getRuntimeAudioParamConfig(activeRuntimeModel, key);
+    if (config?.ui === "select") {
+      if (typeof config.default === "string" || typeof config.default === "number") {
+        return String(config.default);
+      }
+      const firstOptionValue = getRuntimeParameterOptionValue(config.options?.[0]);
+      if (typeof firstOptionValue === "string" || typeof firstOptionValue === "number") {
+        return String(firstOptionValue);
+      }
+      return "";
+    }
+    if (config?.ui === "range") {
+      return typeof config.default === "number"
+        ? config.default
+        : getRuntimeAudioParamRange(activeRuntimeModel, key).min;
+    }
+    if (config?.ui === "toggle") {
+      return typeof config.default === "boolean" ? config.default : false;
+    }
+    if (typeof config?.default === "string") {
+      return config.default;
+    }
+    if (key === "voice") {
+      return activeDefaults.voice;
+    }
+    return activeDefaults[key];
+  };
+
+  const renderAudioField = (key: AudioFieldName) => {
+    const config = getRuntimeAudioParamConfig(activeRuntimeModel, key);
+    if (!config || config.ui === "hidden") return null;
+    const label = getFieldLabel(key);
+
+    if (key === "inputAudio") {
+      return (
+        <FormField
+          key={`${activeModel}-${key}`}
+          control={form.control}
+          name={key}
+          render={() => (
+            <FormItem className="flex flex-col gap-3">
+              <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                {label}
+              </FormLabel>
+              <FormControl>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="audio/*"
+                  aria-label={label}
+                  onChange={handleInputAudioSelection}
+                  className="block w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white file:mr-3 file:rounded-md file:border-0 file:bg-white/10 file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-white"
+                />
+              </FormControl>
+              {inputAudio ? (
+                <div className="flex flex-col gap-2">
+                  <audio
+                    src={inputAudio}
+                    controls
+                    className="w-full rounded-lg border border-white/10 bg-black/60"
+                  />
+                  <Button
+                    type="button"
+                    variant="surface"
+                    size="sm"
+                    onClick={handleRemoveInputAudio}
+                    className="self-start"
+                  >
+                    {tActions("remove")}
+                  </Button>
+                </div>
+              ) : null}
+              <FormMessage className="text-xs text-red-400" />
+            </FormItem>
+          )}
+        />
+      );
+    }
+
+    if (config.ui === "range") {
+      const range = getRuntimeAudioParamRange(activeRuntimeModel, key);
+      return (
+        <FormField
+          key={`${activeModel}-${key}`}
+          control={form.control}
+          name={key}
+          render={({ field }) => (
+            <FormItem className="flex flex-col gap-3">
+              {(() => {
+                const effectiveValue =
+                  typeof field.value === "number"
+                    ? field.value
+                    : typeof getResolvedDefaultValue(key) === "number"
+                      ? Number(getResolvedDefaultValue(key))
+                      : range.min;
+                return (
+                  <>
+              <div className="flex items-center justify-between">
+                <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                  {label}
+                </FormLabel>
+                <span className="rounded border border-white/10 bg-surface-lighter px-2 py-0.5 text-xs font-bold text-white font-mono">
+                  {effectiveValue}
+                </span>
+              </div>
+              <FormControl>
+                <input
+                  type="range"
+                  min={range.min}
+                  max={range.max}
+                  step={range.step}
+                  value={effectiveValue}
+                  onChange={(event) => field.onChange(Number(event.target.value))}
+                  className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-surface-lighter"
+                />
+              </FormControl>
+              <FormMessage className="text-xs text-red-400" />
+                  </>
+                );
+              })()}
+            </FormItem>
+          )}
+        />
+      );
+    }
+
+    if (config.ui === "select") {
+      const options = Array.isArray(config.options) ? config.options : [];
+      return (
+        <FormField
+          key={`${activeModel}-${key}`}
+          control={form.control}
+          name={key}
+          render={({ field }) => (
+            <FormItem className="flex flex-col gap-2">
+              <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                {label}
+              </FormLabel>
+              <Select
+                value={
+                  field.value
+                    ? String(field.value)
+                    : typeof getResolvedDefaultValue(key) === "string"
+                      ? String(getResolvedDefaultValue(key))
+                      : ""
+                }
+                onValueChange={(nextValue) => field.onChange(nextValue)}
+              >
+                <FormControl>
+                  <SelectTrigger className="h-11 rounded-xl border-white/10 bg-black/40 px-4 text-sm text-white">
+                    <SelectValue placeholder={label} />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {options.map((option) => (
+                    <SelectItem
+                      key={String(getRuntimeParameterOptionValue(option))}
+                      value={String(getRuntimeParameterOptionValue(option))}
+                    >
+                      {getRuntimeParameterOptionLabel(option)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage className="text-xs text-red-400" />
+            </FormItem>
+          )}
+        />
+      );
+    }
+
+    if (config.ui === "toggle") {
+      return (
+        <FormField
+          key={`${activeModel}-${key}`}
+          control={form.control}
+          name={key}
+          render={({ field }) => {
+            const isEnabled =
+              typeof field.value === "boolean"
+                ? field.value
+                : Boolean(getResolvedDefaultValue(key));
+            return (
+              <FormItem className="flex items-center justify-between gap-4">
+                <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                  {label}
+                </FormLabel>
+                <FormControl>
+                  <Button
+                    type="button"
+                    variant={isEnabled ? "default" : "surface"}
+                    size="sm"
+                    aria-pressed={isEnabled}
+                    onClick={() => field.onChange(!isEnabled)}
+                    className={cn(
+                      "h-8 px-3 text-xs font-bold uppercase tracking-wider",
+                      isEnabled ? "text-black" : "text-gray-300",
+                    )}
+                  >
+                    {isEnabled ? "On" : "Off"}
+                  </Button>
+                </FormControl>
+              </FormItem>
+            );
+          }}
+        />
+      );
+    }
+
+    if (config.ui === "textarea") {
+      return (
+        <FormField
+          key={`${activeModel}-${key}`}
+          control={form.control}
+          name={key}
+          render={({ field }) => (
+            <FormItem className="flex flex-col gap-2">
+              <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                {label}
+              </FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  value={typeof field.value === "string" ? field.value : ""}
+                  placeholder={getFieldTextareaPlaceholder(key)}
+                  className="min-h-[96px] rounded-xl border-white/10 bg-black/40 px-4 py-3 text-sm text-white"
+                />
+              </FormControl>
+              <FormMessage className="text-xs text-red-400" />
+            </FormItem>
+          )}
+        />
+      );
+    }
+
+    return (
+      <FormField
+        key={`${activeModel}-${key}`}
+        control={form.control}
+        name={key}
+        render={({ field }) => (
+          <FormItem className="flex flex-col gap-2">
+            <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+              {label}
+            </FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                value={typeof field.value === "string" ? field.value : ""}
+                placeholder={getFieldInputPlaceholder(key)}
+                className="h-11 rounded-xl border-white/10 bg-black/40 px-4 text-sm text-white"
+              />
+            </FormControl>
+            <FormMessage className="text-xs text-red-400" />
+          </FormItem>
+        )}
+      />
+    );
   };
 
   return (
@@ -459,7 +936,9 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
                       }
                       footerLeft={
                         <span className="text-[10px] font-mono text-gray-600">
-                          {voice?.trim() ? `${tAudio("voiceLabel")}: ${voice}` : tAudio("voiceUnset")}
+                          {(speaker || voice)?.trim()
+                            ? `${speaker?.trim() ? "Speaker" : tAudio("voiceLabel")}: ${speaker?.trim() || voice}`
+                            : tAudio("voiceUnset")}
                         </span>
                       }
                       footerRight={
@@ -494,153 +973,19 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
 
           <GenerationSettingsPanel onReset={handleReset}>
             <div className="flex flex-col gap-8">
-              {showSpeed ? (
-                <FormField
-                  control={form.control}
-                  name="speed"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-col gap-3">
-                      <div className="flex items-center justify-between">
-                        <span className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                          {tAudio("speedLabel")}
-                        </span>
-                        <span className="rounded border border-white/10 bg-surface-lighter px-2 py-0.5 text-xs font-bold text-white font-mono">
-                          {field.value?.toFixed(2)}x
-                        </span>
-                      </div>
-                      <FormControl>
-                        <input
-                          type="range"
-                          min={speedRange.min}
-                          max={speedRange.max}
-                          step={speedRange.step}
-                          value={field.value ?? speed}
-                          onChange={(event) =>
-                            field.onChange(Number(event.target.value))
-                          }
-                          className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-surface-lighter"
-                        />
-                      </FormControl>
-                      <div className="flex justify-between px-1 text-[10px] font-mono text-gray-600">
-                        <span>{speedRange.min.toFixed(2)}x</span>
-                        <span>{speedRange.max.toFixed(2)}x</span>
-                      </div>
-                      <FormMessage className="text-xs text-red-400" />
-                    </FormItem>
-                  )}
-                />
-              ) : null}
-
-              {showVoice ? (
-                <FormField
-                  control={form.control}
-                  name="voice"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-col gap-2">
-                      <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                        {tAudio("voiceLabel")}
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          value={field.value ?? ""}
-                          placeholder={tAudio("voicePlaceholder")}
-                          className="h-11 rounded-xl border-white/10 bg-black/40 px-4 text-sm text-white"
-                        />
-                      </FormControl>
-                      <FormMessage className="text-xs text-red-400" />
-                    </FormItem>
-                  )}
-                />
-              ) : null}
-
-              {showInputAudio ? (
-                <FormField
-                  control={form.control}
-                  name="inputAudio"
-                  render={() => (
-                    <FormItem className="flex flex-col gap-3">
-                      <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                        {inputAudioConfig?.label ?? "Reference Audio"}
-                      </FormLabel>
-                      <FormControl>
-                        <input
-                          ref={fileInputRef}
-                          type="file"
-                          accept="audio/*"
-                          aria-label={inputAudioConfig?.label ?? "Reference Audio"}
-                          onChange={handleInputAudioSelection}
-                          className="block w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white file:mr-3 file:rounded-md file:border-0 file:bg-white/10 file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-white"
-                        />
-                      </FormControl>
-                      {inputAudio ? (
-                        <div className="flex flex-col gap-2">
-                          <audio
-                            src={inputAudio}
-                            controls
-                            className="w-full rounded-lg border border-white/10 bg-black/60"
-                          />
-                          <Button
-                            type="button"
-                            variant="surface"
-                            size="sm"
-                            onClick={handleRemoveInputAudio}
-                            className="self-start"
-                          >
-                            {tActions("remove")}
-                          </Button>
-                        </div>
-                      ) : null}
-                      <FormMessage className="text-xs text-red-400" />
-                    </FormItem>
-                  )}
-                />
-              ) : null}
-
-              {showReferenceText ? (
-                <FormField
-                  control={form.control}
-                  name="referenceText"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-col gap-2">
-                      <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                        {referenceTextConfig?.label ?? tAudio("referenceTextLabel")}
-                      </FormLabel>
-                      <FormControl>
-                        <Textarea
-                          {...field}
-                          value={field.value ?? ""}
-                          placeholder={tAudio("referenceTextPlaceholder")}
-                          className="min-h-[96px] rounded-xl border-white/10 bg-black/40 px-4 py-3 text-sm text-white"
-                        />
-                      </FormControl>
-                      <FormMessage className="text-xs text-red-400" />
-                    </FormItem>
-                  )}
-                />
-              ) : null}
-
-              {showSeed ? (
-                <FormField
-                  control={form.control}
-                  name="seed"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-col gap-2">
-                      <FormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                        {tLabels("seed")}
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          value={field.value ?? ""}
-                          placeholder={tAudio("seedPlaceholder")}
-                          className="h-11 rounded-xl border-white/10 bg-black/40 px-4 text-sm text-white"
-                        />
-                      </FormControl>
-                      <FormMessage className="text-xs text-red-400" />
-                    </FormItem>
-                  )}
-                />
+              {primaryParameterKeys.map((key) => renderAudioField(key))}
+              {advancedParameterKeys.length > 0 ? (
+                <>
+                  <div className="h-px bg-white/5" />
+                  <div className="flex flex-col gap-4">
+                    <div className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                      Advanced Settings
+                    </div>
+                    <div className="flex flex-col gap-6">
+                      {advancedParameterKeys.map((key) => renderAudioField(key))}
+                    </div>
+                  </div>
+                </>
               ) : null}
             </div>
           </GenerationSettingsPanel>

--- a/src/features/generation-history/api/history-delete-api.test.ts
+++ b/src/features/generation-history/api/history-delete-api.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { deleteHistoryItem } from "@/features/generation-history/api/history-delete-api";
+
+describe("deleteHistoryItem", () => {
+  it("audio 항목은 audio-generation endpoint로 삭제한다", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await deleteHistoryItem({
+      id: "aud-1",
+      type: "audio" as never,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/audio-generation/aud-1", {
+      method: "DELETE",
+    });
+  });
+});

--- a/src/features/generation-history/api/history-delete-api.ts
+++ b/src/features/generation-history/api/history-delete-api.ts
@@ -6,6 +6,8 @@ export async function deleteHistoryItem(
   const endpoint =
     item.type === "video"
       ? `/api/video-generation/${item.id}`
+      : item.type === "audio"
+        ? `/api/audio-generation/${item.id}`
       : `/api/image-generation/${item.id}`;
 
   const response = await fetch(endpoint, {
@@ -18,4 +20,3 @@ export async function deleteHistoryItem(
     throw new Error(message);
   }
 }
-

--- a/src/features/generation-history/ui/history-item.audio.test.tsx
+++ b/src/features/generation-history/ui/history-item.audio.test.tsx
@@ -1,0 +1,40 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { HistoryItem } from "@/features/generation-history/ui/history-item";
+import { renderWithIntl } from "@/test-utils/intl";
+
+const mockPush = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+describe("HistoryItem audio", () => {
+  it("audio 항목은 /audio 재사용 경로와 오디오 프리뷰를 사용한다", async () => {
+    const user = userEvent.setup();
+    renderWithIntl(
+      <HistoryItem
+        item={{
+          id: "item-audio-1",
+          type: "audio" as never,
+          status: "completed",
+          prompt: "hello audio",
+          model: "qwen-tts",
+          createdAt: "2026-02-03T00:00:00.000Z",
+          resultUrl: "https://example.com/result.mp3",
+          thumbnailUrl: null,
+          errorMessage: null,
+        }}
+      />,
+    );
+
+    expect(document.querySelector("audio")).not.toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "프롬프트 재사용" }));
+
+    expect(mockPush).toHaveBeenCalledWith("/audio?prompt=hello+audio&model=qwen-tts");
+  });
+});

--- a/src/features/generation-history/ui/history-item.audio.test.tsx
+++ b/src/features/generation-history/ui/history-item.audio.test.tsx
@@ -26,6 +26,8 @@ describe("HistoryItem audio", () => {
           createdAt: "2026-02-03T00:00:00.000Z",
           resultUrl: "https://example.com/result.mp3",
           thumbnailUrl: null,
+          inputAudios: ["data:audio/wav;base64,UklGRg=="],
+          referenceText: "reference words",
           errorMessage: null,
         }}
       />,
@@ -35,6 +37,8 @@ describe("HistoryItem audio", () => {
 
     await user.click(screen.getByRole("button", { name: "프롬프트 재사용" }));
 
-    expect(mockPush).toHaveBeenCalledWith("/audio?prompt=hello+audio&model=qwen-tts");
+    expect(mockPush).toHaveBeenCalledWith(
+      "/audio?prompt=hello+audio&model=qwen-tts&referenceText=reference+words",
+    );
   });
 });

--- a/src/features/generation-history/ui/history-item.tsx
+++ b/src/features/generation-history/ui/history-item.tsx
@@ -217,6 +217,8 @@ export function HistoryItem({
         progress: null,
         errorMessage: item.errorMessage ?? null,
         inputImages,
+        inputAudios: item.inputAudios ?? [],
+        referenceText: item.referenceText ?? null,
         assets,
       };
     },
@@ -224,9 +226,11 @@ export function HistoryItem({
       item.createdAt,
       item.errorMessage,
       item.id,
+      item.inputAudios,
       item.inputImages,
       item.model,
       item.prompt,
+      item.referenceText,
       item.resultUrl,
       item.status,
       item.thumbnailUrl,
@@ -276,6 +280,11 @@ export function HistoryItem({
       initImages.forEach((value) => {
         params.append("initImage", value);
       });
+    } else if (item.type === "audio") {
+      const referenceText = item.referenceText?.trim();
+      if (referenceText) {
+        params.set("referenceText", referenceText);
+      }
     }
 
     router.push(`${target}?${params.toString()}`);

--- a/src/features/generation-history/ui/history-item.tsx
+++ b/src/features/generation-history/ui/history-item.tsx
@@ -215,7 +215,9 @@ export function HistoryItem({
         updatedAt: item.createdAt,
         durationMs: null,
         progress: null,
-        errorMessage: item.errorMessage ?? null,
+        errorMessage: item.status === "completed" ? null : (item.errorMessage ?? null),
+        warningMessage:
+          item.status === "completed" ? (item.errorMessage ?? null) : null,
         inputImages,
         inputAudios: item.inputAudios ?? [],
         referenceText: item.referenceText ?? null,

--- a/src/features/generation-history/ui/history-item.tsx
+++ b/src/features/generation-history/ui/history-item.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import {
   AlertTriangle,
+  AudioLines,
   CheckCircle2,
   Clock,
   Copy,
@@ -76,6 +77,10 @@ const typeConfig = {
     className: "border-white/10 bg-black/80 text-accent-purple",
     icon: Video,
   },
+  audio: {
+    className: "border-white/10 bg-black/80 text-sky-300",
+    icon: AudioLines,
+  },
 };
 
 export function HistoryItem({
@@ -109,12 +114,16 @@ export function HistoryItem({
   const hasInputImages = inputImages.length > 0;
   const showActions = item.status === "completed";
   const isVideo = item.type === "video";
+  const isAudio = item.type === "audio";
   const canDelete = item.status === "completed" || item.status === "failed";
   const canShowViewMore = item.prompt.trim().length > 0;
-  const isPreviewLoaded = !!previewUrl && !isVideo && loadedPreviewUrl === previewUrl;
-  const isPreviewFailed = !!previewUrl && !isVideo && failedPreviewUrl === previewUrl;
+  const usesImagePreview = !isVideo && !isAudio;
+  const isPreviewLoaded =
+    !!previewUrl && usesImagePreview && loadedPreviewUrl === previewUrl;
+  const isPreviewFailed =
+    !!previewUrl && usesImagePreview && failedPreviewUrl === previewUrl;
   const shouldShowPreviewSkeleton =
-    !!previewUrl && !isVideo && !isPreviewLoaded && !isPreviewFailed;
+    !!previewUrl && usesImagePreview && !isPreviewLoaded && !isPreviewFailed;
   const downloadUrl =
     item.type === "image" && item.resultUrl
       ? `/api/image-generation/${item.id}/download?index=0`
@@ -165,6 +174,17 @@ export function HistoryItem({
                 },
               ]
             : []
+          : item.type === "audio"
+            ? item.resultUrl
+              ? [
+                  {
+                    url: item.resultUrl,
+                    width: null,
+                    height: null,
+                    durationSec: null,
+                  },
+                ]
+              : []
           : item.resultUrl
             ? [
                 {
@@ -227,7 +247,12 @@ export function HistoryItem({
   });
 
   const handleReusePrompt = () => {
-    const target = item.type === "video" ? "/video" : "/image";
+    const target =
+      item.type === "video"
+        ? "/video"
+        : item.type === "audio"
+          ? "/audio"
+          : "/image";
     const trimmedPrompt = item.prompt.trim();
     if (!trimmedPrompt) return;
 
@@ -244,7 +269,7 @@ export function HistoryItem({
       if (initImage) {
         params.set("initImage", initImage);
       }
-    } else {
+    } else if (item.type === "image") {
       const initImages = (item.inputImages ?? [])
         .map((value) => value.trim())
         .filter((value) => value.length > 0);
@@ -302,6 +327,10 @@ export function HistoryItem({
               playsInline
               preload="metadata"
             />
+          ) : isAudio ? (
+            <div className="flex h-full items-center justify-center bg-black p-4">
+              <audio controls className="w-full max-w-[18rem]" preload="metadata" src={previewUrl} />
+            </div>
           ) : (
             <>
               {shouldShowPreviewSkeleton ? (
@@ -407,7 +436,7 @@ export function HistoryItem({
               {downloadUrl ? (
                 <a
                   href={downloadUrl}
-                  download={item.type === "video" ? true : undefined}
+                  download={item.type === "image" ? undefined : true}
                   className="flex h-9 w-9 items-center justify-center rounded-full border border-white/20 bg-black/50 text-white backdrop-blur-md transition-colors hover:border-white hover:bg-black"
                   aria-label={tCommonActions("download")}
                 >

--- a/src/features/image-generation/ui/image-generation-form.test.tsx
+++ b/src/features/image-generation/ui/image-generation-form.test.tsx
@@ -73,7 +73,7 @@ describe("ImageGenerationForm", () => {
     expect(
       screen.getByDisplayValue("a query prompt"),
     ).toBeInTheDocument();
-    expect(screen.getAllByAltText("입력 이미지 미리보기")).toHaveLength(2);
+    expect(await screen.findAllByAltText("입력 이미지 미리보기")).toHaveLength(2);
 
     const modelButton = screen.getByRole("button", {
       name: /FLUX\.2 Klein 9B/i,

--- a/src/features/image-generation/ui/image-generation-form.tsx
+++ b/src/features/image-generation/ui/image-generation-form.tsx
@@ -49,6 +49,10 @@ import { useImageInitPreviews } from "@/features/image-generation/hook/use-image
 import { useTranslations } from "next-intl";
 import { useRuntimeModelCatalog } from "@/shared/lib/hooks/use-runtime-model-catalog";
 import {
+  getRuntimeParameterOptionLabel,
+  getRuntimeParameterOptionValue,
+} from "@/shared/model-catalog/parameter-options";
+import {
   getRuntimeImageParamConfig,
   getRuntimeImageParamRange,
   resolveRuntimeDefaultModelKey,
@@ -195,10 +199,13 @@ export function ImageGenerationForm({ isAuthenticated }: ImageGenerationFormProp
   );
   const seedConfig = getRuntimeImageParamConfig(activeRuntimeModel, "seed");
   const modeOptions = Array.isArray(modeConfig?.options)
-    ? modeConfig.options.filter(
-        (option): option is string =>
-          typeof option === "string" && option.trim().length > 0,
-      )
+    ? modeConfig.options.filter((option) => {
+        const value = getRuntimeParameterOptionValue(option);
+        return (
+          (typeof value === "string" && value.trim().length > 0) ||
+          typeof value === "number"
+        );
+      })
     : [];
   const showSizeControls =
     widthConfig?.ui !== "hidden" || heightConfig?.ui !== "hidden";
@@ -726,21 +733,24 @@ export function ImageGenerationForm({ isAuthenticated }: ImageGenerationFormProp
                         <FormControl>
                           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                             {modeOptions.map((option) => {
-                              const isActive = field.value === option;
+                              const optionValue = String(
+                                getRuntimeParameterOptionValue(option),
+                              );
+                              const isActive = field.value === optionValue;
                               return (
                                 <Button
-                                  key={option}
+                                  key={optionValue}
                                   type="button"
                                   variant={isActive ? "default" : "surface"}
                                   size="sm"
                                   aria-pressed={isActive}
-                                  onClick={() => field.onChange(option)}
+                                  onClick={() => field.onChange(optionValue)}
                                   className={cn(
                                     "h-auto justify-start whitespace-normal text-xs font-semibold",
                                     isActive ? "text-black" : "text-gray-300",
                                   )}
                                 >
-                                  {option}
+                                  {getRuntimeParameterOptionLabel(option)}
                                 </Button>
                               );
                             })}

--- a/src/features/image-generation/ui/image-generation-form.tsx
+++ b/src/features/image-generation/ui/image-generation-form.tsx
@@ -349,7 +349,7 @@ export function ImageGenerationForm({ isAuthenticated }: ImageGenerationFormProp
       ? "grid-cols-2"
       : "grid-cols-2 lg:grid-cols-3";
 
-  const resetDefaults = useMemo<ImageGenerationFormValues>(() => {
+  const resetDefaults: ImageGenerationFormValues = (() => {
     const model = runtimeModelMap.get(defaultModelKey);
     if (!model) return imageGenerationDefaults;
     const defaults = resolveRuntimeImageDefaults(model);
@@ -363,7 +363,7 @@ export function ImageGenerationForm({ isAuthenticated }: ImageGenerationFormProp
       modeChoice: defaults.modeChoice,
       promptUpsampling: defaults.promptUpsampling,
     };
-  }, [defaultModelKey, runtimeModelMap]);
+  })();
 
   const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
     if (!isAuthenticated) {

--- a/src/features/model-management/model/model-catalog.ts
+++ b/src/features/model-management/model/model-catalog.ts
@@ -9,7 +9,7 @@ import {
   videoModels,
 } from "@/features/video-generation/model/video-models";
 
-export type ModelCatalogType = "image" | "video";
+export type ModelCatalogType = "image" | "video" | "audio";
 export type ModelCatalogFilterType = "all" | ModelCatalogType;
 
 interface BaseModelCatalogItem {
@@ -43,6 +43,12 @@ export interface VideoModelMeta {
   defaultGuidanceScale: VideoModel["default_guidance_scale"];
 }
 
+export interface AudioModelMeta {
+  modelId: string;
+  defaultSpeed: number;
+  supportsInputAudio: boolean;
+}
+
 export interface ImageModelCatalogItem extends BaseModelCatalogItem {
   type: "image";
   meta: ImageModelMeta;
@@ -53,7 +59,15 @@ export interface VideoModelCatalogItem extends BaseModelCatalogItem {
   meta: VideoModelMeta;
 }
 
-export type ModelCatalogItem = ImageModelCatalogItem | VideoModelCatalogItem;
+export interface AudioModelCatalogItem extends BaseModelCatalogItem {
+  type: "audio";
+  meta: AudioModelMeta;
+}
+
+export type ModelCatalogItem =
+  | ImageModelCatalogItem
+  | VideoModelCatalogItem
+  | AudioModelCatalogItem;
 
 export const imageModelCatalog: ImageModelCatalogItem[] = imageModels.map(
   (model) => ({
@@ -98,13 +112,18 @@ export const videoModelCatalog: VideoModelCatalogItem[] = videoModels.map(
   }),
 );
 
+export const audioModelCatalog: AudioModelCatalogItem[] = [];
+
 export const modelCatalog: ModelCatalogItem[] = [
   ...imageModelCatalog,
   ...videoModelCatalog,
+  ...audioModelCatalog,
 ];
 
 export function getModelCatalogByType(type: ModelCatalogType) {
-  return type === "image" ? imageModelCatalog : videoModelCatalog;
+  if (type === "image") return imageModelCatalog;
+  if (type === "video") return videoModelCatalog;
+  return audioModelCatalog;
 }
 
 export interface ModelCatalogFilterOptions {

--- a/src/features/model-management/ui/model-card.tsx
+++ b/src/features/model-management/ui/model-card.tsx
@@ -1,10 +1,11 @@
-import { Image as ImageIcon, Sparkles, Video } from "lucide-react";
+import { AudioLines, Image as ImageIcon, Sparkles, Video } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { ModelCatalogItem } from "@/features/model-management/model/model-catalog";
 import { cn } from "@/shared/lib/utils";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import {
+  resolveAudioModalities,
   resolveImageModalities,
   resolveVideoModalities,
 } from "@/shared/model-catalog/modality";
@@ -27,32 +28,26 @@ const typeConfig = {
     accentText: "text-accent-purple",
     glowClass: "from-accent-purple/35 via-transparent to-transparent",
   },
+  audio: {
+    className: "border-white/10 bg-black/80 text-cyan-300",
+    icon: AudioLines,
+    accentText: "text-cyan-300",
+    glowClass: "from-cyan-400/35 via-transparent to-transparent",
+  },
 };
 
 function buildMeta(item: ModelCatalogItem, t: (key: string) => string) {
-  const modalities =
-    item.type === "image"
-      ? resolveImageModalities({ maxInputImages: item.meta.maxInputImages })
-      : resolveVideoModalities({
-          supportsInitImage: item.meta.supportsInitImage,
-          t2vModelId: item.meta.t2vModelId,
-          i2vModelId: item.meta.i2vModelId,
-        });
-
-  const base = [
-    {
-      label: t("meta.provider"),
-      value: item.provider,
-    },
-    {
-      label: t("meta.modality"),
-      value: modalities.join(" · "),
-    },
+  const base = (modalities: string[]) => [
+    { label: t("meta.provider"), value: item.provider },
+    { label: t("meta.modality"), value: modalities.join(" · ") },
   ];
 
   if (item.type === "image") {
+    const modalities = resolveImageModalities({
+      maxInputImages: item.meta.maxInputImages,
+    });
     return [
-      ...base,
+      ...base(modalities),
       { label: t("meta.pipeline"), value: item.meta.pipeline },
       {
         label: t("meta.size"),
@@ -65,19 +60,45 @@ function buildMeta(item: ModelCatalogItem, t: (key: string) => string) {
     ];
   }
 
+  if (item.type === "video") {
+    const modalities = resolveVideoModalities({
+      supportsInitImage: item.meta.supportsInitImage,
+      t2vModelId: item.meta.t2vModelId,
+      i2vModelId: item.meta.i2vModelId,
+    });
+    return [
+      ...base(modalities),
+      {
+        label: t("meta.mode"),
+        value: modalities.includes("I2V") ? "I2V" : "T2V",
+      },
+      {
+        label: t("meta.size"),
+        value: `${item.meta.defaultWidth}x${item.meta.defaultHeight}`,
+      },
+      {
+        label: t("meta.duration"),
+        value: `${item.meta.defaultDurationSec}s`,
+      },
+    ];
+  }
+
+  const modalities = resolveAudioModalities({
+    supportsInputAudio: item.meta.supportsInputAudio,
+  });
   return [
-    ...base,
+    ...base(modalities),
     {
-      label: t("meta.mode"),
-      value: modalities.includes("I2V") ? "I2V" : "T2V",
+      label: t("meta.model"),
+      value: item.meta.modelId,
     },
     {
-      label: t("meta.size"),
-      value: `${item.meta.defaultWidth}x${item.meta.defaultHeight}`,
+      label: t("meta.speed"),
+      value: `${item.meta.defaultSpeed}x`,
     },
     {
-      label: t("meta.duration"),
-      value: `${item.meta.defaultDurationSec}s`,
+      label: t("meta.input"),
+      value: item.meta.supportsInputAudio ? "A2A" : "T2A",
     },
   ];
 }

--- a/src/features/model-management/ui/model-list.test.tsx
+++ b/src/features/model-management/ui/model-list.test.tsx
@@ -27,11 +27,11 @@ describe("ModelList", () => {
 
     const wrapper = container.firstElementChild;
     expect(wrapper).toBeTruthy();
-    expect(wrapper).toHaveClass("grid");
-    expect(wrapper).toHaveClass("grid-cols-1");
-    expect(wrapper).toHaveClass("sm:grid-cols-2");
-    expect(wrapper).toHaveClass("xl:grid-cols-3");
-    expect(wrapper).not.toHaveClass("columns-1");
+    const className = wrapper?.getAttribute("class") ?? "";
+    expect(className).toContain("grid");
+    expect(className).toContain("grid-cols-1");
+    expect(className).toContain("sm:grid-cols-2");
+    expect(className).toContain("xl:grid-cols-3");
+    expect(className).not.toContain("columns-1");
   });
 });
-

--- a/src/features/monitoring-dashboard/api/monitoring-dashboard-api.ts
+++ b/src/features/monitoring-dashboard/api/monitoring-dashboard-api.ts
@@ -100,7 +100,7 @@ export async function fetchMonitoringRequests(
 }
 
 export async function fetchMonitoringRequestDetail(
-  type: "image" | "video",
+  type: "image" | "video" | "audio",
   requestId: string,
 ): Promise<MonitoringRequestDetail> {
   const params = new URLSearchParams({

--- a/src/features/monitoring-dashboard/hook/use-monitoring-dashboard.ts
+++ b/src/features/monitoring-dashboard/hook/use-monitoring-dashboard.ts
@@ -75,7 +75,7 @@ export function useMonitoringRequests(
 }
 
 export function useMonitoringRequestDetail(
-  type: "image" | "video" | null,
+  type: "image" | "video" | "audio" | null,
   requestId: string | null,
   enabled: boolean,
 ) {

--- a/src/features/monitoring-dashboard/model/types.ts
+++ b/src/features/monitoring-dashboard/model/types.ts
@@ -60,6 +60,7 @@ export type MonitoringRequestDetail = {
   durationMs: number | null;
   progress: number | null;
   errorMessage: string | null;
+  warningMessage: string | null;
   inputImages: string[];
   inputAudios: string[];
   referenceText: string | null;

--- a/src/features/monitoring-dashboard/model/types.ts
+++ b/src/features/monitoring-dashboard/model/types.ts
@@ -61,6 +61,8 @@ export type MonitoringRequestDetail = {
   progress: number | null;
   errorMessage: string | null;
   inputImages: string[];
+  inputAudios: string[];
+  referenceText: string | null;
   assets: MonitoringRequestAsset[];
 };
 

--- a/src/features/monitoring-dashboard/model/types.ts
+++ b/src/features/monitoring-dashboard/model/types.ts
@@ -1,4 +1,4 @@
-export type MonitoringType = "all" | "image" | "video";
+export type MonitoringType = "all" | "image" | "video" | "audio";
 
 export type MonitoringStatusFilter =
   | "all"
@@ -34,7 +34,7 @@ export type MonitoringStatsResponse = {
 
 export type MonitoringRequestItem = {
   id: string;
-  type: "image" | "video";
+  type: "image" | "video" | "audio";
   status: string;
   model: string | null;
   createdAt: string;
@@ -51,7 +51,7 @@ export type MonitoringRequestAsset = {
 
 export type MonitoringRequestDetail = {
   id: string;
-  type: "image" | "video";
+  type: "image" | "video" | "audio";
   status: string;
   model: string | null;
   prompt: string;

--- a/src/features/monitoring-dashboard/ui/monitoring-filters.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-filters.tsx
@@ -30,7 +30,7 @@ import {
 export type MonitoringFilterModel = {
   key: string;
   label: string;
-  type: "image" | "video";
+  type: "image" | "video" | "audio";
 };
 
 export type MonitoringFilterApiKey = {

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
@@ -39,6 +39,7 @@ describe("MonitoringRequestDetailDialog", () => {
           durationMs: 1000,
           progress: 100,
           errorMessage: null,
+          warningMessage: null,
           inputImages: [],
           inputAudios: ["data:audio/wav;base64,UklGRg=="],
           referenceText: "reference words",
@@ -58,5 +59,57 @@ describe("MonitoringRequestDetailDialog", () => {
     expect(screen.getByText("입력 오디오")).toBeTruthy();
     expect(screen.getByText("3s")).toBeTruthy();
     expect(screen.getByText("reference words")).toBeTruthy();
+  });
+
+  it("completed 요청의 안내 메시지는 오류가 아니라 경고로 렌더링한다", () => {
+    renderWithIntl(
+      <MonitoringRequestDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        request={{
+          id: "aud-2",
+          type: "audio" as never,
+          status: "completed",
+          model: "qwen-tts",
+          createdAt: "2026-01-10T10:00:00.000Z",
+          durationMs: 1000,
+          apiKeyLabel: "UI",
+        }}
+        timeZone="UTC"
+        detailOverride={{
+          id: "aud-2",
+          type: "audio" as never,
+          status: "completed",
+          model: "qwen-tts",
+          prompt: "hello audio",
+          createdAt: "2026-01-10T10:00:00.000Z",
+          updatedAt: "2026-01-10T10:00:01.000Z",
+          durationMs: 1000,
+          progress: 100,
+          errorMessage: null,
+          warningMessage:
+            "오디오 저장소가 지정되지 않아 외부 저장소 업로드를 건너뛰고 inline 결과를 사용합니다.",
+          inputImages: [],
+          inputAudios: [],
+          referenceText: null,
+          assets: [
+            {
+              url: "https://example.com/audio.mp3",
+              width: null,
+              height: null,
+              durationSec: 3,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("경고")).toBeTruthy();
+    expect(screen.queryByText("오류")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "오디오 저장소가 지정되지 않아 외부 저장소 업로드를 건너뛰고 inline 결과를 사용합니다.",
+      ),
+    ).toBeTruthy();
   });
 });

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
@@ -1,0 +1,58 @@
+import "@testing-library/jest-dom/vitest";
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MonitoringRequestDetailDialog } from "@/features/monitoring-dashboard/ui/monitoring-request-detail-dialog";
+import { renderWithIntl } from "@/test-utils/intl";
+
+vi.mock("@/features/monitoring-dashboard/hook/use-monitoring-dashboard", () => ({
+  useMonitoringRequestDetail: () => ({
+    data: null,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+describe("MonitoringRequestDetailDialog", () => {
+  it("audio 상세는 오디오 플레이어를 렌더링한다", () => {
+    renderWithIntl(
+      <MonitoringRequestDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        request={{
+          id: "aud-1",
+          type: "audio" as never,
+          status: "completed",
+          model: "qwen-tts",
+          createdAt: "2026-01-10T10:00:00.000Z",
+          durationMs: 1000,
+          apiKeyLabel: "UI",
+        }}
+        timeZone="UTC"
+        detailOverride={{
+          id: "aud-1",
+          type: "audio" as never,
+          status: "completed",
+          model: "qwen-tts",
+          prompt: "hello audio",
+          createdAt: "2026-01-10T10:00:00.000Z",
+          updatedAt: "2026-01-10T10:00:01.000Z",
+          durationMs: 1000,
+          progress: 100,
+          errorMessage: null,
+          inputImages: [],
+          assets: [
+            {
+              url: "https://example.com/audio.mp3",
+              width: null,
+              height: null,
+              durationSec: 3,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(document.querySelector("audio")).not.toBeNull();
+    expect(screen.getByText("3s")).toBeTruthy();
+  });
+});

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
@@ -40,6 +40,8 @@ describe("MonitoringRequestDetailDialog", () => {
           progress: 100,
           errorMessage: null,
           inputImages: [],
+          inputAudios: ["data:audio/wav;base64,UklGRg=="],
+          referenceText: "reference words",
           assets: [
             {
               url: "https://example.com/audio.mp3",
@@ -52,7 +54,8 @@ describe("MonitoringRequestDetailDialog", () => {
       />,
     );
 
-    expect(document.querySelector("audio")).not.toBeNull();
+    expect(document.querySelectorAll("audio")).toHaveLength(2);
     expect(screen.getByText("3s")).toBeTruthy();
+    expect(screen.getByText("reference words")).toBeTruthy();
   });
 });

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
@@ -55,6 +55,7 @@ describe("MonitoringRequestDetailDialog", () => {
     );
 
     expect(document.querySelectorAll("audio")).toHaveLength(2);
+    expect(screen.getByText("입력 오디오")).toBeTruthy();
     expect(screen.getByText("3s")).toBeTruthy();
     expect(screen.getByText("reference words")).toBeTruthy();
   });

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
@@ -42,6 +42,23 @@ function formatResolution(asset: MonitoringRequestDetail["assets"][number]) {
   return `${asset.width}x${asset.height}`;
 }
 
+function resolveInputLabels(
+  detail: MonitoringRequestDetail,
+  t: ReturnType<typeof useTranslations<"monitoringDashboard">>,
+) {
+  if (detail.type === "audio") {
+    return {
+      title: t("requests.detailAudioInputs"),
+      empty: t("requests.detailAudioInputsEmpty"),
+    };
+  }
+
+  return {
+    title: t("requests.detailInputs"),
+    empty: t("requests.detailInputsEmpty"),
+  };
+}
+
 export function MonitoringRequestDetailDialog({
   open,
   onOpenChange,
@@ -85,6 +102,7 @@ export function MonitoringRequestDetailDialog({
     ? resolveMonitoringStatus(detail.status, statusLabels)
     : null;
   const StatusIcon = status?.icon ?? null;
+  const inputLabels = detail ? resolveInputLabels(detail, t) : null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -152,13 +170,13 @@ export function MonitoringRequestDetailDialog({
 
             <div>
               <div className="text-xs font-mono uppercase tracking-widest text-gray-500">
-                {t("requests.detailInputs")}
+                {inputLabels?.title ?? t("requests.detailInputs")}
               </div>
               {detail.inputImages.length === 0 &&
               detail.inputAudios.length === 0 &&
               !detail.referenceText ? (
                 <div className="mt-3 rounded-xl border border-white/10 bg-background-dark/40 p-4 text-sm text-gray-400">
-                  {t("requests.detailInputsEmpty")}
+                  {inputLabels?.empty ?? t("requests.detailInputsEmpty")}
                 </div>
               ) : (
                 <div className="mt-3 grid gap-4 sm:grid-cols-2">

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
@@ -202,6 +202,10 @@ export function MonitoringRequestDetailDialog({
                             className="h-48 w-full object-contain bg-black/70"
                             loading="lazy"
                           />
+                        ) : detail.type === "audio" ? (
+                          <div className="flex h-48 w-full items-center justify-center bg-black/70 p-4">
+                            <audio controls className="w-full" src={asset.url} />
+                          </div>
                         ) : (
                           <video
                             controls

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
@@ -154,7 +154,9 @@ export function MonitoringRequestDetailDialog({
               <div className="text-xs font-mono uppercase tracking-widest text-gray-500">
                 {t("requests.detailInputs")}
               </div>
-              {detail.inputImages.length === 0 ? (
+              {detail.inputImages.length === 0 &&
+              detail.inputAudios.length === 0 &&
+              !detail.referenceText ? (
                 <div className="mt-3 rounded-xl border border-white/10 bg-background-dark/40 p-4 text-sm text-gray-400">
                   {t("requests.detailInputsEmpty")}
                 </div>
@@ -174,6 +176,22 @@ export function MonitoringRequestDetailDialog({
                       <div className="px-3 py-2 text-xs text-gray-400">#{index + 1}</div>
                     </div>
                   ))}
+                  {detail.inputAudios.map((url, index) => (
+                    <div
+                      key={`${url}-audio-${index}`}
+                      className="overflow-hidden rounded-xl border border-white/10 bg-black/30"
+                    >
+                      <div className="flex h-48 w-full items-center justify-center bg-black/70 p-4">
+                        <audio controls className="w-full" src={url} />
+                      </div>
+                      <div className="px-3 py-2 text-xs text-gray-400">#{index + 1}</div>
+                    </div>
+                  ))}
+                  {detail.referenceText ? (
+                    <div className="rounded-xl border border-white/10 bg-background-dark/40 p-4 text-sm text-white sm:col-span-2">
+                      {detail.referenceText}
+                    </div>
+                  ) : null}
                 </div>
               )}
             </div>

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
@@ -273,6 +273,17 @@ export function MonitoringRequestDetailDialog({
                 </div>
               </div>
             ) : null}
+
+            {detail.warningMessage ? (
+              <div>
+                <div className="text-xs font-mono uppercase tracking-widest text-gray-500">
+                  {t("requests.detailWarning")}
+                </div>
+                <div className="mt-2 rounded-xl border border-amber-400/30 bg-amber-500/10 p-4 text-sm text-amber-200">
+                  {detail.warningMessage}
+                </div>
+              </div>
+            ) : null}
           </div>
         ) : null}
 

--- a/src/features/monitoring-dashboard/ui/monitoring-request-table.test.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-table.test.tsx
@@ -135,6 +135,8 @@ describe("MonitoringRequestTable", () => {
       progress: 100,
       errorMessage: null,
       inputImages: [],
+      inputAudios: [],
+      referenceText: null,
       assets: [],
     };
     mockUseMonitoringRequestDetail.mockImplementation(

--- a/src/features/monitoring-dashboard/ui/monitoring-request-table.test.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-table.test.tsx
@@ -134,6 +134,7 @@ describe("MonitoringRequestTable", () => {
       durationMs: 1_000,
       progress: 100,
       errorMessage: null,
+      warningMessage: null,
       inputImages: [],
       inputAudios: [],
       referenceText: null,

--- a/src/features/monitoring-dashboard/ui/monitoring-request-table.test.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-table.test.tsx
@@ -114,9 +114,12 @@ describe("MonitoringRequestTable", () => {
     expect(onOffsetChange).toHaveBeenCalledWith(100);
 
     await user.click(screen.getByRole("combobox"));
-    await user.click(await screen.findByRole("option", { name: "100" }));
-    expect(onLimitChange).toHaveBeenCalledWith(100);
-  });
+    await user.keyboard("{End}{Enter}");
+
+    await waitFor(() => {
+      expect(onLimitChange).toHaveBeenCalledWith(100);
+    });
+  }, 10_000);
 
   it("행 선택 시 상세 모달을 연다", async () => {
     const user = userEvent.setup();

--- a/src/features/monitoring-queue/model/types.ts
+++ b/src/features/monitoring-queue/model/types.ts
@@ -1,5 +1,5 @@
 export type QueueStatusItem = {
-  type: "image" | "video";
+  type: "image" | "video" | "audio";
   model: string;
   pending: number;
   processing: number;

--- a/src/screens/audio-generation/ui/audio-generation-screen.tsx
+++ b/src/screens/audio-generation/ui/audio-generation-screen.tsx
@@ -1,0 +1,53 @@
+import { FolderOpen, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { AudioGenerationForm } from "@/features/audio-generation/ui/audio-generation-form";
+import { GenerationHeaderActions } from "@/shared/ui/generation-header-actions";
+import { PageHeader } from "@/shared/ui/page-header";
+
+type AudioGenerationScreenProps = {
+  isAuthenticated: boolean;
+};
+
+export function AudioGenerationScreen({
+  isAuthenticated,
+}: AudioGenerationScreenProps) {
+  const tAudio = useTranslations("generation.audio");
+  const tCommonActions = useTranslations("common.actions");
+
+  return (
+    <div className="flex flex-col gap-8 pb-20 overflow-x-hidden">
+      <PageHeader
+        title={
+          <>
+            <span className="text-white">{tAudio("title.leading")}</span>{" "}
+            <span className="text-primary">{tAudio("title.accent")}</span>
+          </>
+        }
+        subtitle={tAudio("subtitle")}
+        rightSlot={
+          <GenerationHeaderActions
+            actions={[
+              {
+                label: tCommonActions("loadPreset"),
+                icon: <FolderOpen className="h-4 w-4" />,
+                disabled: true,
+                title: tCommonActions("comingSoon"),
+              },
+              {
+                label: tCommonActions("clear"),
+                icon: <Trash2 className="h-4 w-4" />,
+                disabled: true,
+                title: tCommonActions("comingSoon"),
+              },
+            ]}
+          />
+        }
+        rightSlotClassName="w-full md:w-auto"
+      />
+
+      <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-8">
+        <AudioGenerationForm isAuthenticated={isAuthenticated} />
+      </div>
+    </div>
+  );
+}

--- a/src/screens/model-management/ui/model-management-screen.test.tsx
+++ b/src/screens/model-management/ui/model-management-screen.test.tsx
@@ -10,7 +10,7 @@ import { renderWithIntl } from "@/test-utils/intl";
 
 type AdminModelRecord = {
   id: string;
-  type: "image" | "video";
+  type: "image" | "video" | "audio";
   key: string;
   label: string;
   vendor: string;
@@ -54,25 +54,52 @@ function toRecord(item: ModelCatalogItem): AdminModelRecord {
     };
   }
 
+  if (item.type === "video") {
+    return {
+      ...base,
+      meta: {
+        supports_init_image: item.meta.supportsInitImage,
+        t2v_model_id: item.meta.t2vModelId,
+        i2v_model_id: item.meta.i2vModelId,
+        default_width: item.meta.defaultWidth,
+        default_height: item.meta.defaultHeight,
+        default_duration_sec: item.meta.defaultDurationSec,
+        default_fps: item.meta.defaultFps,
+        default_steps: item.meta.defaultSteps,
+        default_guidance_scale: item.meta.defaultGuidanceScale,
+      },
+    };
+  }
+
   return {
     ...base,
     meta: {
-      supports_init_image: item.meta.supportsInitImage,
-      t2v_model_id: item.meta.t2vModelId,
-      i2v_model_id: item.meta.i2vModelId,
-      default_width: item.meta.defaultWidth,
-      default_height: item.meta.defaultHeight,
-      default_duration_sec: item.meta.defaultDurationSec,
-      default_fps: item.meta.defaultFps,
-      default_steps: item.meta.defaultSteps,
-      default_guidance_scale: item.meta.defaultGuidanceScale,
+      model_id: item.meta.modelId,
+      default_speed: item.meta.defaultSpeed,
+      supports_input_audio: item.meta.supportsInputAudio,
     },
   };
 }
 
-const records = modelCatalog.map((item) => toRecord(item));
+const audioModelFixture: ModelCatalogItem = {
+  type: "audio",
+  key: "qwen-tts-faster",
+  label: "Qwen TTS Faster",
+  vendor: "HUGGINGFACE",
+  provider: "hf_space",
+  isActive: true,
+  isDefault: false,
+  meta: {
+    modelId: "leey00nsu/qwen-3.5-tts-faster-gradio",
+    defaultSpeed: 1,
+    supportsInputAudio: false,
+  },
+};
+
+const records = [...modelCatalog.map((item) => toRecord(item)), toRecord(audioModelFixture)];
 const imageModel = records.find((item) => item.type === "image");
 const videoModel = records.find((item) => item.type === "video");
+const audioModel = records.find((item) => item.type === "audio");
 
 function mockFetch() {
   vi.stubGlobal(
@@ -136,6 +163,7 @@ describe("ModelManagementScreen", () => {
 
   it("모달리티 배지를 표시한다", async () => {
     expect(imageModel).toBeDefined();
+    expect(audioModel).toBeDefined();
     const imageModelLabel = imageModel?.label;
     expect(imageModelLabel).toBeDefined();
 
@@ -151,5 +179,36 @@ describe("ModelManagementScreen", () => {
     expect(screen.getAllByText(/I2I/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/T2V/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/I2V/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/T2A/).length).toBeGreaterThan(0);
+  });
+
+  it("오디오 타입 필터와 생성 폼 기본값을 지원한다", async () => {
+    expect(audioModel).toBeDefined();
+
+    mockFetch();
+
+    const user = userEvent.setup();
+
+    renderWithIntl(<ModelManagementScreen />);
+
+    await screen.findAllByText(audioModel!.label);
+
+    await user.click(screen.getByRole("button", { name: "오디오" }));
+
+    await waitFor(() => {
+      expect(screen.queryAllByText(audioModel!.label).length).toBeGreaterThan(0);
+      expect(screen.queryAllByText(imageModel!.label)).toHaveLength(0);
+      expect(screen.queryAllByText(videoModel!.label)).toHaveLength(0);
+    });
+
+    await user.click(screen.getByRole("button", { name: "모델 추가" }));
+    const typeSelect = screen.getByLabelText("유형");
+    await user.selectOptions(typeSelect, "audio");
+
+    await waitFor(() => {
+      expect(typeSelect).toHaveValue("audio");
+      expect(screen.getByDisplayValue(/generate_audio/)).toBeInTheDocument();
+      expect(screen.getByDisplayValue(/default_speed/)).toBeInTheDocument();
+    });
   });
 });

--- a/src/screens/model-management/ui/model-management-screen.test.tsx
+++ b/src/screens/model-management/ui/model-management-screen.test.tsx
@@ -209,6 +209,70 @@ describe("ModelManagementScreen", () => {
       expect((typeSelect as HTMLSelectElement).value).toBe("audio");
       expect(screen.getByDisplayValue(/generate_audio/)).toBeTruthy();
       expect(screen.getByDisplayValue(/default_speed/)).toBeTruthy();
+      expect(screen.getByDisplayValue(/referenceText/)).toBeTruthy();
+      expect(screen.getByDisplayValue(/inputAudio/)).toBeTruthy();
+    });
+  });
+
+  it("HF Space import로 qwen clone draft를 반영한다", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: records }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          apiNames: ["/toggle_mode", "/run_generation"],
+          resolvedApiName: "/run_generation",
+          warnings: [],
+          draft: {
+            type: "audio",
+            key: "leey00nsu-qwen-3-5-tts-faster-gradio",
+            label: "Faster Qwen3 TTS",
+            vendor: "HUGGINGFACE",
+            provider: "hf_space",
+            isActive: true,
+            isDefault: false,
+            providerConfig: {
+              space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+              api_name: "/run_generation",
+              timeout_ms: 300000,
+            },
+            parameters: {
+              prompt: { ui: "textarea", required: true },
+              inputAudio: { ui: "upload", required: true },
+              referenceText: { ui: "textarea", required: true },
+            },
+            meta: {
+              model_id: "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+              default_speed: 1,
+              concurrent_limit: 1,
+              supports_input_audio: true,
+            },
+          },
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const user = userEvent.setup();
+    renderWithIntl(<ModelManagementScreen />);
+
+    await screen.findAllByText(audioModel!.label);
+
+    await user.click(screen.getByRole("button", { name: "모델 추가" }));
+    await user.type(
+      screen.getByPlaceholderText("https://huggingface.co/spaces/owner/space"),
+      "https://huggingface.co/spaces/leey00nsu/qwen-3.5-tts-faster-gradio",
+    );
+    await user.click(screen.getByRole("button", { name: "가져오기" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByDisplayValue(/run_generation/).length).toBeGreaterThan(0);
+      expect(screen.getByDisplayValue(/supports_input_audio/)).toBeTruthy();
+      expect(screen.getByDisplayValue(/referenceText/)).toBeTruthy();
+      expect(screen.getByDisplayValue(/inputAudio/)).toBeTruthy();
     });
   });
 });

--- a/src/screens/model-management/ui/model-management-screen.test.tsx
+++ b/src/screens/model-management/ui/model-management-screen.test.tsx
@@ -206,9 +206,9 @@ describe("ModelManagementScreen", () => {
     await user.selectOptions(typeSelect, "audio");
 
     await waitFor(() => {
-      expect(typeSelect).toHaveValue("audio");
-      expect(screen.getByDisplayValue(/generate_audio/)).toBeInTheDocument();
-      expect(screen.getByDisplayValue(/default_speed/)).toBeInTheDocument();
+      expect((typeSelect as HTMLSelectElement).value).toBe("audio");
+      expect(screen.getByDisplayValue(/generate_audio/)).toBeTruthy();
+      expect(screen.getByDisplayValue(/default_speed/)).toBeTruthy();
     });
   });
 });

--- a/src/screens/model-management/ui/model-management-screen.tsx
+++ b/src/screens/model-management/ui/model-management-screen.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  AudioLines,
   Grid2X2,
   Image as ImageIcon,
   Loader2,
@@ -54,7 +55,7 @@ import {
 const DEFAULT_VENDOR = "HUGGINGFACE";
 const DEFAULT_PROVIDER = "hf_space";
 
-type ModelType = "image" | "video";
+type ModelType = "image" | "video" | "audio";
 type VendorOption = "HUGGINGFACE" | "API";
 
 const vendorOptions: Array<{ value: VendorOption; disabled?: boolean }> = [
@@ -110,6 +111,12 @@ const defaultVideoProviderConfig = {
   timeout_ms: 300000,
 };
 
+const defaultAudioProviderConfig = {
+  space_id: "owner/space",
+  api_name: "/generate_audio",
+  timeout_ms: 300000,
+};
+
 const defaultImageParameters = {
   prompt: { ui: "textarea", required: true },
   width: { ui: "input", min: 512, max: 2048, step: 1, default: 1024 },
@@ -129,6 +136,13 @@ const defaultVideoParameters = {
   aspectRatio: { ui: "select", options: ["16:9", "9:16", "1:1"], default: "16:9" },
   resolution: { ui: "select", options: [480, 640, 720, 832], default: 720 },
   fps: { ui: "hidden", min: 16, max: 16, step: 1, default: 16 },
+};
+
+const defaultAudioParameters = {
+  prompt: { ui: "textarea", required: true },
+  voice: { ui: "input", default: "default" },
+  speed: { ui: "range", min: 0.25, max: 4, step: 0.05, default: 1 },
+  seed: { ui: "input", default: "" },
 };
 
 const defaultImageMeta = {
@@ -154,6 +168,13 @@ const defaultVideoMeta = {
   concurrent_limit: 1,
 };
 
+const defaultAudioMeta = {
+  model_id: "owner/model",
+  default_speed: 1,
+  concurrent_limit: 1,
+  supports_input_audio: false,
+};
+
 const safeString = (value: unknown, fallback: string) =>
   typeof value === "string" && value.trim() ? value : fallback;
 
@@ -174,6 +195,24 @@ const resolvePipeline = (value: unknown): PipelineOption =>
     ? (value as PipelineOption)
     : "diffusion";
 
+function getDefaultProviderConfig(type: ModelType) {
+  if (type === "image") return defaultImageProviderConfig;
+  if (type === "video") return defaultVideoProviderConfig;
+  return defaultAudioProviderConfig;
+}
+
+function getDefaultParameters(type: ModelType) {
+  if (type === "image") return defaultImageParameters;
+  if (type === "video") return defaultVideoParameters;
+  return defaultAudioParameters;
+}
+
+function getDefaultMeta(type: ModelType) {
+  if (type === "image") return defaultImageMeta;
+  if (type === "video") return defaultVideoMeta;
+  return defaultAudioMeta;
+}
+
 function buildDraft(type: ModelType): ModelDraft {
   return {
     type,
@@ -183,13 +222,9 @@ function buildDraft(type: ModelType): ModelDraft {
     provider: DEFAULT_PROVIDER,
     isActive: true,
     isDefault: false,
-    providerConfigText: stringifyJson(
-      type === "image" ? defaultImageProviderConfig : defaultVideoProviderConfig,
-    ),
-    parametersText: stringifyJson(
-      type === "image" ? defaultImageParameters : defaultVideoParameters,
-    ),
-    metaText: stringifyJson(type === "image" ? defaultImageMeta : defaultVideoMeta),
+    providerConfigText: stringifyJson(getDefaultProviderConfig(type)),
+    parametersText: stringifyJson(getDefaultParameters(type)),
+    metaText: stringifyJson(getDefaultMeta(type)),
   };
 }
 
@@ -235,20 +270,32 @@ function toCatalogItem(record: AdminModelRecord): ModelCatalogItem {
     };
   }
 
+  if (record.type === "video") {
+    return {
+      ...base,
+      type: "video",
+      meta: {
+        supportsInitImage: safeBoolean(meta.supports_init_image, false),
+        t2vModelId: safeString(meta.t2v_model_id, record.key),
+        i2vModelId:
+          typeof meta.i2v_model_id === "string" ? meta.i2v_model_id : null,
+        defaultWidth: safeNumber(meta.default_width, 832),
+        defaultHeight: safeNumber(meta.default_height, 480),
+        defaultDurationSec: safeNumber(meta.default_duration_sec, 3),
+        defaultFps: safeNumber(meta.default_fps, 16),
+        defaultSteps: safeNumber(meta.default_steps, 6),
+        defaultGuidanceScale: safeNumber(meta.default_guidance_scale, 1),
+      },
+    };
+  }
+
   return {
     ...base,
-    type: "video",
+    type: "audio",
     meta: {
-      supportsInitImage: safeBoolean(meta.supports_init_image, false),
-      t2vModelId: safeString(meta.t2v_model_id, record.key),
-      i2vModelId:
-        typeof meta.i2v_model_id === "string" ? meta.i2v_model_id : null,
-      defaultWidth: safeNumber(meta.default_width, 832),
-      defaultHeight: safeNumber(meta.default_height, 480),
-      defaultDurationSec: safeNumber(meta.default_duration_sec, 3),
-      defaultFps: safeNumber(meta.default_fps, 16),
-      defaultSteps: safeNumber(meta.default_steps, 6),
-      defaultGuidanceScale: safeNumber(meta.default_guidance_scale, 1),
+      modelId: safeString(meta.model_id, record.key),
+      defaultSpeed: safeNumber(meta.default_speed, 1),
+      supportsInputAudio: safeBoolean(meta.supports_input_audio, false),
     },
   };
 }
@@ -705,6 +752,14 @@ export function ModelManagementScreen() {
           >
             {tCommonLabels("videos")}
           </DashboardFilterToggle>
+          <DashboardFilterToggle
+            onClick={() => setType("audio")}
+            aria-pressed={type === "audio"}
+            active={type === "audio"}
+            icon={<AudioLines className="h-4 w-4" />}
+          >
+            {tCommonLabels("audios")}
+          </DashboardFilterToggle>
           <DashboardFilterDivider />
           <span className="text-xs font-mono uppercase tracking-widest text-gray-500">
             {tCommonLabels("total", { total: filteredModels.length })}
@@ -861,10 +916,14 @@ export function ModelManagementScreen() {
             ) : null}
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <Label className="text-xs font-mono uppercase tracking-widest text-gray-500">
+                <Label
+                  htmlFor="model-type"
+                  className="text-xs font-mono uppercase tracking-widest text-gray-500"
+                >
                   {tAdmin("fields.type")}
                 </Label>
                 <select
+                  id="model-type"
                   value={draft.type}
                   onChange={(event) => updateType(event.target.value as ModelType)}
                   disabled={dialogMode === "edit"}
@@ -872,6 +931,7 @@ export function ModelManagementScreen() {
                 >
                   <option value="image">{tCommonLabels("images")}</option>
                   <option value="video">{tCommonLabels("videos")}</option>
+                  <option value="audio">{tCommonLabels("audios")}</option>
                 </select>
               </div>
               <div className="space-y-2">

--- a/src/screens/model-management/ui/model-management-screen.tsx
+++ b/src/screens/model-management/ui/model-management-screen.tsx
@@ -143,6 +143,8 @@ const defaultAudioParameters = {
   voice: { ui: "input", default: "default" },
   speed: { ui: "range", min: 0.25, max: 4, step: 0.05, default: 1 },
   seed: { ui: "input", default: "" },
+  inputAudio: { ui: "upload" },
+  referenceText: { ui: "textarea" },
 };
 
 const defaultImageMeta = {

--- a/src/server/audio-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.test.ts
@@ -406,4 +406,90 @@ describe("hfSpaceAudioAdapter", () => {
       }),
     );
   });
+
+  it("동일 asset의 여러 file reference 중 하나만 성공해도 생성 성공으로 처리한다", async () => {
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts-mixed-refs",
+        label: "Qwen TTS Mixed Refs",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/run_generation",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+          speaker: {
+            ui: "select",
+            default: "Vivian",
+            options: ["Vivian"],
+          },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          concurrent_limit: 1,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/run_generation": {
+            parameters: [{ parameter_name: "text", label: "Text" }],
+          },
+        },
+      }),
+      predict: vi.fn().mockResolvedValue({
+        data: [
+          {
+            audio: {
+              url: "https://leey00nsu-qwen-3-5-tts-faster-gradio.hf.space/gradio_api/file=/tmp/gradio/job-1/audio.wav",
+              path: "/tmp/gradio/job-1/audio.wav",
+              name: "audio.wav",
+            },
+          },
+        ],
+      }),
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "application/octet-stream" }),
+        arrayBuffer: async () => Uint8Array.from([82, 73, 70, 70]).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    const result = await hfSpaceAudioAdapter.generate({
+      prompt: "hello",
+      model: "qwen-tts-mixed-refs",
+      speed: 1,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://leey00nsu-qwen-3-5-tts-faster-gradio.hf.space/gradio_api/file=/tmp/gradio/job-1/audio.wav",
+      expect.objectContaining({}),
+    );
+    expect(result).toEqual({
+      audios: ["data:application/octet-stream;base64,UklGRg=="],
+      meta: { duration_sec: undefined },
+    });
+  });
 });

--- a/src/server/audio-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.test.ts
@@ -111,6 +111,11 @@ describe("hfSpaceAudioAdapter", () => {
       "https://huggingface.co/api/spaces/leey00nsu/qwen-3.5-tts-faster-gradio",
       expect.objectContaining({})
     );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://leey00nsu-qwen-3.5-tts-faster-gradio.hf.space/gradio_api/file=/tmp/generated.wav",
+      expect.objectContaining({})
+    );
     expect(result).toEqual({
       audios: ["data:audio/wav;base64,UklGRg=="],
       meta: { duration_sec: 3.2 },
@@ -130,6 +135,18 @@ describe("hfSpaceAudioAdapter", () => {
     );
     expect(hfSpaceAudioAdapter.mapError?.(new Error("HF_SPACE_RESPONSE_INVALID"))).toBe(
       "HF Space 응답에서 오디오 결과를 찾지 못했습니다."
+    );
+    expect(
+      hfSpaceAudioAdapter.mapError?.({
+        title: "ZeroGPU quota exceeded",
+        message:
+          "You have exceeded your GPU quota (120s requested vs. 100s left).",
+      }),
+    ).toBe(
+      "ZeroGPU 일일 쿼터를 초과했습니다. 내일 다시 시도하거나 다른 제공자를 사용해주세요."
+    );
+    expect(hfSpaceAudioAdapter.mapError?.(new TypeError("fetch failed"))).toBe(
+      "HF Space 통신 중 네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
     );
   });
 
@@ -230,5 +247,163 @@ describe("hfSpaceAudioAdapter", () => {
       }),
     );
     expect(mockHandleFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("mode 기반 TTS 파라미터를 run_generation payload로 전달하고 speaker 기본값을 사용한다", async () => {
+    const predict = vi.fn().mockResolvedValue({
+      data: [
+        "ok",
+        {
+          path: "/file=/tmp/generated.wav",
+        },
+      ],
+    });
+
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts-mode",
+        label: "Qwen TTS Mode",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/run_generation",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+          modeChoice: {
+            ui: "select",
+            default: "voice_clone",
+            options: ["voice_clone", "custom", "voice_design"],
+          },
+          language: {
+            ui: "select",
+            default: "English",
+            options: ["English", "Korean"],
+          },
+          speaker: {
+            ui: "select",
+            default: "Vivian",
+            options: ["Vivian", "Serena"],
+          },
+          streamMode: { ui: "toggle", default: true },
+          inputAudio: { ui: "upload" },
+          referenceText: { ui: "textarea" },
+          referencePreset: {
+            ui: "select",
+            default: "ref_audio_3",
+            options: ["ref_audio_1", "ref_audio_3"],
+          },
+          xvecOnly: { ui: "toggle", default: false },
+          chunkSize: { ui: "range", default: 120, min: 40, max: 200, step: 10 },
+          temperature: { ui: "range", default: 0.7, min: 0.1, max: 1.2, step: 0.1 },
+          topK: { ui: "range", default: 20, min: 1, max: 100, step: 1 },
+          repetitionPenalty: {
+            ui: "range",
+            default: 1.1,
+            min: 1,
+            max: 2,
+            step: 0.1,
+          },
+          voiceInstruction: { ui: "textarea" },
+          customInstruction: { ui: "textarea" },
+          seed: { ui: "input" },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: true,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/run_generation": {
+            parameters: [
+              { parameter_name: "text", label: "Text" },
+              { parameter_name: "language", label: "Language", parameter_default: "English" },
+              { parameter_name: "mode", label: "Generation Mode", parameter_default: "voice_clone" },
+              { parameter_name: "stream_mode", label: "Streaming", parameter_default: true },
+              { parameter_name: "ref_audio_path", label: "Reference Audio" },
+              { parameter_name: "ref_text", label: "Reference Transcript (for advanced ICL mode)" },
+              { parameter_name: "speaker", label: "Speaker", parameter_default: "Vivian" },
+              { parameter_name: "ref_preset", label: "Reference Preset", parameter_default: "ref_audio_3" },
+              { parameter_name: "xvec_only", label: "xvec only", parameter_default: false },
+              { parameter_name: "chunk_size", label: "Chunk Size", parameter_default: 120 },
+              { parameter_name: "temperature", label: "Temperature", parameter_default: 0.7 },
+              { parameter_name: "top_k", label: "Top K", parameter_default: 20 },
+              { parameter_name: "repetition_penalty", label: "Repetition Penalty", parameter_default: 1.1 },
+            ],
+          },
+        },
+      }),
+      predict,
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "audio/wav" }),
+        arrayBuffer: async () => Uint8Array.from([82, 73, 70, 70]).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    const payload = {
+      prompt: "hello clone",
+      model: "qwen-tts-mode",
+      voice: "",
+      speed: 1,
+      seed: "11",
+      inputAudio: "data:audio/wav;base64,UklGRg==",
+      referenceText: "reference words",
+      modeChoice: "voice_clone",
+      language: "English",
+      speaker: "",
+      streamMode: true,
+      referencePreset: "ref_audio_3",
+      xvecOnly: false,
+      chunkSize: 120,
+      temperature: 0.7,
+      topK: 20,
+      repetitionPenalty: 1.1,
+    };
+
+    await hfSpaceAudioAdapter.generate(payload);
+
+    expect(predict).toHaveBeenCalledWith(
+      "/run_generation",
+      expect.objectContaining({
+        text: "hello clone",
+        language: "English",
+        mode: "voice_clone",
+        stream_mode: true,
+        ref_audio_path: expect.anything(),
+        ref_text: "reference words",
+        speaker: "Vivian",
+        ref_preset: "ref_audio_3",
+        xvec_only: false,
+        chunk_size: 120,
+        temperature: 0.7,
+        top_k: 20,
+        repetition_penalty: 1.1,
+      }),
+    );
   });
 });

--- a/src/server/audio-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.test.ts
@@ -2,11 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockConnect = vi.hoisted(() => vi.fn());
 const mockGetModelCatalog = vi.hoisted(() => vi.fn());
+const mockHandleFile = vi.hoisted(() => vi.fn((value) => ({ mockedFile: value })));
 
 vi.mock("@gradio/client", () => ({
   Client: {
     connect: mockConnect,
   },
+  handle_file: mockHandleFile,
 }));
 
 vi.mock("@/server/model-catalog/catalog-service", () => ({
@@ -129,5 +131,104 @@ describe("hfSpaceAudioAdapter", () => {
     expect(hfSpaceAudioAdapter.mapError?.(new Error("HF_SPACE_RESPONSE_INVALID"))).toBe(
       "HF Space 응답에서 오디오 결과를 찾지 못했습니다."
     );
+  });
+
+  it("reference audio와 reference text를 run_generation payload로 전달한다", async () => {
+    const predict = vi.fn().mockResolvedValue({
+      data: [
+        "ok",
+        {
+          path: "/file=/tmp/generated.wav",
+        },
+      ],
+    });
+
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts-clone",
+        label: "Qwen TTS Clone",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/run_generation",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+          inputAudio: { ui: "upload", required: true },
+          referenceText: { ui: "textarea", required: true },
+          voice: { ui: "input", default: "Vivian" },
+          speed: { ui: "range", min: 0.25, max: 4, step: 0.05, default: 1 },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: true,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/run_generation": {
+            parameters: [
+              { parameter_name: "model_id", label: "Model", parameter_default: "Qwen/Qwen3-TTS-12Hz-1.7B-Base" },
+              { parameter_name: "text", label: "Text" },
+              { parameter_name: "language", label: "Language", parameter_default: "English" },
+              { parameter_name: "mode", label: "Generation Mode", parameter_default: "voice_clone" },
+              { parameter_name: "stream_mode", label: "Streaming", parameter_default: true },
+              { parameter_name: "ref_audio_path", label: "Reference Audio" },
+              { parameter_name: "ref_preset", label: "Reference Preset", parameter_default: "ref_audio_3" },
+              { parameter_name: "ref_text", label: "Reference Transcript (for advanced ICL mode)" },
+            ],
+          },
+        },
+      }),
+      predict,
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "audio/wav" }),
+        arrayBuffer: async () => Uint8Array.from([82, 73, 70, 70]).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    await hfSpaceAudioAdapter.generate({
+      prompt: "hello clone",
+      model: "qwen-tts-clone",
+      voice: "Vivian",
+      speed: 1,
+      seed: "",
+      inputAudio: "data:audio/wav;base64,UklGRg==",
+      referenceText: "reference words",
+    });
+
+    expect(predict).toHaveBeenCalledWith(
+      "/run_generation",
+      expect.objectContaining({
+        text: "hello clone",
+        ref_text: "reference words",
+        ref_audio_path: expect.anything(),
+      }),
+    );
+    expect(mockHandleFile).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/audio-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockConnect = vi.hoisted(() => vi.fn());
+const mockGetModelCatalog = vi.hoisted(() => vi.fn());
+
+vi.mock("@gradio/client", () => ({
+  Client: {
+    connect: mockConnect,
+  },
+}));
+
+vi.mock("@/server/model-catalog/catalog-service", () => ({
+  getModelCatalog: mockGetModelCatalog,
+}));
+
+describe("hfSpaceAudioAdapter", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("HF Space 응답의 파일 경로를 data URL 결과로 정규화한다", async () => {
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts",
+        label: "Qwen TTS",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/generate_audio",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+          voice: { ui: "input", default: "default" },
+          speed: { ui: "range", min: 0.25, max: 4, step: 0.05, default: 1 },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: false,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/generate_audio": {
+            parameters: [
+              { parameter_name: "prompt", label: "Prompt" },
+              { parameter_name: "voice", label: "Voice" },
+              { parameter_name: "speed", label: "Speed" },
+              { parameter_name: "seed", label: "Seed" },
+            ],
+          },
+        },
+      }),
+      predict: vi.fn().mockResolvedValue({
+        data: [
+          {
+            audio: {
+              path: "/file=/tmp/generated.wav",
+              duration_sec: 3.2,
+            },
+          },
+        ],
+      }),
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "audio/wav" }),
+        arrayBuffer: async () =>
+          Uint8Array.from([82, 73, 70, 70]).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    const result = await hfSpaceAudioAdapter.generate({
+      prompt: "hello",
+      model: "qwen-tts",
+      voice: "alloy",
+      speed: 1.25,
+      seed: "42",
+    });
+
+    expect(mockConnect).toHaveBeenCalledWith(
+      "leey00nsu/qwen-3.5-tts-faster-gradio",
+      { token: undefined },
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://huggingface.co/api/spaces/leey00nsu/qwen-3.5-tts-faster-gradio",
+      expect.objectContaining({})
+    );
+    expect(result).toEqual({
+      audios: ["data:audio/wav;base64,UklGRg=="],
+      meta: { duration_sec: 3.2 },
+    });
+  });
+
+  it("quota/sleep 오류를 사용자 친화적으로 매핑한다", async () => {
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    expect(hfSpaceAudioAdapter.mapError?.(new Error("ZeroGPU quota exceeded"))).toBe(
+      "ZeroGPU 일일 쿼터를 초과했습니다. 내일 다시 시도하거나 다른 제공자를 사용해주세요."
+    );
+    expect(hfSpaceAudioAdapter.mapError?.(new Error("Space is sleeping"))).toBe(
+      "HF Space가 준비 중입니다. 잠시 후 다시 시도해주세요."
+    );
+    expect(hfSpaceAudioAdapter.mapError?.(new Error("HF_SPACE_RESPONSE_INVALID"))).toBe(
+      "HF Space 응답에서 오디오 결과를 찾지 못했습니다."
+    );
+  });
+});

--- a/src/server/audio-generation/adapters/hf-space-adapter.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.ts
@@ -2,6 +2,10 @@ import { Client, handle_file } from "@gradio/client";
 import { z } from "zod";
 import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
 import type { AudioGenerationAdapter } from "@/server/audio-generation/adapters/types";
+import {
+  resolveHfSpaceFileReferenceCandidates,
+  resolveHfSpaceFileReference,
+} from "@/server/hf-space/file-reference-resolver";
 import { getModelCatalog } from "@/server/model-catalog/catalog-service";
 import type { AudioModelCatalogItem } from "@/server/model-catalog/catalog-schema";
 import {
@@ -472,25 +476,6 @@ async function buildRequestPayload(
   return requestPayload;
 }
 
-function extractFileUrl(file: unknown) {
-  if (!file) return null;
-  if (typeof file === "string") return file;
-  if (typeof file !== "object") return null;
-  const candidate = file as {
-    url?: unknown;
-    path?: unknown;
-    name?: unknown;
-    data?: unknown;
-  };
-  if (typeof candidate.data === "string" && candidate.data.startsWith("data:")) {
-    return candidate.data;
-  }
-  if (typeof candidate.url === "string") return candidate.url;
-  if (typeof candidate.path === "string") return candidate.path;
-  if (typeof candidate.name === "string") return candidate.name;
-  return null;
-}
-
 function looksLikeAudioPath(value: string) {
   const trimmed = value.trim().toLowerCase();
   if (!trimmed) return false;
@@ -498,50 +483,6 @@ function looksLikeAudioPath(value: string) {
   if (trimmed.includes("file=") || trimmed.includes("/file/")) return true;
   if (/\.(mp3|wav|flac|ogg|m4a|aac|webm)(\?|$)/.test(trimmed)) return true;
   return false;
-}
-
-function collectAudioFileUrls(value: unknown, urls: Set<string>, depth = 0) {
-  if (depth > 4 || value === null || value === undefined) return;
-
-  if (typeof value === "string") {
-    if (looksLikeAudioPath(value)) {
-      urls.add(value);
-    }
-    return;
-  }
-
-  if (Array.isArray(value)) {
-    value.forEach((item) => collectAudioFileUrls(item, urls, depth + 1));
-    return;
-  }
-
-  if (typeof value !== "object") return;
-
-  const direct = extractFileUrl(value);
-  if (direct && looksLikeAudioPath(direct)) {
-    urls.add(direct);
-  }
-
-  Object.values(value as Record<string, unknown>).forEach((item) =>
-    collectAudioFileUrls(item, urls, depth + 1),
-  );
-}
-
-function normalizeFileUrl(fileUrl: string, spaceUrl: string) {
-  if (fileUrl.startsWith("data:")) return fileUrl;
-  if (fileUrl.startsWith("http://") || fileUrl.startsWith("https://")) {
-    return fileUrl;
-  }
-  if (fileUrl.startsWith("/gradio_api/file=")) {
-    return `${spaceUrl}${fileUrl}`;
-  }
-  if (fileUrl.startsWith("/file=")) {
-    return `${spaceUrl}/gradio_api${fileUrl}`;
-  }
-  if (fileUrl.startsWith("file=")) {
-    return `${spaceUrl}/gradio_api/${fileUrl}`;
-  }
-  return `${spaceUrl}/gradio_api/file=${fileUrl}`;
 }
 
 function dataUrlToBlob(dataUrl: string) {
@@ -562,11 +503,15 @@ function toGradioInputAudio(inputAudio: string) {
 }
 
 async function fetchAudioDataUrl(
-  fileUrl: string,
+  fileRef: string | ReturnType<typeof resolveHfSpaceFileReference>,
   spaceUrl: string,
   timeoutMs: number = FILE_FETCH_TIMEOUT_MS,
 ) {
-  const normalized = normalizeFileUrl(fileUrl, spaceUrl);
+  const resolvedFile =
+    typeof fileRef === "string"
+      ? resolveHfSpaceFileReference(fileRef, spaceUrl)
+      : fileRef;
+  const normalized = resolvedFile.normalizedUrl;
   if (normalized.startsWith("data:")) {
     return normalized;
   }
@@ -751,22 +696,40 @@ export const hfSpaceAudioAdapter: AudioGenerationAdapter = {
     }
 
     const rawData = Array.isArray(result?.data) ? result.data : result;
-    const audioUrls = new Set<string>();
-    collectAudioFileUrls(rawData, audioUrls);
+    const audioGroups = resolveHfSpaceFileReferenceCandidates(rawData, {
+      spaceUrl: config.spaceUrl,
+      matcher: looksLikeAudioPath,
+      maxDepth: 4,
+    });
 
-    if (audioUrls.size === 0) {
+    if (audioGroups.length === 0) {
       throw new Error("HF_SPACE_RESPONSE_INVALID");
     }
 
-    const dataUrls = await Promise.all(
-      Array.from(audioUrls).map((url) =>
-        fetchAudioDataUrl(
-          url,
-          config.spaceUrl,
-          Math.min(config.timeoutMs, FILE_FETCH_TIMEOUT_MS),
-        ),
-      ),
-    );
+    const dataUrls: string[] = [];
+    for (const group of audioGroups) {
+      let lastError: Error | null = null;
+      let resolvedDataUrl: string | null = null;
+
+      for (const candidate of group.candidates) {
+        try {
+          resolvedDataUrl = await fetchAudioDataUrl(
+            candidate,
+            config.spaceUrl,
+            Math.min(config.timeoutMs, FILE_FETCH_TIMEOUT_MS),
+          );
+          break;
+        } catch (error) {
+          lastError = error instanceof Error ? error : new Error(String(error));
+        }
+      }
+
+      if (!resolvedDataUrl) {
+        throw lastError ?? new Error("HF_SPACE_AUDIO_FETCH_FAILED");
+      }
+
+      dataUrls.push(resolvedDataUrl);
+    }
 
     return {
       audios: dataUrls,

--- a/src/server/audio-generation/adapters/hf-space-adapter.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.ts
@@ -1,4 +1,4 @@
-import { Client } from "@gradio/client";
+import { Client, handle_file } from "@gradio/client";
 import { z } from "zod";
 import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
 import type { AudioGenerationAdapter } from "@/server/audio-generation/adapters/types";
@@ -248,6 +248,23 @@ function resolveParamValue(
   const lookup = normalizeLookupKey(parameter);
 
   if (
+    lookup.includes("reference transcript") ||
+    lookup.includes("reference text") ||
+    lookup.includes("ref text") ||
+    lookup.includes("ref_text")
+  ) {
+    return payload.referenceText?.trim() || parameter.parameter_default;
+  }
+
+  if (
+    lookup.includes("reference audio") ||
+    lookup.includes("ref audio") ||
+    lookup.includes("ref_audio")
+  ) {
+    return payload.inputAudio ? toGradioInputAudio(payload.inputAudio) : parameter.parameter_default;
+  }
+
+  if (
     lookup.includes("prompt") ||
     lookup.includes("text") ||
     lookup.includes("script") ||
@@ -395,6 +412,23 @@ function normalizeFileUrl(fileUrl: string, spaceUrl: string) {
     return `${spaceUrl}/${fileUrl}`;
   }
   return `${spaceUrl}/file=${fileUrl}`;
+}
+
+function dataUrlToBlob(dataUrl: string) {
+  const match = dataUrl.match(/^data:([^;]+);base64,(.+)$/);
+  if (!match) {
+    throw new Error("HF_SPACE_INPUT_AUDIO_INVALID");
+  }
+  return new Blob([Buffer.from(match[2], "base64")], {
+    type: match[1],
+  });
+}
+
+function toGradioInputAudio(inputAudio: string) {
+  if (inputAudio.startsWith("data:")) {
+    return handle_file(dataUrlToBlob(inputAudio));
+  }
+  return handle_file(inputAudio);
 }
 
 async function fetchAudioDataUrl(

--- a/src/server/audio-generation/adapters/hf-space-adapter.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.ts
@@ -185,10 +185,38 @@ async function ensureSpaceRunning(config: SpaceConfig) {
     }
   } catch (error) {
     statusCache.set(config.spaceId, { checkedAt: Date.now(), ok: false });
-    throw error;
+    if (controller.signal.aborted) {
+      throw new Error("HF_SPACE_STATUS_FETCH_FAILED");
+    }
+    if (error instanceof Error && error.message === "HF_SPACE_STATUS_FETCH_FAILED") {
+      throw error;
+    }
+    throw new Error("HF_SPACE_STATUS_FETCH_FAILED");
   } finally {
     clearTimeout(timeoutId);
   }
+}
+
+function extractErrorText(error: unknown) {
+  if (error instanceof Error) {
+    return error.message || "";
+  }
+  if (!error || typeof error !== "object") {
+    return "";
+  }
+
+  const record = error as Record<string, unknown>;
+  const candidates = [
+    record.message,
+    record.title,
+    record.original_msg,
+    record.stage,
+  ];
+
+  return candidates
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join(" ")
+    .trim();
 }
 
 function normalizeApiName(value: string) {
@@ -241,7 +269,7 @@ function normalizeLookupKey(parameter: EndpointParameter) {
 function resolveParamValue(
   parameter: EndpointParameter,
   payload: AudioGenerationFormValues,
-  defaults: { voice: string; speed: number },
+  defaults: ReturnType<typeof resolveRuntimeAudioDefaults>,
   speed: number,
   seed: { seedValue: number; randomize: boolean },
 ) {
@@ -264,6 +292,10 @@ function resolveParamValue(
     return payload.inputAudio ? toGradioInputAudio(payload.inputAudio) : parameter.parameter_default;
   }
 
+  if (lookup.includes("reference preset") || lookup.includes("ref preset") || lookup.includes("ref_preset")) {
+    return payload.referencePreset?.trim() || defaults.referencePreset || parameter.parameter_default;
+  }
+
   if (
     lookup.includes("prompt") ||
     lookup.includes("text") ||
@@ -273,12 +305,63 @@ function resolveParamValue(
     return payload.prompt;
   }
 
+  if (lookup.includes("language")) {
+    return payload.language?.trim() || defaults.language || parameter.parameter_default;
+  }
+
+  if (lookup.includes("stream mode") || lookup.includes("stream_mode")) {
+    return payload.streamMode ?? defaults.streamMode ?? parameter.parameter_default;
+  }
+
+  if (lookup.includes("custom instruction") || lookup.includes("custom_instruct")) {
+    return payload.customInstruction?.trim() || parameter.parameter_default;
+  }
+
+  if (lookup.includes("voice instruction") || lookup.includes("voice_instruct")) {
+    return payload.voiceInstruction?.trim() || parameter.parameter_default;
+  }
+
+  if (lookup.includes("xvec")) {
+    return payload.xvecOnly ?? defaults.xvecOnly ?? parameter.parameter_default;
+  }
+
+  if (lookup.includes("chunk size") || lookup.includes("chunk_size")) {
+    return payload.chunkSize ?? defaults.chunkSize ?? parameter.parameter_default;
+  }
+
+  if (lookup.includes("temperature")) {
+    return payload.temperature ?? defaults.temperature ?? parameter.parameter_default;
+  }
+
+  if (lookup.includes("top k") || lookup.includes("top_k")) {
+    return payload.topK ?? defaults.topK ?? parameter.parameter_default;
+  }
+
+  if (lookup.includes("repetition penalty") || lookup.includes("repetition_penalty")) {
+    return payload.repetitionPenalty ?? defaults.repetitionPenalty ?? parameter.parameter_default;
+  }
+
+  if (lookup === "mode" || lookup.includes("generation mode")) {
+    return (
+      payload.modeChoice?.trim() ||
+      (payload.inputAudio ? "voice_clone" : "") ||
+      defaults.modeChoice ||
+      parameter.parameter_default
+    );
+  }
+
   if (
     lookup.includes("voice") ||
     lookup.includes("speaker") ||
     lookup.includes("spk")
   ) {
-    return payload.voice?.trim() || defaults.voice;
+    return (
+      payload.speaker?.trim() ||
+      payload.voice?.trim() ||
+      defaults.speaker ||
+      defaults.voice ||
+      parameter.parameter_default
+    );
   }
 
   if (lookup.includes("speed") || lookup.includes("rate")) {
@@ -300,7 +383,7 @@ async function buildRequestPayload(
   client: Client,
   apiName: string,
   payload: AudioGenerationFormValues,
-  defaults: { voice: string; speed: number },
+  defaults: ReturnType<typeof resolveRuntimeAudioDefaults>,
   speed: number,
   seed: { seedValue: number; randomize: boolean },
 ) {
@@ -315,8 +398,52 @@ async function buildRequestPayload(
     if (payload.voice?.trim()) {
       fallbackPayload.voice = payload.voice.trim();
     }
+    if (payload.speaker?.trim()) {
+      fallbackPayload.speaker = payload.speaker.trim();
+    }
     if (typeof payload.speed === "number") {
       fallbackPayload.speed = speed;
+    }
+    if (payload.modeChoice?.trim()) {
+      fallbackPayload.mode = payload.modeChoice.trim();
+    } else if (payload.inputAudio) {
+      fallbackPayload.mode = "voice_clone";
+    }
+    if (payload.language?.trim()) {
+      fallbackPayload.language = payload.language.trim();
+    }
+    if (typeof payload.streamMode === "boolean") {
+      fallbackPayload.stream_mode = payload.streamMode;
+    }
+    if (payload.referencePreset?.trim()) {
+      fallbackPayload.ref_preset = payload.referencePreset.trim();
+    }
+    if (payload.inputAudio) {
+      fallbackPayload.ref_audio_path = toGradioInputAudio(payload.inputAudio);
+    }
+    if (payload.referenceText?.trim()) {
+      fallbackPayload.ref_text = payload.referenceText.trim();
+    }
+    if (payload.customInstruction?.trim()) {
+      fallbackPayload.custom_instruct = payload.customInstruction.trim();
+    }
+    if (payload.voiceInstruction?.trim()) {
+      fallbackPayload.voice_instruct = payload.voiceInstruction.trim();
+    }
+    if (typeof payload.xvecOnly === "boolean") {
+      fallbackPayload.xvec_only = payload.xvecOnly;
+    }
+    if (typeof payload.chunkSize === "number") {
+      fallbackPayload.chunk_size = payload.chunkSize;
+    }
+    if (typeof payload.temperature === "number") {
+      fallbackPayload.temperature = payload.temperature;
+    }
+    if (typeof payload.topK === "number") {
+      fallbackPayload.top_k = payload.topK;
+    }
+    if (typeof payload.repetitionPenalty === "number") {
+      fallbackPayload.repetition_penalty = payload.repetitionPenalty;
     }
     if (!seed.randomize) {
       fallbackPayload.seed = seed.seedValue;
@@ -405,13 +532,16 @@ function normalizeFileUrl(fileUrl: string, spaceUrl: string) {
   if (fileUrl.startsWith("http://") || fileUrl.startsWith("https://")) {
     return fileUrl;
   }
-  if (fileUrl.startsWith("/")) {
+  if (fileUrl.startsWith("/gradio_api/file=")) {
     return `${spaceUrl}${fileUrl}`;
   }
-  if (fileUrl.startsWith("file=")) {
-    return `${spaceUrl}/${fileUrl}`;
+  if (fileUrl.startsWith("/file=")) {
+    return `${spaceUrl}/gradio_api${fileUrl}`;
   }
-  return `${spaceUrl}/file=${fileUrl}`;
+  if (fileUrl.startsWith("file=")) {
+    return `${spaceUrl}/gradio_api/${fileUrl}`;
+  }
+  return `${spaceUrl}/gradio_api/file=${fileUrl}`;
 }
 
 function dataUrlToBlob(dataUrl: string) {
@@ -455,7 +585,7 @@ async function fetchAudioDataUrl(
     if (controller.signal.aborted) {
       throw new Error("HF_SPACE_AUDIO_FETCH_TIMEOUT");
     }
-    throw error;
+    throw new Error("HF_SPACE_AUDIO_FETCH_FAILED");
   } finally {
     clearTimeout(timeoutId);
   }
@@ -503,11 +633,10 @@ function extractDurationSec(value: unknown, depth = 0): number | undefined {
 
 export const hfSpaceAudioAdapter: AudioGenerationAdapter = {
   mapError(error: unknown) {
-    if (!(error instanceof Error)) {
+    const message = extractErrorText(error);
+    if (!message) {
       return "오디오 생성에 실패했습니다.";
     }
-
-    const message = error.message || "";
     const lower = message.toLowerCase();
 
     if (lower.startsWith("hf_space_not_ready")) {
@@ -530,6 +659,9 @@ export const hfSpaceAudioAdapter: AudioGenerationAdapter = {
     }
     if (lower === "hf_space_config_invalid") {
       return "오디오 모델 설정이 올바르지 않습니다.";
+    }
+    if (lower === "fetch failed") {
+      return "HF Space 통신 중 네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
     }
     if (lower === "invalid_hf_token_format") {
       return "HF 토큰 형식이 올바르지 않습니다.";

--- a/src/server/audio-generation/adapters/hf-space-adapter.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.ts
@@ -1,0 +1,612 @@
+import { Client } from "@gradio/client";
+import { z } from "zod";
+import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
+import type { AudioGenerationAdapter } from "@/server/audio-generation/adapters/types";
+import { getModelCatalog } from "@/server/model-catalog/catalog-service";
+import type { AudioModelCatalogItem } from "@/server/model-catalog/catalog-schema";
+import {
+  getRuntimeAudioParamRange,
+  resolveRuntimeAudioDefaults,
+  type RuntimeAudioModel,
+} from "@/shared/model-catalog/runtime-utils";
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const STATUS_CHECK_TTL_MS = 30_000;
+const STATUS_CHECK_TIMEOUT_MS = 5_000;
+const FILE_FETCH_TIMEOUT_MS = 60_000;
+
+const hfSpaceConfigSchema = z
+  .object({
+    space_id: z.string().min(1),
+    api_name: z.string().min(1),
+    timeout_ms: z.number().int().positive().optional(),
+    space_url: z.string().min(1).optional(),
+  })
+  .passthrough();
+
+type SpaceConfig = {
+  spaceId: string;
+  apiName: string;
+  token?: `hf_${string}`;
+  timeoutMs: number;
+  spaceUrl: string;
+};
+
+type EndpointParameter = {
+  parameter_name?: string;
+  label?: string;
+  parameter_default?: unknown;
+};
+
+type EndpointInfo = {
+  parameters?: EndpointParameter[];
+};
+
+type ViewApiResponse = {
+  named_endpoints?: Record<string, EndpointInfo>;
+};
+
+const clientCache = new Map<string, Promise<Client>>();
+const statusCache = new Map<
+  string,
+  { checkedAt: number; ok: boolean | null }
+>();
+
+function resolveSpaceUrl(spaceId: string, explicit?: string) {
+  if (explicit?.trim()) return explicit.trim();
+  const slug = spaceId.replace("/", "-");
+  return `https://${slug}.hf.space`;
+}
+
+function toRuntimeAudioModel(model: AudioModelCatalogItem): RuntimeAudioModel {
+  return model as RuntimeAudioModel;
+}
+
+async function getCatalogAudioModel(modelKey: string) {
+  const catalog = await getModelCatalog({ includeInactive: true });
+  const model = catalog.find(
+    (item): item is AudioModelCatalogItem =>
+      item.type === "audio" && item.key === modelKey,
+  );
+  if (!model) {
+    throw new Error(`AUDIO_MODEL_NOT_FOUND:${modelKey}`);
+  }
+  return toRuntimeAudioModel(model);
+}
+
+async function getSpaceConfig(modelKey: AudioGenerationFormValues["model"]) {
+  const model = await getCatalogAudioModel(modelKey);
+  if (model.provider !== "hf_space") {
+    throw new Error("AUDIO_PROVIDER_NOT_SUPPORTED");
+  }
+  const parsedConfig = hfSpaceConfigSchema.safeParse(model.providerConfig);
+  if (!parsedConfig.success) {
+    throw new Error("HF_SPACE_CONFIG_INVALID");
+  }
+  const providerConfig = parsedConfig.data;
+  const timeoutRaw = Number(providerConfig.timeout_ms ?? DEFAULT_TIMEOUT_MS);
+  const tokenValue =
+    process.env.HF_TOKEN?.trim() ||
+    process.env.HUGGINGFACEHUB_API_TOKEN?.trim() ||
+    undefined;
+  if (tokenValue && !tokenValue.startsWith("hf_")) {
+    throw new Error("INVALID_HF_TOKEN_FORMAT");
+  }
+
+  const config: SpaceConfig = {
+    spaceId: providerConfig.space_id,
+    apiName: providerConfig.api_name,
+    token: tokenValue as `hf_${string}` | undefined,
+    timeoutMs:
+      Number.isFinite(timeoutRaw) && timeoutRaw > 0
+        ? timeoutRaw
+        : DEFAULT_TIMEOUT_MS,
+    spaceUrl: resolveSpaceUrl(providerConfig.space_id, providerConfig.space_url),
+  };
+
+  return { config, model };
+}
+
+async function getClient(config: SpaceConfig) {
+  let cached = clientCache.get(config.spaceId);
+  if (!cached) {
+    cached = Client.connect(config.spaceId, { token: config.token });
+    clientCache.set(config.spaceId, cached);
+  }
+  try {
+    return await cached;
+  } catch (error) {
+    clientCache.delete(config.spaceId);
+    throw error;
+  }
+}
+
+function resolveSpaceApiUrl(spaceId: string) {
+  return `https://huggingface.co/api/spaces/${spaceId}`;
+}
+
+function extractRuntimeStage(payload: Record<string, unknown>) {
+  const runtime = payload.runtime as Record<string, unknown> | undefined;
+  const candidates = [
+    runtime?.stage,
+    runtime?.status,
+    payload.stage,
+    payload.status,
+    payload.state,
+  ];
+  for (const value of candidates) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+async function ensureSpaceRunning(config: SpaceConfig) {
+  const now = Date.now();
+  const cached = statusCache.get(config.spaceId);
+  if (
+    cached &&
+    cached.checkedAt > 0 &&
+    now - cached.checkedAt < STATUS_CHECK_TTL_MS &&
+    cached.ok !== null
+  ) {
+    if (!cached.ok) {
+      throw new Error("HF_SPACE_NOT_READY");
+    }
+    return;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), STATUS_CHECK_TIMEOUT_MS);
+  const headers: Record<string, string> = {};
+  if (config.token) {
+    headers.Authorization = `Bearer ${config.token}`;
+  }
+
+  try {
+    const response = await fetch(resolveSpaceApiUrl(config.spaceId), {
+      headers,
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      statusCache.set(config.spaceId, { checkedAt: Date.now(), ok: false });
+      throw new Error("HF_SPACE_STATUS_FETCH_FAILED");
+    }
+    const data = (await response.json()) as Record<string, unknown>;
+    const stage = extractRuntimeStage(data);
+    const normalized = stage?.toUpperCase() ?? "";
+    const ok = normalized === "RUNNING" || normalized === "READY";
+    statusCache.set(config.spaceId, { checkedAt: Date.now(), ok });
+    if (!ok) {
+      throw new Error(
+        stage ? `HF_SPACE_NOT_READY:${stage}` : "HF_SPACE_NOT_READY",
+      );
+    }
+  } catch (error) {
+    statusCache.set(config.spaceId, { checkedAt: Date.now(), ok: false });
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function normalizeApiName(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return "/generate_audio";
+  if (trimmed.startsWith("/")) return trimmed;
+  return `/${trimmed}`;
+}
+
+function clampNumber(value: number, range: { min: number; max: number; step: number }) {
+  if (!Number.isFinite(value)) return range.min;
+  let resolved = Math.min(range.max, Math.max(range.min, value));
+  if (range.step > 0) {
+    const steps = Math.round((resolved - range.min) / range.step);
+    resolved = range.min + steps * range.step;
+  }
+  return Math.min(range.max, Math.max(range.min, resolved));
+}
+
+function parseSeed(seed?: string) {
+  if (!seed?.trim()) {
+    return { seedValue: 0, randomize: true };
+  }
+  const parsed = Number(seed);
+  const isValid =
+    Number.isSafeInteger(parsed) &&
+    parsed >= 0 &&
+    parsed <= Number.MAX_SAFE_INTEGER;
+  return { seedValue: isValid ? parsed : 0, randomize: !isValid };
+}
+
+async function getEndpointInfo(client: Client, apiName: string) {
+  const apiInfo = (await client
+    .view_api()
+    .catch(() => null)) as ViewApiResponse | null;
+  if (!apiInfo?.named_endpoints) return null;
+  return (
+    apiInfo.named_endpoints[apiName] ??
+    apiInfo.named_endpoints[apiName.replace(/^\//, "")] ??
+    null
+  );
+}
+
+function normalizeLookupKey(parameter: EndpointParameter) {
+  return `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`
+    .toLowerCase()
+    .replace(/[_\-]+/g, " ");
+}
+
+function resolveParamValue(
+  parameter: EndpointParameter,
+  payload: AudioGenerationFormValues,
+  defaults: { voice: string; speed: number },
+  speed: number,
+  seed: { seedValue: number; randomize: boolean },
+) {
+  const lookup = normalizeLookupKey(parameter);
+
+  if (
+    lookup.includes("prompt") ||
+    lookup.includes("text") ||
+    lookup.includes("script") ||
+    lookup.includes("message")
+  ) {
+    return payload.prompt;
+  }
+
+  if (
+    lookup.includes("voice") ||
+    lookup.includes("speaker") ||
+    lookup.includes("spk")
+  ) {
+    return payload.voice?.trim() || defaults.voice;
+  }
+
+  if (lookup.includes("speed") || lookup.includes("rate")) {
+    return speed;
+  }
+
+  if (lookup.includes("seed") && lookup.includes("random")) {
+    return seed.randomize;
+  }
+
+  if (lookup.includes("seed")) {
+    return seed.seedValue;
+  }
+
+  return parameter.parameter_default;
+}
+
+async function buildRequestPayload(
+  client: Client,
+  apiName: string,
+  payload: AudioGenerationFormValues,
+  defaults: { voice: string; speed: number },
+  speed: number,
+  seed: { seedValue: number; randomize: boolean },
+) {
+  const endpoint = await getEndpointInfo(client, apiName);
+  const parameters = endpoint?.parameters;
+
+  if (!parameters?.length) {
+    const fallbackPayload: Record<string, unknown> = {
+      prompt: payload.prompt,
+    };
+
+    if (payload.voice?.trim()) {
+      fallbackPayload.voice = payload.voice.trim();
+    }
+    if (typeof payload.speed === "number") {
+      fallbackPayload.speed = speed;
+    }
+    if (!seed.randomize) {
+      fallbackPayload.seed = seed.seedValue;
+    }
+
+    return fallbackPayload;
+  }
+
+  const requestPayload: Record<string, unknown> = {};
+
+  parameters.forEach((parameter, index) => {
+    const key =
+      typeof parameter.parameter_name === "string" && parameter.parameter_name.trim()
+        ? parameter.parameter_name
+        : `param_${index}`;
+
+    requestPayload[key] = resolveParamValue(
+      parameter,
+      payload,
+      defaults,
+      speed,
+      seed,
+    );
+  });
+
+  return requestPayload;
+}
+
+function extractFileUrl(file: unknown) {
+  if (!file) return null;
+  if (typeof file === "string") return file;
+  if (typeof file !== "object") return null;
+  const candidate = file as {
+    url?: unknown;
+    path?: unknown;
+    name?: unknown;
+    data?: unknown;
+  };
+  if (typeof candidate.data === "string" && candidate.data.startsWith("data:")) {
+    return candidate.data;
+  }
+  if (typeof candidate.url === "string") return candidate.url;
+  if (typeof candidate.path === "string") return candidate.path;
+  if (typeof candidate.name === "string") return candidate.name;
+  return null;
+}
+
+function looksLikeAudioPath(value: string) {
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return false;
+  if (trimmed.startsWith("data:audio/")) return true;
+  if (trimmed.includes("file=") || trimmed.includes("/file/")) return true;
+  if (/\.(mp3|wav|flac|ogg|m4a|aac|webm)(\?|$)/.test(trimmed)) return true;
+  return false;
+}
+
+function collectAudioFileUrls(value: unknown, urls: Set<string>, depth = 0) {
+  if (depth > 4 || value === null || value === undefined) return;
+
+  if (typeof value === "string") {
+    if (looksLikeAudioPath(value)) {
+      urls.add(value);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectAudioFileUrls(item, urls, depth + 1));
+    return;
+  }
+
+  if (typeof value !== "object") return;
+
+  const direct = extractFileUrl(value);
+  if (direct && looksLikeAudioPath(direct)) {
+    urls.add(direct);
+  }
+
+  Object.values(value as Record<string, unknown>).forEach((item) =>
+    collectAudioFileUrls(item, urls, depth + 1),
+  );
+}
+
+function normalizeFileUrl(fileUrl: string, spaceUrl: string) {
+  if (fileUrl.startsWith("data:")) return fileUrl;
+  if (fileUrl.startsWith("http://") || fileUrl.startsWith("https://")) {
+    return fileUrl;
+  }
+  if (fileUrl.startsWith("/")) {
+    return `${spaceUrl}${fileUrl}`;
+  }
+  if (fileUrl.startsWith("file=")) {
+    return `${spaceUrl}/${fileUrl}`;
+  }
+  return `${spaceUrl}/file=${fileUrl}`;
+}
+
+async function fetchAudioDataUrl(
+  fileUrl: string,
+  spaceUrl: string,
+  timeoutMs: number = FILE_FETCH_TIMEOUT_MS,
+) {
+  const normalized = normalizeFileUrl(fileUrl, spaceUrl);
+  if (normalized.startsWith("data:")) {
+    return normalized;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(normalized, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error("HF_SPACE_AUDIO_FETCH_FAILED");
+    }
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const contentType = response.headers.get("content-type") ?? "audio/mpeg";
+    return `data:${contentType};base64,${buffer.toString("base64")}`;
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error("HF_SPACE_AUDIO_FETCH_TIMEOUT");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function extractDurationSec(value: unknown, depth = 0): number | undefined {
+  if (depth > 4 || value === null || value === undefined) return undefined;
+
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = extractDurationSec(item, depth + 1);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  if (typeof value !== "object") return undefined;
+
+  const record = value as Record<string, unknown>;
+  const candidates = [
+    record.duration_sec,
+    record.durationSec,
+    record.duration,
+    record.audio_duration,
+    record.audioDuration,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "number" && Number.isFinite(candidate) && candidate > 0) {
+      return candidate;
+    }
+  }
+
+  for (const nested of Object.values(record)) {
+    const found = extractDurationSec(nested, depth + 1);
+    if (found) return found;
+  }
+
+  return undefined;
+}
+
+export const hfSpaceAudioAdapter: AudioGenerationAdapter = {
+  mapError(error: unknown) {
+    if (!(error instanceof Error)) {
+      return "오디오 생성에 실패했습니다.";
+    }
+
+    const message = error.message || "";
+    const lower = message.toLowerCase();
+
+    if (lower.startsWith("hf_space_not_ready")) {
+      return "HF Space가 준비 중입니다. 잠시 후 다시 시도해주세요.";
+    }
+    if (lower === "hf_space_status_fetch_failed") {
+      return "HF Space 상태 확인에 실패했습니다. 잠시 후 다시 시도해주세요.";
+    }
+    if (lower === "hf_space_audio_fetch_failed") {
+      return "생성된 오디오 다운로드에 실패했습니다. 잠시 후 다시 시도해주세요.";
+    }
+    if (lower === "hf_space_audio_fetch_timeout") {
+      return "생성된 오디오 다운로드 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.";
+    }
+    if (lower === "hf_space_request_timeout") {
+      return "오디오 생성 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.";
+    }
+    if (lower === "hf_space_response_invalid") {
+      return "HF Space 응답에서 오디오 결과를 찾지 못했습니다.";
+    }
+    if (lower === "hf_space_config_invalid") {
+      return "오디오 모델 설정이 올바르지 않습니다.";
+    }
+    if (lower === "invalid_hf_token_format") {
+      return "HF 토큰 형식이 올바르지 않습니다.";
+    }
+    if (lower.startsWith("audio_model_not_found:")) {
+      return "선택한 오디오 모델을 찾을 수 없습니다.";
+    }
+
+    let code: string | null = null;
+    if (
+      lower.includes("quota") ||
+      lower.includes("exceed") ||
+      lower.includes("limit") ||
+      lower.includes("daily") ||
+      lower.includes("zero gpu") ||
+      lower.includes("zerogpu")
+    ) {
+      code = "HF_SPACE_QUOTA_EXCEEDED";
+    } else if (lower.includes("queue") || lower.includes("queued")) {
+      code = "HF_SPACE_QUEUE_FULL";
+    } else if (
+      lower.includes("too many requests") ||
+      lower.includes("rate limit") ||
+      lower.includes("429")
+    ) {
+      code = "HF_SPACE_RATE_LIMITED";
+    } else if (
+      lower.includes("sleep") ||
+      lower.includes("paused") ||
+      lower.includes("building") ||
+      lower.includes("loading")
+    ) {
+      code = "HF_SPACE_NOT_READY";
+    }
+
+    switch (code) {
+      case "HF_SPACE_QUOTA_EXCEEDED":
+        return "ZeroGPU 일일 쿼터를 초과했습니다. 내일 다시 시도하거나 다른 제공자를 사용해주세요.";
+      case "HF_SPACE_QUEUE_FULL":
+        return "현재 대기열이 가득합니다. 잠시 후 다시 시도해주세요.";
+      case "HF_SPACE_RATE_LIMITED":
+        return "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.";
+      case "HF_SPACE_NOT_READY":
+        return "HF Space가 준비 중입니다. 잠시 후 다시 시도해주세요.";
+      default:
+        return message || "오디오 생성에 실패했습니다.";
+    }
+  },
+
+  async generate(payload: AudioGenerationFormValues) {
+    const { config, model } = await getSpaceConfig(payload.model);
+    await ensureSpaceRunning(config);
+    const client = await getClient(config);
+
+    const defaults = resolveRuntimeAudioDefaults(model);
+    const speedRange = getRuntimeAudioParamRange(model, "speed");
+    const speed = clampNumber(payload.speed ?? defaults.speed, speedRange);
+    const seed = parseSeed(payload.seed);
+    const apiName = normalizeApiName(config.apiName || "/generate_audio");
+
+    const requestPayload = await buildRequestPayload(
+      client,
+      apiName,
+      payload,
+      defaults,
+      speed,
+      seed,
+    );
+
+    const predictPromise = client.predict(apiName, requestPayload);
+
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error("HF_SPACE_REQUEST_TIMEOUT")),
+        config.timeoutMs,
+      );
+    });
+
+    let result: Awaited<typeof predictPromise>;
+    try {
+      result = await Promise.race([predictPromise, timeoutPromise]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+
+    const rawData = Array.isArray(result?.data) ? result.data : result;
+    const audioUrls = new Set<string>();
+    collectAudioFileUrls(rawData, audioUrls);
+
+    if (audioUrls.size === 0) {
+      throw new Error("HF_SPACE_RESPONSE_INVALID");
+    }
+
+    const dataUrls = await Promise.all(
+      Array.from(audioUrls).map((url) =>
+        fetchAudioDataUrl(
+          url,
+          config.spaceUrl,
+          Math.min(config.timeoutMs, FILE_FETCH_TIMEOUT_MS),
+        ),
+      ),
+    );
+
+    return {
+      audios: dataUrls,
+      meta: {
+        duration_sec: extractDurationSec(rawData),
+      },
+    };
+  },
+};

--- a/src/server/audio-generation/adapters/types.ts
+++ b/src/server/audio-generation/adapters/types.ts
@@ -1,0 +1,15 @@
+import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
+
+export type AudioGenerationAdapterResult = {
+  audios: string[];
+  meta?: {
+    duration_sec?: number;
+  };
+};
+
+export type AudioGenerationAdapter = {
+  generate: (
+    payload: AudioGenerationFormValues,
+  ) => Promise<AudioGenerationAdapterResult>;
+  mapError?: (error: unknown) => string;
+};

--- a/src/server/audio-generation/audio-generation-repository.ts
+++ b/src/server/audio-generation/audio-generation-repository.ts
@@ -18,6 +18,8 @@ export async function createAudioGenerationRecord(
     voice: payload.voice ?? null,
     speed: payload.speed ?? null,
     seed: payload.seed || null,
+    inputAudio: payload.inputAudio || null,
+    referenceText: payload.referenceText || null,
   };
 
   return prisma.audioGeneration.create({

--- a/src/server/audio-generation/audio-generation-repository.ts
+++ b/src/server/audio-generation/audio-generation-repository.ts
@@ -1,0 +1,103 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/server/db/prisma";
+import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
+import type {
+  AudioGenerationResponse,
+  AudioGenerationStatus,
+} from "@/features/audio-generation/model/audio-generation-types";
+
+export async function createAudioGenerationRecord(
+  requestId: string,
+  payload: AudioGenerationFormValues,
+  ownerEmail: string,
+  apiKeyId: string | null = null,
+) {
+  const requestParams: Prisma.InputJsonValue = {
+    model: payload.model,
+    prompt: payload.prompt,
+    voice: payload.voice ?? null,
+    speed: payload.speed ?? null,
+    seed: payload.seed || null,
+  };
+
+  return prisma.audioGeneration.create({
+    data: {
+      requestId,
+      ownerEmail,
+      apiKeyId,
+      prompt: payload.prompt,
+      requestParams,
+      modelKey: payload.model,
+      status: "pending",
+      progress: 0,
+    },
+  });
+}
+
+export async function saveAudioGenerationResult(
+  generationId: string,
+  status: AudioGenerationStatus,
+  progress: number,
+  result?: AudioGenerationResponse["result"],
+  errorMessage?: string,
+) {
+  const operations: Prisma.PrismaPromise<unknown>[] = [
+    prisma.audioGeneration.update({
+      where: { id: generationId },
+      data: {
+        status,
+        progress,
+        errorMessage: errorMessage ?? null,
+      },
+    }),
+  ];
+
+  if (result?.audios?.length) {
+    operations.push(
+      prisma.audioGenerationAudio.deleteMany({
+        where: { generationId },
+      }),
+    );
+    operations.push(
+      prisma.audioGenerationAudio.createMany({
+        data: result.audios.map((audio) => ({
+          generationId,
+          url: audio.url,
+          durationSec: audio.durationSec ?? null,
+        })),
+      }),
+    );
+  }
+
+  await prisma.$transaction(operations);
+}
+
+export async function updateAudioGenerationStatus(
+  generationId: string,
+  status: AudioGenerationStatus,
+  progress: number,
+  errorMessage?: string,
+) {
+  return prisma.audioGeneration.update({
+    where: { id: generationId },
+    data: {
+      status,
+      progress,
+      errorMessage: errorMessage ?? null,
+    },
+  });
+}
+
+export async function getAudioGenerationByRequestId(
+  requestId: string,
+  ownerEmail: string,
+) {
+  return prisma.audioGeneration.findFirst({
+    where: { requestId, ownerEmail },
+    include: {
+      audios: {
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+}

--- a/src/server/audio-generation/audio-generation-repository.ts
+++ b/src/server/audio-generation/audio-generation-repository.ts
@@ -12,15 +12,16 @@ export async function createAudioGenerationRecord(
   ownerEmail: string,
   apiKeyId: string | null = null,
 ) {
-  const requestParams: Prisma.InputJsonValue = {
-    model: payload.model,
-    prompt: payload.prompt,
-    voice: payload.voice ?? null,
-    speed: payload.speed ?? null,
-    seed: payload.seed || null,
-    inputAudio: payload.inputAudio || null,
-    referenceText: payload.referenceText || null,
-  };
+  const requestParams: Record<string, Prisma.InputJsonValue | null> = {};
+  Object.entries(payload).forEach(([key, value]) => {
+    if (value === undefined) {
+      return;
+    }
+    requestParams[key] =
+      typeof value === "string"
+        ? value.trim() || null
+        : value;
+  });
 
   return prisma.audioGeneration.create({
     data: {

--- a/src/server/audio-generation/audio-generation-store.ts
+++ b/src/server/audio-generation/audio-generation-store.ts
@@ -1,0 +1,68 @@
+import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
+import type {
+  AudioGenerationResponse,
+  AudioGenerationStatus,
+} from "@/features/audio-generation/model/audio-generation-types";
+import {
+  createAudioGenerationRecord,
+  getAudioGenerationByRequestId,
+} from "@/server/audio-generation/audio-generation-repository";
+
+export type AudioGenerationRecord = {
+  id: string;
+  status: AudioGenerationStatus;
+  progress: number;
+  result?: AudioGenerationResponse["result"];
+  errorMessage?: string;
+};
+
+function mapRecord(
+  record: Awaited<ReturnType<typeof getAudioGenerationByRequestId>>,
+): AudioGenerationRecord | null {
+  if (!record) return null;
+  const audios = record.audios ?? [];
+  const result = audios.length
+    ? {
+        audios: audios.map((audio) => ({
+          url: audio.url,
+          durationSec: audio.durationSec ?? undefined,
+        })),
+      }
+    : undefined;
+
+  return {
+    id: record.requestId,
+    status: record.status,
+    progress: record.progress,
+    result,
+    errorMessage: record.errorMessage ?? undefined,
+  };
+}
+
+export async function createMockAudioGenerationWithLimit(
+  payload: AudioGenerationFormValues,
+  ownerEmail: string,
+  apiKeyId: string | null = null,
+) {
+  const requestId = crypto.randomUUID();
+  const record = await createAudioGenerationRecord(
+    requestId,
+    payload,
+    ownerEmail,
+    apiKeyId,
+  );
+
+  return {
+    record: {
+      id: record.requestId,
+      status: record.status,
+      progress: record.progress,
+    } satisfies AudioGenerationRecord,
+    latest: null,
+  };
+}
+
+export async function getAudioGeneration(id: string, ownerEmail: string) {
+  const record = await getAudioGenerationByRequestId(id, ownerEmail);
+  return mapRecord(record);
+}

--- a/src/server/audio-generation/audio-generation.test.ts
+++ b/src/server/audio-generation/audio-generation.test.ts
@@ -30,7 +30,7 @@ describe("resolveAudioGenerationResult", () => {
     vi.clearAllMocks();
   });
 
-  it("storage provider가 없으면 inline 결과와 경고를 반환한다", async () => {
+  it("storage provider가 없으면 inline 결과와 안내 메시지를 반환한다", async () => {
     mockGenerate.mockResolvedValue({
       audios: ["data:audio/mpeg;base64,ZmFrZQ=="],
       meta: { duration_sec: 2.5 },
@@ -64,6 +64,31 @@ describe("resolveAudioGenerationResult", () => {
       skipDbSave: true,
     });
     expect(mockUploadAudios).not.toHaveBeenCalled();
+  });
+
+  it("storage provider 미설정 기본 메시지는 inline 저장 동작을 설명한다", async () => {
+    mockGenerate.mockResolvedValue({
+      audios: ["data:audio/mpeg;base64,ZmFrZQ=="],
+      meta: { duration_sec: 1.1 },
+    });
+    mockResolveAudioStorageProvider.mockReturnValue({
+      provider: null,
+      warningMessage: undefined,
+    });
+
+    const result = await resolveAudioGenerationResult(
+      {
+        ...audioGenerationDefaults,
+        prompt: "hello",
+        model: "qwen-tts",
+        speed: 1,
+      },
+      "request-id",
+    );
+
+    expect(result.errorMessage).toBe(
+      "오디오 저장소가 지정되지 않아 외부 저장소 업로드를 건너뛰고 inline 결과를 사용합니다.",
+    );
   });
 
   it("storage provider가 있으면 업로드 결과를 반환한다", async () => {

--- a/src/server/audio-generation/audio-generation.test.ts
+++ b/src/server/audio-generation/audio-generation.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { audioGenerationDefaults } from "@/features/audio-generation/model/audio-generation-schema";
+import { resolveAudioGenerationResult } from "@/server/audio-generation/audio-generation";
+
+const mockGenerate = vi.hoisted(() => vi.fn());
+const mockUploadAudios = vi.hoisted(() => vi.fn());
+const mockResolveAudioStorageProvider = vi.hoisted(() => vi.fn());
+
+vi.mock("@/server/audio-generation/adapters/hf-space-adapter", () => ({
+  hfSpaceAudioAdapter: {
+    generate: mockGenerate,
+    mapError: (error: unknown) =>
+      error instanceof Error ? `mapped:${error.message}` : "mapped:unknown",
+  },
+}));
+
+vi.mock("@/server/audio-generation/storage/adapters/leemage-storage-adapter", () => ({
+  leemageAudioStorageAdapter: {
+    name: "leemage",
+    uploadAudios: mockUploadAudios,
+  },
+}));
+
+vi.mock("@/server/audio-generation/storage/storage-selector", () => ({
+  resolveAudioStorageProvider: mockResolveAudioStorageProvider,
+}));
+
+describe("resolveAudioGenerationResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("storage provider가 없으면 inline 결과와 경고를 반환한다", async () => {
+    mockGenerate.mockResolvedValue({
+      audios: ["data:audio/mpeg;base64,ZmFrZQ=="],
+      meta: { duration_sec: 2.5 },
+    });
+    mockResolveAudioStorageProvider.mockReturnValue({
+      provider: null,
+      warningMessage: "storage skipped",
+    });
+
+    const result = await resolveAudioGenerationResult(
+      {
+        ...audioGenerationDefaults,
+        prompt: "hello",
+        model: "qwen-tts",
+        speed: 1,
+      },
+      "request-id",
+    );
+
+    expect(result).toEqual({
+      status: "completed",
+      result: {
+        audios: [
+          {
+            url: "data:audio/mpeg;base64,ZmFrZQ==",
+            durationSec: 2.5,
+          },
+        ],
+      },
+      errorMessage: "storage skipped",
+      skipDbSave: true,
+    });
+    expect(mockUploadAudios).not.toHaveBeenCalled();
+  });
+
+  it("storage provider가 있으면 업로드 결과를 반환한다", async () => {
+    mockGenerate.mockResolvedValue({
+      audios: ["data:audio/mpeg;base64,ZmFrZQ=="],
+      meta: { duration_sec: 1.2 },
+    });
+    mockResolveAudioStorageProvider.mockReturnValue({ provider: "leemage" });
+    mockUploadAudios.mockResolvedValue({
+      status: "completed",
+      result: {
+        audios: [{ url: "https://cdn.example.com/audio.mp3", durationSec: 1.2 }],
+      },
+    });
+
+    const payload = {
+      ...audioGenerationDefaults,
+      prompt: "hello",
+      model: "qwen-tts",
+      speed: 1.5,
+    };
+
+    const result = await resolveAudioGenerationResult(payload, "request-id");
+
+    expect(mockUploadAudios).toHaveBeenCalledWith(
+      payload,
+      "request-id",
+      ["data:audio/mpeg;base64,ZmFrZQ=="],
+      { duration_sec: 1.2 },
+    );
+    expect(result.status).toBe("completed");
+    expect(result.result?.audios[0]?.url).toBe("https://cdn.example.com/audio.mp3");
+  });
+
+  it("provider 오류를 사용자 친화적 메시지로 반환한다", async () => {
+    mockGenerate.mockRejectedValue(new Error("HF_SPACE_NOT_READY"));
+    mockResolveAudioStorageProvider.mockReturnValue({ provider: "leemage" });
+
+    const result = await resolveAudioGenerationResult(
+      {
+        ...audioGenerationDefaults,
+        prompt: "hello",
+        model: "qwen-tts",
+      },
+      "request-id",
+    );
+
+    expect(result).toEqual({
+      status: "failed",
+      errorMessage: "mapped:HF_SPACE_NOT_READY",
+    });
+  });
+});

--- a/src/server/audio-generation/audio-generation.ts
+++ b/src/server/audio-generation/audio-generation.ts
@@ -82,7 +82,7 @@ export async function resolveAudioGenerationResult(
     if (!provider) {
       const message =
         warningMessage ??
-        "오디오 저장소가 지정되지 않아 결과가 저장되지 않습니다.";
+        "오디오 저장소가 지정되지 않아 외부 저장소 업로드를 건너뛰고 inline 결과를 사용합니다.";
       console.warn("[audio-storage] storage skipped", { requestId, message });
       return {
         status: "completed",

--- a/src/server/audio-generation/audio-generation.ts
+++ b/src/server/audio-generation/audio-generation.ts
@@ -1,0 +1,108 @@
+import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
+import type { AudioGenerationResponse } from "@/features/audio-generation/model/audio-generation-types";
+import { hfSpaceAudioAdapter } from "@/server/audio-generation/adapters/hf-space-adapter";
+import type { AudioGenerationAdapter } from "@/server/audio-generation/adapters/types";
+import { leemageAudioStorageAdapter } from "@/server/audio-generation/storage/adapters/leemage-storage-adapter";
+import type {
+  AudioStorageAdapter,
+  AudioStorageMeta,
+} from "@/server/audio-generation/storage/storage-adapter";
+import { resolveAudioStorageProvider } from "@/server/audio-generation/storage/storage-selector";
+
+type AudioProvider = "hf_space";
+
+function resolveAudioProvider(
+  modelKey: AudioGenerationFormValues["model"],
+): AudioProvider {
+  void modelKey;
+  return "hf_space";
+}
+
+function getAdapter(
+  modelKey: AudioGenerationFormValues["model"],
+): AudioGenerationAdapter {
+  const provider = resolveAudioProvider(modelKey);
+  if (provider === "hf_space") return hfSpaceAudioAdapter;
+  throw new Error(`AUDIO_PROVIDER_NOT_SUPPORTED:${provider}`);
+}
+
+function getStorageAdapter(): AudioStorageAdapter {
+  const { provider } = resolveAudioStorageProvider();
+  if (provider === "leemage") return leemageAudioStorageAdapter;
+  throw new Error("AUDIO_STORAGE_PROVIDER_NOT_RESOLVED");
+}
+
+function resolveDurationSec(payload: AudioGenerationFormValues, meta?: AudioStorageMeta) {
+  if (typeof meta?.duration_sec === "number" && Number.isFinite(meta.duration_sec)) {
+    return meta.duration_sec;
+  }
+  const fallback = payload.speed && payload.speed > 0 ? 1 / payload.speed : 1;
+  return Number.isFinite(fallback) ? Math.max(0.1, Number(fallback.toFixed(2))) : 1;
+}
+
+function buildInlineResult(
+  payload: AudioGenerationFormValues,
+  dataUrls: string[],
+  meta?: AudioStorageMeta,
+): NonNullable<AudioGenerationResponse["result"]> {
+  const durationSec = resolveDurationSec(payload, meta);
+  return {
+    audios: dataUrls.map((url) => ({
+      url,
+      durationSec,
+    })),
+  };
+}
+
+function mapProviderError(adapter: AudioGenerationAdapter | null, error: unknown) {
+  if (adapter?.mapError) {
+    return adapter.mapError(error);
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return "오디오 생성에 실패했습니다.";
+}
+
+export async function resolveAudioGenerationResult(
+  payload: AudioGenerationFormValues,
+  requestId: string,
+): Promise<{
+  status: "completed" | "failed";
+  result?: AudioGenerationResponse["result"];
+  errorMessage?: string;
+  skipDbSave?: boolean;
+}> {
+  let adapter: AudioGenerationAdapter | null = null;
+  try {
+    adapter = getAdapter(payload.model);
+    const result = await adapter.generate(payload);
+    const { provider, warningMessage } = resolveAudioStorageProvider();
+
+    if (!provider) {
+      const message =
+        warningMessage ??
+        "오디오 저장소가 지정되지 않아 결과가 저장되지 않습니다.";
+      console.warn("[audio-storage] storage skipped", { requestId, message });
+      return {
+        status: "completed",
+        result: buildInlineResult(payload, result.audios, result.meta),
+        errorMessage: message,
+        skipDbSave: true,
+      };
+    }
+
+    const storageAdapter = getStorageAdapter();
+    return storageAdapter.uploadAudios(
+      payload,
+      requestId,
+      result.audios,
+      result.meta,
+    );
+  } catch (error) {
+    return {
+      status: "failed",
+      errorMessage: mapProviderError(adapter, error),
+    };
+  }
+}

--- a/src/server/audio-generation/storage/adapters/leemage-storage-adapter.ts
+++ b/src/server/audio-generation/storage/adapters/leemage-storage-adapter.ts
@@ -1,0 +1,188 @@
+import { LeemageClient, type UploadableFile } from "leemage-sdk";
+import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
+import type { AudioGenerationResponse } from "@/features/audio-generation/model/audio-generation-types";
+import type {
+  AudioStorageAdapter,
+  AudioStorageAvailability,
+  AudioStorageMeta,
+  AudioStorageResult,
+} from "@/server/audio-generation/storage/storage-adapter";
+
+const MISSING_LEEMAGE_MESSAGE =
+  "Leemage 저장소 설정이 없어 결과가 히스토리에 저장되지 않습니다.";
+
+let cachedClient: LeemageClient | null = null;
+let cachedConfig:
+  | {
+      apiKey: string;
+      baseUrl?: string;
+      projectId: string;
+    }
+  | null = null;
+
+function getMissingLeemageEnv() {
+  const requiredLeemageEnv = [
+    ["LEEMAGE_API_KEY", process.env.LEEMAGE_API_KEY],
+    ["LEEMAGE_PROJECT_ID", process.env.LEEMAGE_PROJECT_ID],
+  ] as const;
+
+  return requiredLeemageEnv
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+}
+
+function checkLeemageAvailability(): AudioStorageAvailability {
+  const missing = getMissingLeemageEnv();
+  if (missing.length === 0) {
+    return { isAvailable: true };
+  }
+  return { isAvailable: false, warningMessage: MISSING_LEEMAGE_MESSAGE };
+}
+
+function getLeemageConfig() {
+  const missingLeemageEnv = getMissingLeemageEnv();
+  if (missingLeemageEnv.length > 0) {
+    throw new Error(
+      `LEEMAGE 설정이 필요합니다: ${missingLeemageEnv.join(", ")}`,
+    );
+  }
+
+  return {
+    apiKey: process.env.LEEMAGE_API_KEY as string,
+    baseUrl: process.env.LEEMAGE_BASE_URL,
+    projectId: process.env.LEEMAGE_PROJECT_ID as string,
+  };
+}
+
+function getLeemageClient() {
+  const config = getLeemageConfig();
+  if (
+    !cachedClient ||
+    !cachedConfig ||
+    cachedConfig.apiKey !== config.apiKey ||
+    cachedConfig.baseUrl !== config.baseUrl ||
+    cachedConfig.projectId !== config.projectId
+  ) {
+    cachedClient = new LeemageClient({
+      apiKey: config.apiKey,
+      baseUrl: config.baseUrl ?? "https://leemage.leey00nsu.com",
+      timeout: 20_000,
+    });
+    cachedConfig = config;
+  }
+
+  return cachedClient;
+}
+
+function buildUploadFile(
+  buffer: Buffer,
+  name: string,
+  contentType: string,
+): UploadableFile {
+  const arrayBuffer = Uint8Array.from(buffer).buffer;
+  return {
+    name,
+    type: contentType,
+    size: buffer.byteLength,
+    arrayBuffer: async () => arrayBuffer,
+  };
+}
+
+function parseDataUrl(dataUrl: string) {
+  const match = dataUrl.match(/^data:([^;]+);base64,(.+)$/);
+  if (!match || !match[1] || !match[2]) {
+    throw new Error("지원하지 않는 오디오 포맷입니다.");
+  }
+  const contentType = match[1];
+  const buffer = Buffer.from(match[2], "base64");
+  return { contentType, buffer };
+}
+
+function resolveAudioExtension(contentType: string) {
+  if (contentType === "audio/mpeg") return "mp3";
+  if (contentType === "audio/wav" || contentType === "audio/x-wav") return "wav";
+  if (contentType === "audio/flac") return "flac";
+  if (contentType === "audio/ogg") return "ogg";
+  if (contentType === "audio/aac") return "aac";
+  if (contentType === "audio/mp4") return "m4a";
+  if (contentType === "audio/webm") return "webm";
+  return "bin";
+}
+
+function resolveDurationSec(
+  payload: AudioGenerationFormValues,
+  meta?: AudioStorageMeta,
+) {
+  if (typeof meta?.duration_sec === "number" && Number.isFinite(meta.duration_sec)) {
+    return meta.duration_sec;
+  }
+  const fallback = payload.speed && payload.speed > 0 ? 1 / payload.speed : 1;
+  return Number.isFinite(fallback) ? Math.max(0.1, Number(fallback.toFixed(2))) : 1;
+}
+
+function buildResultFromDataUrls(
+  payload: AudioGenerationFormValues,
+  dataUrls: string[],
+  meta?: AudioStorageMeta,
+): NonNullable<AudioGenerationResponse["result"]> {
+  const durationSec = resolveDurationSec(payload, meta);
+  return {
+    audios: dataUrls.map((url) => ({
+      url,
+      durationSec,
+    })),
+  };
+}
+
+function resolveFileUrl(file: { url: string | null }) {
+  if (!file.url) {
+    throw new Error("업로드된 오디오 URL을 찾을 수 없습니다.");
+  }
+  return file.url;
+}
+
+async function uploadGeneratedAudios(
+  payload: AudioGenerationFormValues,
+  requestId: string,
+  dataUrls: string[],
+  meta?: AudioStorageMeta,
+): Promise<AudioStorageResult> {
+  const client = getLeemageClient();
+  const { projectId } = getLeemageConfig();
+  const durationSec = resolveDurationSec(payload, meta);
+
+  try {
+    const uploads = await Promise.all(
+      dataUrls.map((dataUrl, index) => {
+        const { contentType, buffer } = parseDataUrl(dataUrl);
+        const extension = resolveAudioExtension(contentType);
+        const name = `${requestId}-${index + 1}.${extension}`;
+        const file = buildUploadFile(buffer, name, contentType);
+        return client.files.upload(projectId, file);
+      }),
+    );
+
+    return {
+      status: "completed",
+      result: {
+        audios: uploads.map((file) => ({
+          url: resolveFileUrl(file),
+          durationSec,
+        })),
+      },
+    };
+  } catch (error) {
+    return {
+      status: "completed",
+      result: buildResultFromDataUrls(payload, dataUrls, meta),
+      errorMessage:
+        error instanceof Error ? error.message : "저장에 실패했습니다.",
+    };
+  }
+}
+
+export const leemageAudioStorageAdapter: AudioStorageAdapter = {
+  name: "leemage",
+  checkAvailability: checkLeemageAvailability,
+  uploadAudios: uploadGeneratedAudios,
+};

--- a/src/server/audio-generation/storage/storage-adapter.ts
+++ b/src/server/audio-generation/storage/storage-adapter.ts
@@ -1,0 +1,31 @@
+import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
+import type { AudioGenerationResponse } from "@/features/audio-generation/model/audio-generation-types";
+
+export type AudioStorageProvider = "leemage";
+
+export type AudioStorageMeta = {
+  duration_sec?: number;
+};
+
+export interface AudioStorageResult {
+  status: "completed" | "failed";
+  result?: AudioGenerationResponse["result"];
+  errorMessage?: string;
+  skipDbSave?: boolean;
+}
+
+export interface AudioStorageAvailability {
+  isAvailable: boolean;
+  warningMessage?: string;
+}
+
+export interface AudioStorageAdapter {
+  name: AudioStorageProvider;
+  uploadAudios: (
+    payload: AudioGenerationFormValues,
+    requestId: string,
+    dataUrls: string[],
+    meta?: AudioStorageMeta,
+  ) => Promise<AudioStorageResult>;
+  checkAvailability?: () => AudioStorageAvailability;
+}

--- a/src/server/audio-generation/storage/storage-selector.ts
+++ b/src/server/audio-generation/storage/storage-selector.ts
@@ -10,7 +10,7 @@ interface AudioStorageResolution {
 }
 
 const MISSING_PROVIDER_MESSAGE =
-  "오디오 저장소가 지정되지 않아 결과가 히스토리에 저장되지 않습니다.";
+  "오디오 저장소가 지정되지 않아 외부 저장소 업로드를 건너뛰고 inline 결과를 사용합니다.";
 
 const storageAdapters: Record<AudioStorageProvider, AudioStorageAdapter> = {
   leemage: leemageAudioStorageAdapter,
@@ -38,6 +38,6 @@ export function resolveAudioStorageProvider(): AudioStorageResolution {
 
   return {
     provider: null,
-    warningMessage: `지원하지 않는 오디오 저장소(${raw})로 인해 결과가 히스토리에 저장되지 않습니다.`,
+    warningMessage: `지원하지 않는 오디오 저장소(${raw})로 인해 외부 저장소 업로드를 건너뛰고 inline 결과를 사용합니다.`,
   };
 }

--- a/src/server/audio-generation/storage/storage-selector.ts
+++ b/src/server/audio-generation/storage/storage-selector.ts
@@ -1,0 +1,43 @@
+import type {
+  AudioStorageAdapter,
+  AudioStorageProvider,
+} from "@/server/audio-generation/storage/storage-adapter";
+import { leemageAudioStorageAdapter } from "@/server/audio-generation/storage/adapters/leemage-storage-adapter";
+
+interface AudioStorageResolution {
+  provider: AudioStorageProvider | null;
+  warningMessage?: string;
+}
+
+const MISSING_PROVIDER_MESSAGE =
+  "오디오 저장소가 지정되지 않아 결과가 히스토리에 저장되지 않습니다.";
+
+const storageAdapters: Record<AudioStorageProvider, AudioStorageAdapter> = {
+  leemage: leemageAudioStorageAdapter,
+};
+
+export function resolveAudioStorageProvider(): AudioStorageResolution {
+  const raw = process.env.AUDIO_STORAGE_PROVIDER?.toLowerCase().trim();
+
+  if (!raw) {
+    return { provider: null, warningMessage: MISSING_PROVIDER_MESSAGE };
+  }
+
+  if (raw in storageAdapters) {
+    const provider = raw as AudioStorageProvider;
+    const adapter = storageAdapters[provider];
+    const availability = adapter.checkAvailability?.();
+    if (availability && !availability.isAvailable) {
+      return {
+        provider: null,
+        warningMessage: availability.warningMessage ?? MISSING_PROVIDER_MESSAGE,
+      };
+    }
+    return { provider: adapter.name };
+  }
+
+  return {
+    provider: null,
+    warningMessage: `지원하지 않는 오디오 저장소(${raw})로 인해 결과가 히스토리에 저장되지 않습니다.`,
+  };
+}

--- a/src/server/generation-worker/generation-worker.test.ts
+++ b/src/server/generation-worker/generation-worker.test.ts
@@ -246,7 +246,7 @@ describe("generation worker", () => {
     );
   });
 
-  it("processAudioJobs updates status when completed with skipDbSave", async () => {
+  it("processAudioJobs persists inline audio result even when storage upload is skipped", async () => {
     const mockRecord = {
       id: "aud-db-id",
       requestId: "aud-request-id",
@@ -268,20 +268,35 @@ describe("generation worker", () => {
     });
     (resolveAudioGenerationResult as ReturnType<typeof vi.fn>).mockResolvedValue({
       status: "completed",
-      result: { audios: [] },
-      errorMessage: undefined,
+      result: {
+        audios: [
+          {
+            url: "data:audio/mpeg;base64,ZmFrZQ==",
+            durationSec: 2.5,
+          },
+        ],
+      },
+      errorMessage: "오디오 저장소가 지정되지 않아 외부 저장소 업로드를 건너뛰고 inline 결과를 사용합니다.",
       skipDbSave: true,
     });
 
     await processAudioJobs();
 
-    expect(updateAudioGenerationStatus).toHaveBeenCalledWith(
+    expect(saveAudioGenerationResult).toHaveBeenCalledWith(
       "aud-db-id",
       "completed",
       100,
-      undefined,
+      {
+        audios: [
+          {
+            url: "data:audio/mpeg;base64,ZmFrZQ==",
+            durationSec: 2.5,
+          },
+        ],
+      },
+      "오디오 저장소가 지정되지 않아 외부 저장소 업로드를 건너뛰고 inline 결과를 사용합니다.",
     );
-    expect(saveAudioGenerationResult).not.toHaveBeenCalled();
+    expect(updateAudioGenerationStatus).not.toHaveBeenCalled();
   });
 
   it("processAudioJobs preserves mode-based audio params and does not re-inject legacy voice defaults", async () => {

--- a/src/server/generation-worker/generation-worker.test.ts
+++ b/src/server/generation-worker/generation-worker.test.ts
@@ -1,7 +1,16 @@
-import { processImageJobs, processVideoJobs } from "@/server/generation-worker/generation-worker";
+import {
+  processAudioJobs,
+  processImageJobs,
+  processVideoJobs,
+} from "@/server/generation-worker/generation-worker";
 import { prisma } from "@/server/db/prisma";
+import { resolveAudioGenerationResult } from "@/server/audio-generation/audio-generation";
 import { resolveImageGenerationResult } from "@/server/image-generation/image-generation";
 import { resolveVideoGenerationResult } from "@/server/video-generation/video-generation";
+import {
+  saveAudioGenerationResult,
+  updateAudioGenerationStatus,
+} from "@/server/audio-generation/audio-generation-repository";
 import {
   saveImageGenerationResult,
   updateImageGenerationStatus,
@@ -11,16 +20,22 @@ import {
   updateVideoGenerationStatus,
 } from "@/server/video-generation/video-generation-repository";
 import type {
+  RuntimeAudioModel,
   RuntimeImageModel,
   RuntimeVideoModel,
 } from "@/server/model-catalog/runtime-models";
 
+const mockValidateAudioPayload = vi.hoisted(() => vi.fn());
 const mockValidateImagePayload = vi.hoisted(() => vi.fn());
 const mockValidateVideoPayload = vi.hoisted(() => vi.fn());
 const mockGetRuntimeCatalog = vi.hoisted(() => vi.fn());
 
 vi.mock("@/server/db/prisma", () => ({
   prisma: {
+    audioGeneration: {
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+    },
     imageGeneration: {
       findMany: vi.fn(),
       updateMany: vi.fn(),
@@ -32,12 +47,21 @@ vi.mock("@/server/db/prisma", () => ({
   },
 }));
 
+vi.mock("@/server/audio-generation/audio-generation", () => ({
+  resolveAudioGenerationResult: vi.fn(),
+}));
+
 vi.mock("@/server/image-generation/image-generation", () => ({
   resolveImageGenerationResult: vi.fn(),
 }));
 
 vi.mock("@/server/video-generation/video-generation", () => ({
   resolveVideoGenerationResult: vi.fn(),
+}));
+
+vi.mock("@/server/audio-generation/audio-generation-repository", () => ({
+  saveAudioGenerationResult: vi.fn(),
+  updateAudioGenerationStatus: vi.fn(),
 }));
 
 vi.mock("@/server/image-generation/image-generation-repository", () => ({
@@ -61,6 +85,7 @@ vi.mock("@/server/model-catalog/runtime-models", async () => {
 });
 
 vi.mock("@/server/model-catalog/generation-validation", () => ({
+  validateAudioGenerationPayload: mockValidateAudioPayload,
   validateImageGenerationPayload: mockValidateImagePayload,
   validateVideoGenerationPayload: mockValidateVideoPayload,
 }));
@@ -68,6 +93,30 @@ vi.mock("@/server/model-catalog/generation-validation", () => ({
 describe("generation worker", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    const audioModels: RuntimeAudioModel[] = [
+      {
+        key: "alloy-tts",
+        isActive: true,
+        isDefault: true,
+        defaults: {
+          voice: "alloy",
+          speed: 1,
+        },
+        concurrentLimit: 1,
+        supportsInputAudio: false,
+      },
+      {
+        key: "qwen-tts",
+        isActive: true,
+        isDefault: false,
+        defaults: {
+          voice: "alloy",
+          speed: 1,
+        },
+        concurrentLimit: 1,
+        supportsInputAudio: false,
+      },
+    ];
     const imageModels: RuntimeImageModel[] = [
       {
         key: "z-image-turbo",
@@ -102,9 +151,103 @@ describe("generation worker", () => {
         supportsInitImage: true,
       },
     ];
-    mockGetRuntimeCatalog.mockResolvedValue({ imageModels, videoModels });
-    mockValidateImagePayload.mockResolvedValue({ success: true, data: {} });
-    mockValidateVideoPayload.mockResolvedValue({ success: true, data: {} });
+    mockGetRuntimeCatalog.mockResolvedValue({
+      audioModels,
+      imageModels,
+      videoModels,
+    });
+    mockValidateAudioPayload.mockImplementation(async (payload) => ({
+      success: true,
+      data: payload,
+    }));
+    mockValidateImagePayload.mockImplementation(async (payload) => ({
+      success: true,
+      data: payload,
+    }));
+    mockValidateVideoPayload.mockImplementation(async (payload) => ({
+      success: true,
+      data: payload,
+    }));
+  });
+
+  it("processAudioJobs uses modelKey for concurrent-limit accounting", async () => {
+    const processingRecord = {
+      requestParams: {},
+      modelKey: "qwen-tts",
+    };
+    const pendingRecord = {
+      id: "aud-pending-id",
+      requestId: "aud-request-id",
+      prompt: "hello",
+      progress: 0,
+      requestParams: {},
+      modelKey: "alloy-tts",
+    };
+
+    (prisma.audioGeneration.findMany as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([processingRecord])
+      .mockResolvedValueOnce([pendingRecord]);
+    (prisma.audioGeneration.updateMany as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 1 });
+    (resolveAudioGenerationResult as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "completed",
+      result: { audios: [] },
+      errorMessage: undefined,
+      skipDbSave: true,
+    });
+
+    await processAudioJobs();
+
+    expect(prisma.audioGeneration.updateMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { id: "aud-pending-id", status: "pending" },
+        data: { status: "processing", progress: 92 },
+      }),
+    );
+    expect(resolveAudioGenerationResult).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "alloy-tts" }),
+      "aud-request-id",
+    );
+  });
+
+  it("processAudioJobs updates status when completed with skipDbSave", async () => {
+    const mockRecord = {
+      id: "aud-db-id",
+      requestId: "aud-request-id",
+      prompt: "hello",
+      progress: 0,
+      requestParams: {
+        model: "qwen-tts",
+        voice: "alloy",
+        speed: 1,
+        seed: "",
+      },
+    };
+
+    (prisma.audioGeneration.findMany as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([mockRecord]);
+    (prisma.audioGeneration.updateMany as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 1,
+    });
+    (resolveAudioGenerationResult as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "completed",
+      result: { audios: [] },
+      errorMessage: undefined,
+      skipDbSave: true,
+    });
+
+    await processAudioJobs();
+
+    expect(updateAudioGenerationStatus).toHaveBeenCalledWith(
+      "aud-db-id",
+      "completed",
+      100,
+      undefined,
+    );
+    expect(saveAudioGenerationResult).not.toHaveBeenCalled();
   });
 
   it("processImageJobs updates status when completed with skipDbSave", async () => {

--- a/src/server/generation-worker/generation-worker.test.ts
+++ b/src/server/generation-worker/generation-worker.test.ts
@@ -113,8 +113,42 @@ describe("generation worker", () => {
           voice: "alloy",
           speed: 1,
         },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+          inputAudio: { ui: "upload" },
+          referenceText: { ui: "textarea" },
+          modeChoice: {
+            ui: "select",
+            options: ["voice_clone", "custom", "voice_design"],
+          },
+          language: {
+            ui: "select",
+            options: ["English", "Korean"],
+          },
+          speaker: {
+            ui: "select",
+            options: ["Vivian", "Serena"],
+          },
+          streamMode: { ui: "toggle" },
+          referencePreset: {
+            ui: "select",
+            options: ["ref_audio_3"],
+          },
+          xvecOnly: { ui: "toggle" },
+          chunkSize: { ui: "range", min: 1, max: 24, step: 1 },
+          temperature: { ui: "range", min: 0.1, max: 2, step: 0.05 },
+          topK: { ui: "range", min: 1, max: 100, step: 1 },
+          repetitionPenalty: {
+            ui: "range",
+            min: 1,
+            max: 1.5,
+            step: 0.01,
+          },
+          customInstruction: { ui: "textarea" },
+          voiceInstruction: { ui: "textarea" },
+        },
         concurrentLimit: 1,
-        supportsInputAudio: false,
+        supportsInputAudio: true,
       },
     ];
     const imageModels: RuntimeImageModel[] = [
@@ -248,6 +282,65 @@ describe("generation worker", () => {
       undefined,
     );
     expect(saveAudioGenerationResult).not.toHaveBeenCalled();
+  });
+
+  it("processAudioJobs preserves mode-based audio params and does not re-inject legacy voice defaults", async () => {
+    const mockRecord = {
+      id: "aud-mode-db-id",
+      requestId: "aud-mode-request-id",
+      prompt: "hello qwen",
+      progress: 0,
+      requestParams: {
+        model: "qwen-tts",
+        speed: 1,
+        seed: "",
+        inputAudio: "data:audio/wav;base64,UklGRg==",
+        referenceText: "reference transcript",
+        modeChoice: "voice_clone",
+        language: "English",
+        speaker: "Vivian",
+        streamMode: false,
+        referencePreset: "ref_audio_3",
+        xvecOnly: true,
+        chunkSize: 8,
+        temperature: 0.9,
+        topK: 50,
+        repetitionPenalty: 1.05,
+      },
+    };
+
+    (prisma.audioGeneration.findMany as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([mockRecord]);
+    (prisma.audioGeneration.updateMany as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 1,
+    });
+    (resolveAudioGenerationResult as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: "completed",
+      result: { audios: [] },
+      errorMessage: undefined,
+      skipDbSave: true,
+    });
+
+    await processAudioJobs();
+
+    expect(resolveAudioGenerationResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "qwen-tts",
+        voice: "",
+        modeChoice: "voice_clone",
+        language: "English",
+        speaker: "Vivian",
+        streamMode: false,
+        referencePreset: "ref_audio_3",
+        xvecOnly: true,
+        chunkSize: 8,
+        temperature: 0.9,
+        topK: 50,
+        repetitionPenalty: 1.05,
+      }),
+      "aud-mode-request-id",
+    );
   });
 
   it("processImageJobs updates status when completed with skipDbSave", async () => {

--- a/src/server/generation-worker/generation-worker.ts
+++ b/src/server/generation-worker/generation-worker.ts
@@ -34,10 +34,13 @@ const PROCESSING_TIMEOUT_MS = 30 * 60 * 1000;
 const ERROR_AUDIO_GENERATION_FAILED = "오디오 생성에 실패했습니다.";
 const ERROR_IMAGE_GENERATION_FAILED = "이미지 생성에 실패했습니다.";
 const ERROR_VIDEO_GENERATION_FAILED = "비디오 생성에 실패했습니다.";
+const WORKER_INSTANCE_TOKEN = Symbol("generation-worker-instance");
 
 type WorkerGlobal = typeof globalThis & {
   __generationWorkerStarted?: boolean;
   __generationWorkerRunning?: boolean;
+  __generationWorkerInterval?: ReturnType<typeof setInterval>;
+  __generationWorkerInstanceToken?: symbol;
 };
 
 type ImageRuntimeState = {
@@ -240,18 +243,100 @@ function buildAudioPayload(
     typeof params.model === "string" && runtime.modelMap.has(params.model)
       ? params.model
       : runtime.defaultKey;
-  const defaults =
-    runtime.modelMap.get(model)?.defaults ?? runtime.fallbackDefaults;
+  const runtimeModel = runtime.modelMap.get(model);
+  const defaults = runtimeModel?.defaults ?? runtime.fallbackDefaults;
+  const parameters =
+    runtimeModel?.parameters && typeof runtimeModel.parameters === "object"
+      ? runtimeModel.parameters
+      : {};
+  const hasVoiceParameter = "voice" in parameters;
+  const hasSpeakerParameter = "speaker" in parameters;
+  const hasModeChoiceParameter = "modeChoice" in parameters;
+  const hasLanguageParameter = "language" in parameters;
+  const hasStreamModeParameter = "streamMode" in parameters;
+  const hasReferencePresetParameter = "referencePreset" in parameters;
+  const hasCustomInstructionParameter = "customInstruction" in parameters;
+  const hasVoiceInstructionParameter = "voiceInstruction" in parameters;
+  const hasXvecOnlyParameter = "xvecOnly" in parameters;
+  const hasChunkSizeParameter = "chunkSize" in parameters;
+  const hasTemperatureParameter = "temperature" in parameters;
+  const hasTopKParameter = "topK" in parameters;
+  const hasRepetitionPenaltyParameter = "repetitionPenalty" in parameters;
+  const submittedVoice =
+    typeof params.voice === "string" ? params.voice : undefined;
+  const shouldSuppressLegacyVoice =
+    hasSpeakerParameter &&
+    typeof params.speaker === "string" &&
+    Boolean(params.speaker.trim()) &&
+    submittedVoice === defaults.voice;
 
   return {
     prompt: record.prompt,
     model,
-    voice: typeof params.voice === "string" ? params.voice : defaults.voice,
+    voice:
+      shouldSuppressLegacyVoice
+        ? ""
+        : typeof submittedVoice === "string"
+          ? submittedVoice
+        : hasVoiceParameter
+          ? defaults.voice
+          : "",
     speed: normalizeNumber(params.speed, defaults.speed),
     seed: typeof params.seed === "string" ? params.seed : "",
     inputAudio: typeof params.inputAudio === "string" ? params.inputAudio : "",
     referenceText:
       typeof params.referenceText === "string" ? params.referenceText : "",
+    speaker:
+      hasSpeakerParameter && typeof params.speaker === "string"
+        ? params.speaker
+        : "",
+    modeChoice:
+      hasModeChoiceParameter && typeof params.modeChoice === "string"
+        ? params.modeChoice
+        : "",
+    language:
+      hasLanguageParameter && typeof params.language === "string"
+        ? params.language
+        : "",
+    streamMode:
+      hasStreamModeParameter && typeof params.streamMode === "boolean"
+        ? params.streamMode
+        : undefined,
+    referencePreset:
+      hasReferencePresetParameter && typeof params.referencePreset === "string"
+        ? params.referencePreset
+        : "",
+    customInstruction:
+      hasCustomInstructionParameter &&
+      typeof params.customInstruction === "string"
+        ? params.customInstruction
+        : "",
+    voiceInstruction:
+      hasVoiceInstructionParameter &&
+      typeof params.voiceInstruction === "string"
+        ? params.voiceInstruction
+        : "",
+    xvecOnly:
+      hasXvecOnlyParameter && typeof params.xvecOnly === "boolean"
+        ? params.xvecOnly
+        : undefined,
+    chunkSize:
+      hasChunkSizeParameter && typeof params.chunkSize === "number"
+        ? params.chunkSize
+        : undefined,
+    temperature:
+      hasTemperatureParameter && typeof params.temperature === "number"
+        ? params.temperature
+        : undefined,
+    topK:
+      hasTopKParameter && typeof params.topK === "number"
+        ? params.topK
+        : undefined,
+    repetitionPenalty:
+      hasRepetitionPenaltyParameter &&
+      typeof params.repetitionPenalty === "number"
+        ? params.repetitionPenalty
+        : undefined,
   };
 }
 
@@ -652,7 +737,19 @@ export function startGenerationWorker() {
   }
 
   const globalForWorker = globalThis as WorkerGlobal;
-  if (globalForWorker.__generationWorkerStarted) return;
+  const isSameWorkerInstance =
+    globalForWorker.__generationWorkerInstanceToken === WORKER_INSTANCE_TOKEN;
+
+  if (globalForWorker.__generationWorkerStarted && isSameWorkerInstance) {
+    return;
+  }
+
+  if (!isSameWorkerInstance && globalForWorker.__generationWorkerInterval) {
+    clearInterval(globalForWorker.__generationWorkerInterval);
+    globalForWorker.__generationWorkerInterval = undefined;
+  }
+
+  globalForWorker.__generationWorkerInstanceToken = WORKER_INSTANCE_TOKEN;
   globalForWorker.__generationWorkerStarted = true;
 
   const tick = async () => {
@@ -666,5 +763,8 @@ export function startGenerationWorker() {
   };
 
   void tick();
-  setInterval(() => void tick(), WORKER_INTERVAL_MS);
+  globalForWorker.__generationWorkerInterval = setInterval(
+    () => void tick(),
+    WORKER_INTERVAL_MS,
+  );
 }

--- a/src/server/generation-worker/generation-worker.ts
+++ b/src/server/generation-worker/generation-worker.ts
@@ -579,7 +579,7 @@ async function handleAudioRecord(record: {
       record.requestId,
     );
 
-    if (result.status === "completed" && !result.skipDbSave) {
+    if (result.status === "completed" && result.result?.audios?.length) {
       await saveAudioGenerationResult(
         record.id,
         result.status,

--- a/src/server/generation-worker/generation-worker.ts
+++ b/src/server/generation-worker/generation-worker.ts
@@ -249,6 +249,9 @@ function buildAudioPayload(
     voice: typeof params.voice === "string" ? params.voice : defaults.voice,
     speed: normalizeNumber(params.speed, defaults.speed),
     seed: typeof params.seed === "string" ? params.seed : "",
+    inputAudio: typeof params.inputAudio === "string" ? params.inputAudio : "",
+    referenceText:
+      typeof params.referenceText === "string" ? params.referenceText : "",
   };
 }
 

--- a/src/server/generation-worker/generation-worker.ts
+++ b/src/server/generation-worker/generation-worker.ts
@@ -1,4 +1,9 @@
 import { prisma } from "@/server/db/prisma";
+import { resolveAudioGenerationResult } from "@/server/audio-generation/audio-generation";
+import {
+  saveAudioGenerationResult,
+  updateAudioGenerationStatus,
+} from "@/server/audio-generation/audio-generation-repository";
 import { resolveImageGenerationResult } from "@/server/image-generation/image-generation";
 import {
   saveImageGenerationResult,
@@ -10,10 +15,12 @@ import {
   updateVideoGenerationStatus,
 } from "@/server/video-generation/video-generation-repository";
 import {
+  validateAudioGenerationPayload,
   validateImageGenerationPayload,
   validateVideoGenerationPayload,
 } from "@/server/model-catalog/generation-validation";
 import {
+  type RuntimeAudioModel,
   getRuntimeCatalog,
   resolveDefaultModelKey,
   type RuntimeImageModel,
@@ -24,6 +31,7 @@ const WORKER_INTERVAL_MS = 2000;
 const PENDING_SCAN_LIMIT = 60;
 const PROCESSING_PROGRESS = 92;
 const PROCESSING_TIMEOUT_MS = 30 * 60 * 1000;
+const ERROR_AUDIO_GENERATION_FAILED = "오디오 생성에 실패했습니다.";
 const ERROR_IMAGE_GENERATION_FAILED = "이미지 생성에 실패했습니다.";
 const ERROR_VIDEO_GENERATION_FAILED = "비디오 생성에 실패했습니다.";
 
@@ -46,6 +54,13 @@ type VideoRuntimeState = {
   fallbackDefaults: RuntimeVideoModel["defaults"];
 };
 
+type AudioRuntimeState = {
+  modelMap: Map<string, RuntimeAudioModel>;
+  modelKeys: string[];
+  defaultKey: string;
+  fallbackDefaults: RuntimeAudioModel["defaults"];
+};
+
 function normalizeNumber(value: unknown, fallback: number) {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
@@ -62,6 +77,21 @@ function resolveModelKey(
     }
   }
   return fallbackKey;
+}
+
+function resolveRecordModelKey(
+  record: {
+    modelKey?: string | null;
+    requestParams: unknown;
+  },
+  modelKeys: string[],
+  fallbackKey: string,
+) {
+  if (typeof record.modelKey === "string" && modelKeys.includes(record.modelKey)) {
+    return record.modelKey;
+  }
+
+  return resolveModelKey(record.requestParams, modelKeys, fallbackKey);
 }
 
 async function getImageRuntimeState(): Promise<ImageRuntimeState | null> {
@@ -89,6 +119,21 @@ async function getVideoRuntimeState(): Promise<VideoRuntimeState | null> {
   return {
     modelMap,
     modelKeys: videoModels.map((model) => model.key),
+    defaultKey,
+    fallbackDefaults,
+  };
+}
+
+async function getAudioRuntimeState(): Promise<AudioRuntimeState | null> {
+  const { audioModels } = await getRuntimeCatalog({ includeInactive: true });
+  if (audioModels.length === 0) return null;
+  const modelMap = new Map(audioModels.map((model) => [model.key, model]));
+  const defaultKey = resolveDefaultModelKey(audioModels) ?? audioModels[0].key;
+  const fallbackDefaults =
+    modelMap.get(defaultKey)?.defaults ?? audioModels[0].defaults;
+  return {
+    modelMap,
+    modelKeys: audioModels.map((model) => model.key),
     defaultKey,
     fallbackDefaults,
   };
@@ -180,6 +225,33 @@ function buildVideoPayload(
   };
 }
 
+function buildAudioPayload(
+  record: {
+    prompt: string;
+    requestParams: unknown;
+  },
+  runtime: AudioRuntimeState,
+) {
+  const params =
+    record.requestParams && typeof record.requestParams === "object"
+      ? (record.requestParams as Record<string, unknown>)
+      : {};
+  const model =
+    typeof params.model === "string" && runtime.modelMap.has(params.model)
+      ? params.model
+      : runtime.defaultKey;
+  const defaults =
+    runtime.modelMap.get(model)?.defaults ?? runtime.fallbackDefaults;
+
+  return {
+    prompt: record.prompt,
+    model,
+    voice: typeof params.voice === "string" ? params.voice : defaults.voice,
+    speed: normalizeNumber(params.speed, defaults.speed),
+    seed: typeof params.seed === "string" ? params.seed : "",
+  };
+}
+
 function buildSlotsByModel<TModel extends string>(
   models: readonly TModel[],
   processingCounts: Map<TModel, number>,
@@ -205,12 +277,12 @@ async function getImageProcessingCounts(
 ) {
   const records = await prisma.imageGeneration.findMany({
     where: { status: "processing" },
-    select: { requestParams: true },
+    select: { modelKey: true, requestParams: true },
   });
   const counts = new Map<string, number>();
 
   for (const record of records) {
-    const model = resolveModelKey(record.requestParams, modelKeys, defaultKey);
+    const model = resolveRecordModelKey(record, modelKeys, defaultKey);
     counts.set(model, (counts.get(model) ?? 0) + 1);
   }
 
@@ -223,12 +295,30 @@ async function getVideoProcessingCounts(
 ) {
   const records = await prisma.videoGeneration.findMany({
     where: { status: "processing" },
-    select: { requestParams: true },
+    select: { modelKey: true, requestParams: true },
   });
   const counts = new Map<string, number>();
 
   for (const record of records) {
-    const model = resolveModelKey(record.requestParams, modelKeys, defaultKey);
+    const model = resolveRecordModelKey(record, modelKeys, defaultKey);
+    counts.set(model, (counts.get(model) ?? 0) + 1);
+  }
+
+  return counts;
+}
+
+async function getAudioProcessingCounts(
+  modelKeys: string[],
+  defaultKey: string,
+) {
+  const records = await prisma.audioGeneration.findMany({
+    where: { status: "processing" },
+    select: { modelKey: true, requestParams: true },
+  });
+  const counts = new Map<string, number>();
+
+  for (const record of records) {
+    const model = resolveRecordModelKey(record, modelKeys, defaultKey);
     counts.set(model, (counts.get(model) ?? 0) + 1);
   }
 
@@ -250,6 +340,18 @@ async function expireStaleImageProcessing() {
 async function expireStaleVideoProcessing() {
   const cutoff = new Date(Date.now() - PROCESSING_TIMEOUT_MS);
   await prisma.videoGeneration.updateMany({
+    where: { status: "processing", updatedAt: { lt: cutoff } },
+    data: {
+      status: "failed",
+      progress: 0,
+      errorMessage: "PROCESSING_TIMEOUT",
+    },
+  });
+}
+
+async function expireStaleAudioProcessing() {
+  const cutoff = new Date(Date.now() - PROCESSING_TIMEOUT_MS);
+  await prisma.audioGeneration.updateMany({
     where: { status: "processing", updatedAt: { lt: cutoff } },
     data: {
       status: "failed",
@@ -364,6 +466,57 @@ async function handleVideoRecord(record: {
   }
 }
 
+async function handleAudioRecord(record: {
+  id: string;
+  requestId: string;
+  prompt: string;
+  requestParams: unknown;
+  progress: number;
+}, runtime: AudioRuntimeState) {
+  const payload = buildAudioPayload(record, runtime);
+  const parsed = await validateAudioGenerationPayload(payload);
+  if (!parsed.success) {
+    await updateAudioGenerationStatus(
+      record.id,
+      "failed",
+      record.progress,
+      "INVALID_JOB_PAYLOAD",
+    );
+    return;
+  }
+
+  try {
+    const result = await resolveAudioGenerationResult(
+      parsed.data,
+      record.requestId,
+    );
+
+    if (result.status === "completed" && !result.skipDbSave) {
+      await saveAudioGenerationResult(
+        record.id,
+        result.status,
+        100,
+        result.result,
+        result.errorMessage,
+      );
+    } else {
+      await updateAudioGenerationStatus(
+        record.id,
+        result.status,
+        result.status === "completed" ? 100 : 0,
+        result.errorMessage,
+      );
+    }
+  } catch (error) {
+    await updateAudioGenerationStatus(
+      record.id,
+      "failed",
+      0,
+      error instanceof Error ? error.message : ERROR_AUDIO_GENERATION_FAILED,
+    );
+  }
+}
+
 export async function processImageJobs() {
   const runtime = await getImageRuntimeState();
   if (!runtime) return;
@@ -388,11 +541,7 @@ export async function processImageJobs() {
   const claimedRecords: typeof pending = [];
 
   for (const record of pending) {
-    const model = resolveModelKey(
-      record.requestParams,
-      runtime.modelKeys,
-      runtime.defaultKey,
-    );
+    const model = resolveRecordModelKey(record, runtime.modelKeys, runtime.defaultKey);
     const available = slots.get(model) ?? 0;
     if (available <= 0) continue;
 
@@ -434,11 +583,7 @@ export async function processVideoJobs() {
   const claimedRecords: typeof pending = [];
 
   for (const record of pending) {
-    const model = resolveModelKey(
-      record.requestParams,
-      runtime.modelKeys,
-      runtime.defaultKey,
-    );
+    const model = resolveRecordModelKey(record, runtime.modelKeys, runtime.defaultKey);
     const available = slots.get(model) ?? 0;
     if (available <= 0) continue;
 
@@ -456,6 +601,48 @@ export async function processVideoJobs() {
   await Promise.all(claimedRecords.map((record) => handleVideoRecord(record, runtime)));
 }
 
+export async function processAudioJobs() {
+  const runtime = await getAudioRuntimeState();
+  if (!runtime) return;
+  await expireStaleAudioProcessing();
+  const processingCounts = await getAudioProcessingCounts(
+    runtime.modelKeys,
+    runtime.defaultKey,
+  );
+  const { slots, totalSlots } = buildSlotsByModel(
+    runtime.modelKeys,
+    processingCounts,
+    (model) => runtime.modelMap.get(model)?.concurrentLimit ?? 1,
+  );
+  if (totalSlots === 0) return;
+
+  const pending = await prisma.audioGeneration.findMany({
+    where: { status: "pending" },
+    orderBy: { createdAt: "asc" },
+    take: Math.max(totalSlots * 3, PENDING_SCAN_LIMIT),
+  });
+
+  const claimedRecords: typeof pending = [];
+
+  for (const record of pending) {
+    const model = resolveRecordModelKey(record, runtime.modelKeys, runtime.defaultKey);
+    const available = slots.get(model) ?? 0;
+    if (available <= 0) continue;
+
+    const claimed = await prisma.audioGeneration.updateMany({
+      where: { id: record.id, status: "pending" },
+      data: { status: "processing", progress: PROCESSING_PROGRESS },
+    });
+    if (claimed.count === 0) continue;
+
+    slots.set(model, available - 1);
+    claimedRecords.push(record);
+    if (claimedRecords.length >= totalSlots) break;
+  }
+
+  await Promise.all(claimedRecords.map((record) => handleAudioRecord(record, runtime)));
+}
+
 export function startGenerationWorker() {
   if (process.env.NODE_ENV === "test" || process.env.VITEST) {
     return;
@@ -469,7 +656,7 @@ export function startGenerationWorker() {
     if (globalForWorker.__generationWorkerRunning) return;
     globalForWorker.__generationWorkerRunning = true;
     try {
-      await Promise.all([processImageJobs(), processVideoJobs()]);
+      await Promise.all([processImageJobs(), processVideoJobs(), processAudioJobs()]);
     } finally {
       globalForWorker.__generationWorkerRunning = false;
     }

--- a/src/server/hf-space/file-reference-resolver.test.ts
+++ b/src/server/hf-space/file-reference-resolver.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectHfSpaceFileReferences,
+  extractHfSpaceFileReference,
+  resolveHfSpaceFileReferenceCandidates,
+  resolveHfSpaceFileReference,
+} from "@/server/hf-space/file-reference-resolver";
+
+const SPACE_URL = "https://demo-space.hf.space";
+
+describe("file-reference-resolver", () => {
+  it("정규화 규칙을 canonical file reference로 변환한다", () => {
+    expect(
+      resolveHfSpaceFileReference(
+        "data:audio/wav;base64,UklGRg==",
+        SPACE_URL,
+      ),
+    ).toEqual({
+      kind: "data_url",
+      value: "data:audio/wav;base64,UklGRg==",
+      normalizedUrl: "data:audio/wav;base64,UklGRg==",
+    });
+
+    expect(
+      resolveHfSpaceFileReference("https://cdn.example.com/file.png", SPACE_URL),
+    ).toEqual({
+      kind: "absolute_url",
+      value: "https://cdn.example.com/file.png",
+      normalizedUrl: "https://cdn.example.com/file.png",
+    });
+
+    expect(
+      resolveHfSpaceFileReference("/gradio_api/file=/tmp/out.wav", SPACE_URL),
+    ).toEqual({
+      kind: "gradio_file_url",
+      value: "/gradio_api/file=/tmp/out.wav",
+      normalizedUrl: `${SPACE_URL}/gradio_api/file=/tmp/out.wav`,
+    });
+
+    expect(
+      resolveHfSpaceFileReference("/file=/tmp/out.wav", SPACE_URL),
+    ).toEqual({
+      kind: "legacy_gradio_file_url",
+      value: "/file=/tmp/out.wav",
+      normalizedUrl: `${SPACE_URL}/gradio_api/file=/tmp/out.wav`,
+    });
+
+    expect(resolveHfSpaceFileReference("file=/tmp/out.wav", SPACE_URL)).toEqual({
+      kind: "legacy_gradio_file_url",
+      value: "file=/tmp/out.wav",
+      normalizedUrl: `${SPACE_URL}/gradio_api/file=/tmp/out.wav`,
+    });
+
+    expect(resolveHfSpaceFileReference("/tmp/out.wav", SPACE_URL)).toEqual({
+      kind: "space_path",
+      value: "/tmp/out.wav",
+      normalizedUrl: `${SPACE_URL}/gradio_api/file=/tmp/out.wav`,
+    });
+  });
+
+  it("string/object/nested array에서 파일 참조를 추출한다", () => {
+    expect(extractHfSpaceFileReference({ path: "/tmp/out.wav" })).toBe(
+      "/tmp/out.wav",
+    );
+    expect(
+      extractHfSpaceFileReference({
+        data: "data:image/png;base64,abc",
+      }),
+    ).toBe("data:image/png;base64,abc");
+
+    expect(
+      collectHfSpaceFileReferences(
+        [
+          { url: "https://cdn.example.com/a.png" },
+          {
+            nested: [
+              { path: "/tmp/out.wav" },
+              { ignored: "hello" },
+              { data: "data:video/mp4;base64,abc" },
+            ],
+          },
+        ],
+        {
+          matcher: (value) =>
+            value.includes(".png") ||
+            value.includes(".wav") ||
+            value.startsWith("data:video/"),
+        },
+      ),
+    ).toEqual([
+      "https://cdn.example.com/a.png",
+      "/tmp/out.wav",
+      "data:video/mp4;base64,abc",
+    ]);
+  });
+
+  it("absolute url을 canonical origin으로 사용하고 동일 asset 후보를 우선순위로 정리한다", () => {
+    expect(
+      resolveHfSpaceFileReferenceCandidates(
+        [
+          "https://demo-space-real.hf.space/gradio_api/file=/tmp/gradio/job-1/audio.wav",
+          "/tmp/gradio/job-1/audio.wav",
+          "audio.wav",
+        ],
+        {
+          spaceUrl: "https://demo-space-fallback.hf.space",
+        },
+      ),
+    ).toEqual([
+      {
+        assetKey: "/tmp/gradio/job-1/audio.wav",
+        candidates: [
+          {
+            kind: "absolute_url",
+            value:
+              "https://demo-space-real.hf.space/gradio_api/file=/tmp/gradio/job-1/audio.wav",
+            normalizedUrl:
+              "https://demo-space-real.hf.space/gradio_api/file=/tmp/gradio/job-1/audio.wav",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/server/hf-space/file-reference-resolver.ts
+++ b/src/server/hf-space/file-reference-resolver.ts
@@ -1,0 +1,360 @@
+export type HfSpaceFileReferenceKind =
+  | "data_url"
+  | "absolute_url"
+  | "gradio_file_url"
+  | "legacy_gradio_file_url"
+  | "space_path"
+  | "bare_filename";
+
+export type HfSpaceResolvedFileReference = {
+  kind: HfSpaceFileReferenceKind;
+  value: string;
+  normalizedUrl: string;
+};
+
+export type HfSpaceResolvedFileReferenceGroup = {
+  assetKey: string;
+  candidates: HfSpaceResolvedFileReference[];
+};
+
+type ExtractableFileReference = {
+  url?: unknown;
+  path?: unknown;
+  name?: unknown;
+  data?: unknown;
+};
+
+type CollectOptions = {
+  matcher?: (value: string) => boolean;
+  maxDepth?: number;
+};
+
+type ResolveCandidateOptions = CollectOptions & {
+  spaceUrl: string;
+};
+
+type PreparedCandidate = HfSpaceResolvedFileReference & {
+  assetKey: string;
+  assetName: string | null;
+  priority: number;
+};
+
+const GRADIO_FILE_EQUALS_PREFIX = "/gradio_api/file=";
+const GRADIO_FILE_SLASH_PREFIX = "/gradio_api/file/";
+const LEGACY_FILE_EQUALS_PREFIX = "/file=";
+const LEGACY_FILE_BARE_PREFIX = "file=";
+const LEGACY_FILE_SLASH_PREFIX = "/file/";
+
+function trim(value: string) {
+  return value.trim();
+}
+
+function isAbsoluteHttpUrl(value: string) {
+  return value.startsWith("http://") || value.startsWith("https://");
+}
+
+function getBaseUrl(spaceUrl: string) {
+  return spaceUrl.endsWith("/") ? spaceUrl.slice(0, -1) : spaceUrl;
+}
+
+function getOrigin(value: string) {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function getPathBasename(value: string) {
+  const normalized = value.replace(/\\/g, "/");
+  const parts = normalized.split("/").filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : normalized;
+}
+
+function looksLikeBareFilename(value: string) {
+  return (
+    !value.includes("/") &&
+    !value.includes("\\") &&
+    !value.includes("file=") &&
+    !value.includes("?") &&
+    value.length > 0
+  );
+}
+
+function getPriority(kind: HfSpaceFileReferenceKind) {
+  switch (kind) {
+    case "data_url":
+      return 100;
+    case "absolute_url":
+      return 90;
+    case "gradio_file_url":
+      return 80;
+    case "legacy_gradio_file_url":
+      return 70;
+    case "space_path":
+      return 60;
+    case "bare_filename":
+      return 10;
+  }
+}
+
+function extractResourcePath(kind: HfSpaceFileReferenceKind, value: string) {
+  switch (kind) {
+    case "absolute_url": {
+      try {
+        const url = new URL(value);
+        const pathname = `${url.pathname}${url.search}`;
+        if (pathname.startsWith(GRADIO_FILE_EQUALS_PREFIX)) {
+          return pathname.slice(GRADIO_FILE_EQUALS_PREFIX.length);
+        }
+        if (pathname.startsWith(GRADIO_FILE_SLASH_PREFIX)) {
+          return pathname.slice(GRADIO_FILE_SLASH_PREFIX.length - 1);
+        }
+        if (pathname.startsWith(LEGACY_FILE_SLASH_PREFIX)) {
+          return pathname.slice(LEGACY_FILE_SLASH_PREFIX.length - 1);
+        }
+        return pathname;
+      } catch {
+        return value;
+      }
+    }
+    case "gradio_file_url":
+      if (value.startsWith(GRADIO_FILE_EQUALS_PREFIX)) {
+        return value.slice(GRADIO_FILE_EQUALS_PREFIX.length);
+      }
+      if (value.startsWith(GRADIO_FILE_SLASH_PREFIX)) {
+        return value.slice(GRADIO_FILE_SLASH_PREFIX.length - 1);
+      }
+      return value;
+    case "legacy_gradio_file_url":
+      if (value.startsWith(LEGACY_FILE_EQUALS_PREFIX)) {
+        return value.slice(LEGACY_FILE_EQUALS_PREFIX.length);
+      }
+      if (value.startsWith(LEGACY_FILE_BARE_PREFIX)) {
+        return value.slice(LEGACY_FILE_BARE_PREFIX.length);
+      }
+      if (value.startsWith(LEGACY_FILE_SLASH_PREFIX)) {
+        return value.slice(LEGACY_FILE_SLASH_PREFIX.length - 1);
+      }
+      return value;
+    case "space_path":
+      return value;
+    case "bare_filename":
+      return value;
+    case "data_url":
+      return null;
+  }
+}
+
+export function extractHfSpaceFileReference(value: unknown): string | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    const normalized = trim(value);
+    return normalized.length > 0 ? normalized : null;
+  }
+  if (typeof value !== "object") return null;
+
+  const candidate = value as ExtractableFileReference;
+  if (typeof candidate.data === "string" && candidate.data.startsWith("data:")) {
+    return candidate.data;
+  }
+  if (typeof candidate.url === "string") return trim(candidate.url);
+  if (typeof candidate.path === "string") return trim(candidate.path);
+  if (typeof candidate.name === "string") return trim(candidate.name);
+  return null;
+}
+
+export function collectHfSpaceFileReferences(
+  value: unknown,
+  options: CollectOptions = {},
+): string[] {
+  const matcher = options.matcher ?? (() => true);
+  const maxDepth = options.maxDepth ?? 4;
+  const refs: string[] = [];
+  const seen = new Set<string>();
+
+  function visit(current: unknown, depth: number) {
+    if (depth > maxDepth || current === null || current === undefined) return;
+
+    const direct = extractHfSpaceFileReference(current);
+    if (direct && matcher(direct) && !seen.has(direct)) {
+      seen.add(direct);
+      refs.push(direct);
+    }
+
+    if (typeof current === "string" || typeof current !== "object") return;
+
+    if (Array.isArray(current)) {
+      current.forEach((item) => visit(item, depth + 1));
+      return;
+    }
+
+    Object.values(current as Record<string, unknown>).forEach((item) =>
+      visit(item, depth + 1),
+    );
+  }
+
+  visit(value, 0);
+  return refs;
+}
+
+export function resolveHfSpaceFileReference(
+  value: string,
+  spaceUrl: string,
+): HfSpaceResolvedFileReference {
+  const fileRef = trim(value);
+  const baseUrl = getBaseUrl(spaceUrl);
+
+  if (fileRef.startsWith("data:")) {
+    return { kind: "data_url", value: fileRef, normalizedUrl: fileRef };
+  }
+
+  if (isAbsoluteHttpUrl(fileRef)) {
+    return { kind: "absolute_url", value: fileRef, normalizedUrl: fileRef };
+  }
+
+  if (
+    fileRef.startsWith(GRADIO_FILE_EQUALS_PREFIX) ||
+    fileRef.startsWith(GRADIO_FILE_SLASH_PREFIX)
+  ) {
+    return {
+      kind: "gradio_file_url",
+      value: fileRef,
+      normalizedUrl: `${baseUrl}${fileRef}`,
+    };
+  }
+
+  if (fileRef.startsWith(LEGACY_FILE_EQUALS_PREFIX)) {
+    return {
+      kind: "legacy_gradio_file_url",
+      value: fileRef,
+      normalizedUrl: `${baseUrl}/gradio_api${fileRef}`,
+    };
+  }
+
+  if (fileRef.startsWith(LEGACY_FILE_BARE_PREFIX)) {
+    return {
+      kind: "legacy_gradio_file_url",
+      value: fileRef,
+      normalizedUrl: `${baseUrl}/gradio_api/${fileRef}`,
+    };
+  }
+
+  if (fileRef.startsWith(LEGACY_FILE_SLASH_PREFIX)) {
+    return {
+      kind: "legacy_gradio_file_url",
+      value: fileRef,
+      normalizedUrl: `${baseUrl}${fileRef}`,
+    };
+  }
+
+  if (looksLikeBareFilename(fileRef)) {
+    return {
+      kind: "bare_filename",
+      value: fileRef,
+      normalizedUrl: `${baseUrl}/gradio_api/file=${fileRef}`,
+    };
+  }
+
+  return {
+    kind: "space_path",
+    value: fileRef,
+    normalizedUrl: `${baseUrl}/gradio_api/file=${fileRef}`,
+  };
+}
+
+function prepareCandidate(
+  value: string,
+  canonicalBaseUrl: string,
+): PreparedCandidate {
+  const resolved = resolveHfSpaceFileReference(value, canonicalBaseUrl);
+  const resourcePath = extractResourcePath(resolved.kind, resolved.value);
+  const assetName = resourcePath ? getPathBasename(resourcePath) : null;
+
+  return {
+    ...resolved,
+    assetKey:
+      resolved.kind === "data_url"
+        ? resolved.normalizedUrl
+        : resourcePath || resolved.normalizedUrl,
+    assetName,
+    priority: getPriority(resolved.kind),
+  };
+}
+
+export function resolveHfSpaceFileReferenceCandidates(
+  value: unknown,
+  options: ResolveCandidateOptions,
+): HfSpaceResolvedFileReferenceGroup[] {
+  const refs = collectHfSpaceFileReferences(value, options);
+  if (refs.length === 0) {
+    return [];
+  }
+
+  const fallbackBaseUrl = getBaseUrl(options.spaceUrl);
+  const canonicalBaseUrl =
+    refs.map(getOrigin).find((origin): origin is string => Boolean(origin)) ??
+    fallbackBaseUrl;
+
+  const prepared = refs.map((ref) => prepareCandidate(ref, canonicalBaseUrl));
+  const nonBareCandidates = prepared.filter(
+    (candidate) => candidate.kind !== "bare_filename",
+  );
+  const assetKeysByName = new Map<string, string>();
+
+  nonBareCandidates.forEach((candidate) => {
+    if (!candidate.assetName || assetKeysByName.has(candidate.assetName)) {
+      return;
+    }
+    assetKeysByName.set(candidate.assetName, candidate.assetKey);
+  });
+
+  const groups = new Map<string, PreparedCandidate[]>();
+  const addToGroup = (candidate: PreparedCandidate) => {
+    const current = groups.get(candidate.assetKey) ?? [];
+    if (!current.some((item) => item.normalizedUrl === candidate.normalizedUrl)) {
+      current.push(candidate);
+      current.sort((left, right) => right.priority - left.priority);
+      groups.set(candidate.assetKey, current);
+    }
+  };
+
+  nonBareCandidates.forEach(addToGroup);
+
+  prepared
+    .filter((candidate) => candidate.kind === "bare_filename")
+    .forEach((candidate) => {
+      if (candidate.assetName && assetKeysByName.has(candidate.assetName)) {
+        return;
+      }
+      addToGroup(candidate);
+    });
+
+  return Array.from(groups.entries())
+    .map(([assetKey, candidates]) => ({
+      assetKey,
+      candidates: candidates.map(({ kind, value, normalizedUrl }) => ({
+        kind,
+        value,
+        normalizedUrl,
+      })),
+    }))
+    .sort((left, right) => {
+      const leftPriority =
+        groups.get(left.assetKey)?.[0]?.priority ?? Number.NEGATIVE_INFINITY;
+      const rightPriority =
+        groups.get(right.assetKey)?.[0]?.priority ?? Number.NEGATIVE_INFINITY;
+      return rightPriority - leftPriority;
+    });
+}
+
+export function selectPreferredHfSpaceFileReference(
+  value: unknown,
+  options: ResolveCandidateOptions,
+) {
+  return resolveHfSpaceFileReferenceCandidates(value, options)[0]?.candidates[0] ?? null;
+}
+
+export function normalizeHfSpaceFileUrl(value: string, spaceUrl: string) {
+  return resolveHfSpaceFileReference(value, spaceUrl).normalizedUrl;
+}

--- a/src/server/history/handlers/get-history-status.ts
+++ b/src/server/history/handlers/get-history-status.ts
@@ -1,6 +1,11 @@
-import type { ImageGenerationStatus, VideoGenerationStatus } from "@prisma/client";
+import type {
+  AudioGenerationStatus,
+  ImageGenerationStatus,
+  VideoGenerationStatus,
+} from "@prisma/client";
 import { prisma } from "@/server/db/prisma";
 import {
+  buildAudioWhere,
   buildImageWhere,
   buildVideoWhere,
   parseHistoryQuery,
@@ -8,6 +13,7 @@ import {
 
 const ACTIVE_IMAGE_STATUSES: ImageGenerationStatus[] = ["pending", "processing"];
 const ACTIVE_VIDEO_STATUSES: VideoGenerationStatus[] = ["pending", "processing"];
+const ACTIVE_AUDIO_STATUSES: AudioGenerationStatus[] = ["pending", "processing"];
 
 type ActiveStatus = {
   activeCount: number;
@@ -72,6 +78,32 @@ async function getActiveVideoStatus(
   };
 }
 
+async function getActiveAudioStatus(
+  where: Record<string, unknown>,
+): Promise<ActiveStatus> {
+  const [activeCount, latest] = await Promise.all([
+    prisma.audioGeneration.count({
+      where: {
+        ...where,
+        status: { in: ACTIVE_AUDIO_STATUSES },
+      },
+    }),
+    prisma.audioGeneration.findFirst({
+      where: {
+        ...where,
+        status: { in: ACTIVE_AUDIO_STATUSES },
+      },
+      orderBy: { updatedAt: "desc" },
+      select: { updatedAt: true },
+    }),
+  ]);
+
+  return {
+    activeCount,
+    latestUpdatedAt: latest?.updatedAt ?? null,
+  };
+}
+
 export async function getHistoryStatus(
   searchParams: URLSearchParams,
   ownerEmail: string,
@@ -98,18 +130,31 @@ export async function getHistoryStatus(
     };
   }
 
+  if (query.type === "audio") {
+    const where = { ownerEmail, ...buildAudioWhere(query) };
+    const status = await getActiveAudioStatus(where);
+    return {
+      hasActive: status.activeCount > 0,
+      activeCount: status.activeCount,
+      latestUpdatedAt: status.latestUpdatedAt?.toISOString() ?? null,
+    };
+  }
+
   const imageWhere = { ownerEmail, ...buildImageWhere(query) };
   const videoWhere = { ownerEmail, ...buildVideoWhere(query) };
+  const audioWhere = { ownerEmail, ...buildAudioWhere(query) };
 
-  const [imageStatus, videoStatus] = await Promise.all([
+  const [imageStatus, videoStatus, audioStatus] = await Promise.all([
     getActiveImageStatus(imageWhere),
     getActiveVideoStatus(videoWhere),
+    getActiveAudioStatus(audioWhere),
   ]);
 
-  const activeCount = imageStatus.activeCount + videoStatus.activeCount;
+  const activeCount =
+    imageStatus.activeCount + videoStatus.activeCount + audioStatus.activeCount;
   const latestUpdatedAt = maxDate(
-    imageStatus.latestUpdatedAt,
-    videoStatus.latestUpdatedAt,
+    maxDate(imageStatus.latestUpdatedAt, videoStatus.latestUpdatedAt),
+    audioStatus.latestUpdatedAt,
   );
 
   return {

--- a/src/server/history/handlers/get-history.ts
+++ b/src/server/history/handlers/get-history.ts
@@ -3,8 +3,10 @@ import {
   buildAudioWhere,
   buildImageWhere,
   buildVideoWhere,
+  extractInputAudios,
   extractInputImages,
   extractModel,
+  extractReferenceText,
   parseHistoryQuery,
   type HistoryResponse,
 } from "@/server/history/lib/history-query";
@@ -135,6 +137,8 @@ export async function getHistory(
       const model = extractModel(record.requestParams);
       const previewUrl = record.audios[0]?.url ?? null;
       const isCompleted = record.status === "completed";
+      const inputAudios = extractInputAudios(record.requestParams);
+      const referenceText = extractReferenceText(record.requestParams);
 
       return {
         id: record.requestId,
@@ -146,6 +150,8 @@ export async function getHistory(
         resultUrl: isCompleted ? previewUrl : null,
         thumbnailUrl: null,
         inputImages: [],
+        inputAudios,
+        referenceText,
         errorMessage: record.status === "failed" ? record.errorMessage ?? null : null,
       };
     });
@@ -253,6 +259,8 @@ export async function getHistory(
     const model = extractModel(record.requestParams);
     const previewUrl = record.audios[0]?.url ?? null;
     const isCompleted = record.status === "completed";
+    const inputAudios = extractInputAudios(record.requestParams);
+    const referenceText = extractReferenceText(record.requestParams);
 
     return {
       id: record.requestId,
@@ -264,6 +272,8 @@ export async function getHistory(
       resultUrl: isCompleted ? previewUrl : null,
       thumbnailUrl: null,
       inputImages: [],
+      inputAudios,
+      referenceText,
       errorMessage: record.status === "failed" ? record.errorMessage ?? null : null,
     };
   });

--- a/src/server/history/handlers/get-history.ts
+++ b/src/server/history/handlers/get-history.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/server/db/prisma";
 import {
+  buildAudioWhere,
   buildImageWhere,
   buildVideoWhere,
   extractInputImages,
@@ -112,15 +113,63 @@ export async function getHistory(
     };
   }
 
+  if (query.type === "audio") {
+    const where = { ownerEmail, ...buildAudioWhere(query) };
+    const [records, total] = await prisma.$transaction([
+      prisma.audioGeneration.findMany({
+        where,
+        orderBy,
+        skip: cappedOffset,
+        take: query.limit,
+        include: {
+          audios: {
+            orderBy: { createdAt: "asc" },
+            take: 1,
+          },
+        },
+      }),
+      prisma.audioGeneration.count({ where }),
+    ]);
+
+    const items = records.map((record) => {
+      const model = extractModel(record.requestParams);
+      const previewUrl = record.audios[0]?.url ?? null;
+      const isCompleted = record.status === "completed";
+
+      return {
+        id: record.requestId,
+        type: "audio" as const,
+        status: record.status,
+        prompt: record.prompt,
+        model,
+        createdAt: record.createdAt.toISOString(),
+        resultUrl: isCompleted ? previewUrl : null,
+        thumbnailUrl: null,
+        inputImages: [],
+        errorMessage: record.status === "failed" ? record.errorMessage ?? null : null,
+      };
+    });
+
+    return {
+      items,
+      total,
+      limit: query.limit,
+      offset: cappedOffset,
+    };
+  }
+
   const take = query.limit + cappedOffset;
   const imageWhere = { ownerEmail, ...buildImageWhere(query) };
   const videoWhere = { ownerEmail, ...buildVideoWhere(query) };
+  const audioWhere = { ownerEmail, ...buildAudioWhere(query) };
 
   const [
     imageRecords,
     imageTotal,
     videoRecords,
     videoTotal,
+    audioRecords,
+    audioTotal,
   ] = await prisma.$transaction([
     prisma.imageGeneration.findMany({
       where: imageWhere,
@@ -146,6 +195,18 @@ export async function getHistory(
       },
     }),
     prisma.videoGeneration.count({ where: videoWhere }),
+    prisma.audioGeneration.findMany({
+      where: audioWhere,
+      orderBy,
+      take,
+      include: {
+        audios: {
+          orderBy: { createdAt: "asc" },
+          take: 1,
+        },
+      },
+    }),
+    prisma.audioGeneration.count({ where: audioWhere }),
   ]);
 
   const imageItems = imageRecords.map((record) => {
@@ -188,7 +249,26 @@ export async function getHistory(
     };
   });
 
-  const merged = [...imageItems, ...videoItems].sort((a, b) => {
+  const audioItems = audioRecords.map((record) => {
+    const model = extractModel(record.requestParams);
+    const previewUrl = record.audios[0]?.url ?? null;
+    const isCompleted = record.status === "completed";
+
+    return {
+      id: record.requestId,
+      type: "audio" as const,
+      status: record.status,
+      prompt: record.prompt,
+      model,
+      createdAt: record.createdAt.toISOString(),
+      resultUrl: isCompleted ? previewUrl : null,
+      thumbnailUrl: null,
+      inputImages: [],
+      errorMessage: record.status === "failed" ? record.errorMessage ?? null : null,
+    };
+  });
+
+  const merged = [...imageItems, ...videoItems, ...audioItems].sort((a, b) => {
     const aTime = new Date(a.createdAt).getTime();
     const bTime = new Date(b.createdAt).getTime();
     return query.sort === "date_asc" ? aTime - bTime : bTime - aTime;
@@ -196,7 +276,7 @@ export async function getHistory(
 
   return {
     items: merged.slice(cappedOffset, cappedOffset + query.limit),
-    total: imageTotal + videoTotal,
+    total: imageTotal + videoTotal + audioTotal,
     limit: query.limit,
     offset: cappedOffset,
   };

--- a/src/server/history/lib/history-query.test.ts
+++ b/src/server/history/lib/history-query.test.ts
@@ -155,5 +155,19 @@ describe("history-query", () => {
         }),
       ).toBe("reference words");
     });
+
+    it("inputAudio가 없거나 잘못된 타입이면 빈 배열을 반환한다", () => {
+      expect(extractInputAudios({})).toEqual([]);
+      expect(extractInputAudios(null)).toEqual([]);
+      expect(extractInputAudios({ inputAudio: 123 })).toEqual([]);
+      expect(extractInputAudios({ inputAudio: [] })).toEqual([]);
+    });
+
+    it("referenceText가 없거나 잘못된 타입이면 null을 반환한다", () => {
+      expect(extractReferenceText({})).toBeNull();
+      expect(extractReferenceText(null)).toBeNull();
+      expect(extractReferenceText({ referenceText: "" })).toBeNull();
+      expect(extractReferenceText({ referenceText: 123 })).toBeNull();
+    });
   });
 });

--- a/src/server/history/lib/history-query.test.ts
+++ b/src/server/history/lib/history-query.test.ts
@@ -61,6 +61,16 @@ describe("history-query", () => {
       const result = parseHistoryQuery(params);
       expect(result.limit).toBe(1);
     });
+
+    it("audio 타입을 허용한다", () => {
+      const params = new URLSearchParams({
+        type: "AUDIO",
+      });
+
+      const result = parseHistoryQuery(params);
+
+      expect(result.type).toBe("audio");
+    });
   });
 
   describe("buildImageWhere", () => {

--- a/src/server/history/lib/history-query.test.ts
+++ b/src/server/history/lib/history-query.test.ts
@@ -1,6 +1,8 @@
 import {
   buildImageWhere,
   buildVideoWhere,
+  extractInputAudios,
+  extractReferenceText,
   extractModel,
   parseHistoryQuery,
 } from "@/server/history/lib/history-query";
@@ -136,6 +138,22 @@ describe("history-query", () => {
       expect(extractModel({ model: 123 })).toBeNull();
       expect(extractModel({})).toBeNull();
       expect(extractModel(null)).toBeNull();
+    });
+  });
+
+  describe("audio reference extractors", () => {
+    it("inputAudio와 referenceText를 추출한다", () => {
+      expect(
+        extractInputAudios({
+          inputAudio: "data:audio/wav;base64,UklGRg==",
+          referenceText: "reference words",
+        }),
+      ).toEqual(["data:audio/wav;base64,UklGRg=="]);
+      expect(
+        extractReferenceText({
+          referenceText: "reference words",
+        }),
+      ).toBe("reference words");
     });
   });
 });

--- a/src/server/history/lib/history-query.test.ts
+++ b/src/server/history/lib/history-query.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildAudioWhere,
   buildImageWhere,
   buildVideoWhere,
   extractInputAudios,
@@ -122,6 +123,33 @@ describe("history-query", () => {
             requestParams: {
               path: ["model"],
               string_contains: "clip",
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  describe("buildAudioWhere", () => {
+    it("query가 없으면 빈 조건을 반환한다", () => {
+      const query = parseHistoryQuery(new URLSearchParams());
+      expect(buildAudioWhere(query)).toEqual({});
+    });
+
+    it("prompt/model 검색 조건을 생성한다", () => {
+      const query = parseHistoryQuery(new URLSearchParams({ query: "voice" }));
+      expect(buildAudioWhere(query)).toEqual({
+        OR: [
+          {
+            prompt: {
+              contains: "voice",
+              mode: "insensitive",
+            },
+          },
+          {
+            requestParams: {
+              path: ["model"],
+              string_contains: "voice",
             },
           },
         ],

--- a/src/server/history/lib/history-query.ts
+++ b/src/server/history/lib/history-query.ts
@@ -152,3 +152,20 @@ export function extractInputImages(params: unknown): string[] {
   }
   return images;
 }
+
+export function extractInputAudios(params: unknown): string[] {
+  if (!params || typeof params !== "object") return [];
+  const record = params as Record<string, unknown>;
+  if (typeof record.inputAudio === "string" && record.inputAudio.trim()) {
+    return [record.inputAudio.trim()];
+  }
+  return [];
+}
+
+export function extractReferenceText(params: unknown): string | null {
+  if (!params || typeof params !== "object") return null;
+  const record = params as Record<string, unknown>;
+  return typeof record.referenceText === "string" && record.referenceText.trim()
+    ? record.referenceText.trim()
+    : null;
+}

--- a/src/server/history/lib/history-query.ts
+++ b/src/server/history/lib/history-query.ts
@@ -21,7 +21,7 @@ export type HistoryResponse = GenerationHistoryResponse;
 const DEFAULT_LIMIT = 24;
 const MAX_LIMIT = 100;
 
-const HISTORY_TYPES = new Set<HistoryType>(["image", "video", "all"]);
+const HISTORY_TYPES = new Set<HistoryType>(["image", "video", "audio", "all"]);
 const HISTORY_SORTS = new Set<HistorySort>(["date_desc", "date_asc"]);
 
 function toNumber(value: string | null) {
@@ -87,6 +87,29 @@ export function buildImageWhere(
 export function buildVideoWhere(
   query: HistoryQuery,
 ): Prisma.VideoGenerationWhereInput {
+  if (!query.query) return {};
+
+  return {
+    OR: [
+      {
+        prompt: {
+          contains: query.query,
+          mode: "insensitive",
+        },
+      },
+      {
+        requestParams: {
+          path: ["model"],
+          string_contains: query.query,
+        },
+      },
+    ],
+  };
+}
+
+export function buildAudioWhere(
+  query: HistoryQuery,
+): Prisma.AudioGenerationWhereInput {
   if (!query.query) return {};
 
   return {

--- a/src/server/http/form-data-utils.ts
+++ b/src/server/http/form-data-utils.ts
@@ -39,6 +39,14 @@ export function getNumber(formData: FormData, key: string) {
   return Number(value);
 }
 
+export function getBoolean(formData: FormData, key: string) {
+  const value = getString(formData, key);
+  if (value === undefined || value === "") return undefined;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
 export async function getDataUrlList(
   formData: FormData,
   keys: string[],

--- a/src/server/http/form-data-utils.ts
+++ b/src/server/http/form-data-utils.ts
@@ -12,6 +12,19 @@ export async function fileToDataUrl(
   return `data:${mime};base64,${buffer.toString("base64")}`;
 }
 
+function isFileLike(
+  value: FormDataEntryValue | null,
+): value is File {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      "arrayBuffer" in value &&
+      typeof value.arrayBuffer === "function" &&
+      "size" in value &&
+      typeof value.size === "number",
+  );
+}
+
 export function getString(formData: FormData, key: string) {
   const value = formData.get(key);
   if (typeof value !== "string") return undefined;
@@ -41,7 +54,7 @@ export async function getDataUrlList(
       }
       continue;
     }
-    if (entry instanceof File) {
+    if (isFileLike(entry)) {
       if (entry.size === 0) continue;
       results.push(await fileToDataUrl(entry, maxBytes));
     }
@@ -60,7 +73,7 @@ export async function getOptionalDataUrl(
   if (typeof entry === "string") {
     return entry.trim() ? entry.trim() : "";
   }
-  if (entry instanceof File) {
+  if (isFileLike(entry)) {
     if (entry.size === 0) return undefined;
     return fileToDataUrl(entry, maxBytes);
   }

--- a/src/server/image-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/image-generation/adapters/hf-space-adapter.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockConnect = vi.hoisted(() => vi.fn());
+const mockGetModelCatalog = vi.hoisted(() => vi.fn());
+
+vi.mock("@gradio/client", () => ({
+  Client: {
+    connect: mockConnect,
+  },
+  handle_file: vi.fn((value) => ({ mockedFile: value })),
+}));
+
+vi.mock("@/server/model-catalog/catalog-service", () => ({
+  getModelCatalog: mockGetModelCatalog,
+}));
+
+describe("hfSpaceImageAdapter", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("path 기반 HF Space 결과 이미지를 gradio_api/file 경로로 다운로드한다", async () => {
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "image-model-1",
+        type: "image",
+        key: "hf-image",
+        label: "HF Image",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "demo/image-space",
+          api_name: "/generate_image",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+        },
+        meta: {
+          concurrent_limit: 1,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    mockConnect.mockResolvedValue({
+      predict: vi.fn().mockResolvedValue({
+        data: [{ path: "/tmp/generated.png" }],
+      }),
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "image/png" }),
+        arrayBuffer: async () => Uint8Array.from([137, 80, 78, 71]).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceImageAdapter } = await import(
+      "@/server/image-generation/adapters/hf-space-adapter"
+    );
+
+    const result = await hfSpaceImageAdapter.generate({
+      prompt: "hello image",
+      model: "hf-image",
+      width: 1024,
+      height: 1024,
+      imageCount: 1,
+      steps: 10,
+      seed: "",
+      initImages: [],
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://demo-image-space.hf.space/gradio_api/file=/tmp/generated.png",
+      expect.objectContaining({}),
+    );
+    expect(result).toEqual({
+      images: ["data:image/png;base64,iVBORw=="],
+    });
+  });
+});

--- a/src/server/image-generation/adapters/hf-space-adapter.ts
+++ b/src/server/image-generation/adapters/hf-space-adapter.ts
@@ -2,6 +2,10 @@ import { Client, handle_file } from "@gradio/client";
 import { z } from "zod";
 import type { ImageGenerationFormValues } from "@/features/image-generation/model/image-generation-schema";
 import type { ImageGenerationAdapter } from "@/server/image-generation/adapters/types";
+import {
+  resolveHfSpaceFileReference,
+  selectPreferredHfSpaceFileReference,
+} from "@/server/hf-space/file-reference-resolver";
 import { getModelCatalog } from "@/server/model-catalog/catalog-service";
 import type { ImageModelCatalogItem } from "@/server/model-catalog/catalog-schema";
 import {
@@ -239,42 +243,6 @@ function clampNumber(value: number, range: { min: number; max: number; step: num
   return Math.min(range.max, Math.max(range.min, resolved));
 }
 
-function extractFileUrl(file: unknown) {
-  if (!file) return null;
-  if (typeof file === "string") return file;
-  if (typeof file !== "object") return null;
-  const candidate = file as {
-    url?: unknown;
-    path?: unknown;
-    name?: unknown;
-    data?: unknown;
-  };
-  if (
-    typeof candidate.data === "string" &&
-    candidate.data.startsWith("data:")
-  ) {
-    return candidate.data;
-  }
-  if (typeof candidate.url === "string") return candidate.url;
-  if (typeof candidate.path === "string") return candidate.path;
-  if (typeof candidate.name === "string") return candidate.name;
-  return null;
-}
-
-function normalizeFileUrl(fileUrl: string, spaceUrl: string) {
-  if (fileUrl.startsWith("data:")) return fileUrl;
-  if (fileUrl.startsWith("http://") || fileUrl.startsWith("https://")) {
-    return fileUrl;
-  }
-  if (fileUrl.startsWith("/")) {
-    return `${spaceUrl}${fileUrl}`;
-  }
-  if (fileUrl.startsWith("file=")) {
-    return `${spaceUrl}/${fileUrl}`;
-  }
-  return `${spaceUrl}/file=${fileUrl}`;
-}
-
 const FILE_FETCH_TIMEOUT_MS = 60_000;
 const INPUT_IMAGE_FETCH_TIMEOUT_MS = 20_000;
 
@@ -341,11 +309,15 @@ async function resolveInputImageBuffer(source: string) {
 }
 
 async function fetchImageDataUrl(
-  fileUrl: string,
+  fileRef: string | ReturnType<typeof resolveHfSpaceFileReference>,
   spaceUrl: string,
   timeoutMs: number = FILE_FETCH_TIMEOUT_MS
 ) {
-  const normalized = normalizeFileUrl(fileUrl, spaceUrl);
+  const resolved =
+    typeof fileRef === "string"
+      ? resolveHfSpaceFileReference(fileRef, spaceUrl)
+      : fileRef;
+  const normalized = resolved.normalizedUrl;
   if (normalized.startsWith("data:")) {
     return normalized;
   }
@@ -513,13 +485,16 @@ export const hfSpaceImageAdapter: ImageGenerationAdapter = {
     }
     const data = Array.isArray(result?.data) ? result.data : result;
     const imageValue = Array.isArray(data) ? data[0] : data;
-    const imageUrl = extractFileUrl(imageValue);
-    if (!imageUrl) {
+    const imageRef = selectPreferredHfSpaceFileReference(imageValue, {
+      spaceUrl: config.spaceUrl,
+      maxDepth: 4,
+    });
+    if (!imageRef) {
       throw new Error("HF_SPACE_RESPONSE_INVALID");
     }
 
     const dataUrl = await fetchImageDataUrl(
-      imageUrl,
+      imageRef,
       config.spaceUrl,
       Math.min(config.timeoutMs, FILE_FETCH_TIMEOUT_MS)
     );

--- a/src/server/model-catalog/catalog-schema.test.ts
+++ b/src/server/model-catalog/catalog-schema.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { modelCatalogInputSchema, modelCatalogSchema } from "@/server/model-catalog/catalog-schema";
+
+describe("model-catalog option normalization", () => {
+  it("등록 payload의 flat/tuple options를 canonical option object로 정규화한다", () => {
+    const parsed = modelCatalogInputSchema.safeParse({
+      type: "audio",
+      key: "qwen-tts",
+      label: "Qwen TTS",
+      vendor: "HUGGINGFACE",
+      provider: "hf_space",
+      providerConfig: {
+        space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+        api_name: "/run_generation",
+      },
+      parameters: {
+        prompt: { ui: "textarea", required: true },
+        modeChoice: {
+          ui: "select",
+          label: "Generation Mode",
+          options: [
+            ["Voice Clone", "voice_clone"],
+            ["Custom Speaker", "custom"],
+          ],
+          default: "voice_clone",
+        },
+        speaker: {
+          ui: "select",
+          label: "Speaker",
+          options: ["Vivian", "Serena"],
+          default: "Vivian",
+        },
+      },
+      meta: {
+        model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+        default_speed: 1,
+      },
+      isActive: true,
+      isDefault: false,
+    });
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    if (parsed.data.type !== "audio") {
+      throw new Error("expected audio model");
+    }
+
+    expect(parsed.data.parameters.modeChoice?.options).toEqual([
+      { label: "Voice Clone", value: "voice_clone" },
+      { label: "Custom Speaker", value: "custom" },
+    ]);
+    expect(parsed.data.parameters.speaker?.options).toEqual([
+      { label: "Vivian", value: "Vivian" },
+      { label: "Serena", value: "Serena" },
+    ]);
+  });
+
+  it("legacy catalog records의 flat options도 읽을 때 canonical option object로 정규화한다", () => {
+    const parsed = modelCatalogSchema.safeParse([
+      {
+        id: "audio-1",
+        type: "audio",
+        key: "legacy-qwen",
+        label: "Legacy Qwen TTS",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "legacy/qwen",
+          api_name: "/generate",
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+          language: {
+            ui: "select",
+            options: ["English", "Korean"],
+            default: "English",
+          },
+        },
+        meta: {
+          model_id: "legacy/qwen",
+          default_speed: 1,
+        },
+        isActive: true,
+        isDefault: true,
+        createdAt: new Date("2026-03-06T00:00:00Z"),
+        updatedAt: new Date("2026-03-06T00:00:00Z"),
+      },
+    ]);
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    if (parsed.data[0]?.type !== "audio") {
+      throw new Error("expected audio model");
+    }
+
+    expect(parsed.data[0]?.parameters.language?.options).toEqual([
+      { label: "English", value: "English" },
+      { label: "Korean", value: "Korean" },
+    ]);
+  });
+});

--- a/src/server/model-catalog/catalog-schema.ts
+++ b/src/server/model-catalog/catalog-schema.ts
@@ -58,6 +58,8 @@ const audioParametersSchema = z
     voice: parameterSchema.optional(),
     speed: parameterSchema.optional(),
     seed: parameterSchema.optional(),
+    inputAudio: parameterSchema.optional(),
+    referenceText: parameterSchema.optional(),
   })
   .passthrough();
 

--- a/src/server/model-catalog/catalog-schema.ts
+++ b/src/server/model-catalog/catalog-schema.ts
@@ -52,6 +52,15 @@ const videoParametersSchema = z
   })
   .passthrough();
 
+const audioParametersSchema = z
+  .object({
+    prompt: parameterSchema,
+    voice: parameterSchema.optional(),
+    speed: parameterSchema.optional(),
+    seed: parameterSchema.optional(),
+  })
+  .passthrough();
+
 const hfSpaceConfigSchema = z
   .object({
     space_id: z.string().min(1),
@@ -59,6 +68,7 @@ const hfSpaceConfigSchema = z
     timeout_ms: z.number().int().positive().optional(),
     space_url: z.string().min(1).optional(),
     input_images_format: z.enum(["file_array", "gallery"]).optional(),
+    input_audio_format: z.enum(["file", "file_array"]).optional(),
   })
   .passthrough();
 
@@ -85,9 +95,16 @@ const videoMetaSchema = z.object({
   concurrent_limit: z.number().int().positive().nullable().optional(),
 });
 
+const audioMetaSchema = z.object({
+  model_id: z.string().min(1),
+  default_speed: z.number().positive(),
+  concurrent_limit: z.number().int().positive().nullable().optional(),
+  supports_input_audio: z.boolean().optional(),
+});
+
 const baseModelSchema = z.object({
   id: z.string().min(1),
-  type: z.enum(["image", "video"]),
+  type: z.enum(["image", "video", "audio"]),
   key: z.string().min(1),
   label: z.string().min(1),
   vendor: z.string().min(1),
@@ -113,8 +130,14 @@ const videoModelSchema = baseModelSchema.extend({
   meta: videoMetaSchema,
 });
 
+const audioModelSchema = baseModelSchema.extend({
+  type: z.literal("audio"),
+  parameters: audioParametersSchema,
+  meta: audioMetaSchema,
+});
+
 const baseModelInputSchema = z.object({
-  type: z.enum(["image", "video"]),
+  type: z.enum(["image", "video", "audio"]),
   key: z.string().min(1),
   label: z.string().min(1),
   vendor: z.string().min(1),
@@ -138,18 +161,26 @@ const videoModelInputSchema = baseModelInputSchema.extend({
   meta: videoMetaSchema,
 });
 
+const audioModelInputSchema = baseModelInputSchema.extend({
+  type: z.literal("audio"),
+  parameters: audioParametersSchema,
+  meta: audioMetaSchema,
+});
+
 export const modelCatalogSchema = z.array(
-  z.union([imageModelSchema, videoModelSchema]),
+  z.union([imageModelSchema, videoModelSchema, audioModelSchema]),
 );
 
 export const modelCatalogInputSchema = z.union([
   imageModelInputSchema,
   videoModelInputSchema,
+  audioModelInputSchema,
 ]);
 
 export type ModelCatalogItem = z.infer<typeof modelCatalogSchema>[number];
 export type ImageModelCatalogItem = z.infer<typeof imageModelSchema>;
 export type VideoModelCatalogItem = z.infer<typeof videoModelSchema>;
+export type AudioModelCatalogItem = z.infer<typeof audioModelSchema>;
 export type ModelCatalogType = ModelCatalogItem["type"];
 export type ModelCatalogInput = z.infer<typeof modelCatalogInputSchema>;
 

--- a/src/server/model-catalog/catalog-schema.ts
+++ b/src/server/model-catalog/catalog-schema.ts
@@ -11,6 +11,25 @@ const parameterUiOptions = [
   "upload",
 ] as const;
 
+const parameterOptionValueSchema = z.union([z.string(), z.number()]);
+const parameterOptionSchema = z.object({
+  label: z.string().min(1),
+  value: parameterOptionValueSchema,
+});
+const parameterOptionInputSchema = z.union([
+  parameterOptionValueSchema.transform((value) => ({
+    label: String(value),
+    value,
+  })),
+  z
+    .tuple([z.string().min(1), parameterOptionValueSchema])
+    .transform(([label, value]) => ({
+      label,
+      value,
+    })),
+  parameterOptionSchema,
+]);
+
 const parameterSchema = z
   .object({
     ui: z.enum(parameterUiOptions),
@@ -20,7 +39,7 @@ const parameterSchema = z
     max: z.number().optional(),
     step: z.number().optional(),
     default: z.union([z.string(), z.number(), z.boolean()]).optional(),
-    options: z.array(z.union([z.string(), z.number()])).optional(),
+    options: z.array(parameterOptionInputSchema).optional(),
   })
   .passthrough();
 
@@ -56,10 +75,22 @@ const audioParametersSchema = z
   .object({
     prompt: parameterSchema,
     voice: parameterSchema.optional(),
+    speaker: parameterSchema.optional(),
     speed: parameterSchema.optional(),
     seed: parameterSchema.optional(),
     inputAudio: parameterSchema.optional(),
     referenceText: parameterSchema.optional(),
+    modeChoice: parameterSchema.optional(),
+    language: parameterSchema.optional(),
+    streamMode: parameterSchema.optional(),
+    referencePreset: parameterSchema.optional(),
+    customInstruction: parameterSchema.optional(),
+    voiceInstruction: parameterSchema.optional(),
+    xvecOnly: parameterSchema.optional(),
+    chunkSize: parameterSchema.optional(),
+    temperature: parameterSchema.optional(),
+    topK: parameterSchema.optional(),
+    repetitionPenalty: parameterSchema.optional(),
   })
   .passthrough();
 

--- a/src/server/model-catalog/generation-validation.ts
+++ b/src/server/model-catalog/generation-validation.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
+import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
 import type { ImageGenerationFormValues } from "@/features/image-generation/model/image-generation-schema";
 import type { VideoGenerationFormValues } from "@/features/video-generation/model/video-generation-schema";
 import { getModelCatalog } from "@/server/model-catalog/catalog-service";
 import type {
+  AudioModelCatalogItem,
   ImageModelCatalogItem,
   VideoModelCatalogItem,
 } from "@/server/model-catalog/catalog-schema";
@@ -40,6 +42,10 @@ const videoFallbackRanges: Record<
   steps: { min: 1, max: 50, step: 1 },
   guidance: { min: 0, max: 20, step: 0.5 },
   fps: { min: 1, max: 60, step: 1 },
+};
+
+const audioFallbackRanges: Record<"speed", NumericRange> = {
+  speed: { min: 0.25, max: 4, step: 0.05 },
 };
 
 const buildInitImageSchema = (t?: TranslationFn) =>
@@ -405,6 +411,85 @@ function buildVideoSchema(models: VideoModelCatalogItem[], t?: TranslationFn) {
   });
 }
 
+function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
+  const modelMap = new Map(models.map((model) => [model.key, model]));
+  const invalidModelMessage = t
+    ? t("invalidModel")
+    : "지원하지 않는 모델입니다.";
+  const promptRequired = t ? t("promptRequired") : "프롬프트를 입력해주세요.";
+  const labels = {
+    speed: t ? t("labels.speed") : "속도",
+  };
+  const rangeMessage = (label: string, min: number, max: number) =>
+    t
+      ? t("range", { label, min, max })
+      : `${label}는 ${min}~${max} 범위여야 합니다.`;
+  const stepMessage = (label: string, step: number) =>
+    t ? t("step", { label, step }) : `${label}는 ${step} 단위로 입력해야 합니다.`;
+  const unsupportedVoice = t ? t("unsupportedVoice") : "지원하지 않는 음성입니다.";
+
+  const schema = z.object({
+    prompt: z.string().min(1, promptRequired),
+    model: z.string().min(1),
+    voice: z.string().optional().or(z.literal("")),
+    speed: z.number().optional(),
+    seed: z.string().optional().or(z.literal("")),
+  });
+
+  return schema.superRefine((data, ctx) => {
+    const model = modelMap.get(data.model);
+    if (!model) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["model"],
+        message: invalidModelMessage,
+      });
+      return;
+    }
+
+    const parameters = (model.parameters ?? {}) as Record<string, unknown>;
+    const speedRange = resolveRange(
+      getParamConfig(parameters, "speed"),
+      audioFallbackRanges.speed,
+    );
+
+    if (typeof data.speed === "number") {
+      if (data.speed < speedRange.min || data.speed > speedRange.max) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["speed"],
+          message: rangeMessage(labels.speed, speedRange.min, speedRange.max),
+        });
+      } else if (speedRange.step > 0) {
+        const offset = data.speed - speedRange.min;
+        const quotient = offset / speedRange.step;
+        if (Math.abs(quotient - Math.round(quotient)) > 1e-6) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["speed"],
+            message: stepMessage(labels.speed, speedRange.step),
+          });
+        }
+      }
+    }
+
+    const voiceConfig = getParamConfig(parameters, "voice");
+    if (
+      typeof data.voice === "string" &&
+      data.voice.trim() &&
+      Array.isArray(voiceConfig?.options) &&
+      voiceConfig.options.length > 0 &&
+      !voiceConfig.options.includes(data.voice)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["voice"],
+        message: unsupportedVoice,
+      });
+    }
+  });
+}
+
 function buildNoModelsResult<TOutput>(message: string) {
   const error = new z.ZodError([
     {
@@ -452,4 +537,21 @@ export async function validateVideoGenerationPayload(
   const schema = buildVideoSchema(videoModels, t);
   const parsed = schema.safeParse(payload);
   return parsed as SafeParseResult<VideoGenerationFormValues>;
+}
+
+export async function validateAudioGenerationPayload(
+  payload: unknown,
+  t?: TranslationFn,
+) {
+  const catalog = await getModelCatalog();
+  const audioModels = catalog.filter(
+    (item): item is AudioModelCatalogItem => item.type === "audio",
+  );
+  if (audioModels.length === 0) {
+    const message = t ? t("noModels") : "등록된 오디오 모델이 없습니다.";
+    return buildNoModelsResult<AudioGenerationFormValues>(message);
+  }
+  const schema = buildAudioSchema(audioModels, t);
+  const parsed = schema.safeParse(payload);
+  return parsed as SafeParseResult<AudioGenerationFormValues>;
 }

--- a/src/server/model-catalog/generation-validation.ts
+++ b/src/server/model-catalog/generation-validation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { hasRuntimeParameterOption } from "@/shared/model-catalog/parameter-options";
 import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
 import type { ImageGenerationFormValues } from "@/features/image-generation/model/image-generation-schema";
 import type { VideoGenerationFormValues } from "@/features/video-generation/model/video-generation-schema";
@@ -24,6 +25,15 @@ type NumericRange = {
   step: number;
 };
 
+type ParameterConfig = {
+  min?: unknown;
+  max?: unknown;
+  step?: unknown;
+  default?: unknown;
+  required?: unknown;
+  options?: unknown[];
+};
+
 const imageFallbackRanges: Record<
   "size" | "steps" | "count" | "guidance",
   NumericRange
@@ -44,8 +54,15 @@ const videoFallbackRanges: Record<
   fps: { min: 1, max: 60, step: 1 },
 };
 
-const audioFallbackRanges: Record<"speed", NumericRange> = {
+const audioFallbackRanges: Record<
+  "speed" | "chunkSize" | "temperature" | "topK" | "repetitionPenalty",
+  NumericRange
+> = {
   speed: { min: 0.25, max: 4, step: 0.05 },
+  chunkSize: { min: 40, max: 200, step: 10 },
+  temperature: { min: 0.1, max: 1.2, step: 0.1 },
+  topK: { min: 1, max: 100, step: 1 },
+  repetitionPenalty: { min: 1, max: 2, step: 0.1 },
 };
 
 const buildInitImageSchema = (t?: TranslationFn) =>
@@ -87,9 +104,9 @@ function resolveRange(
 function getParamConfig(
   parameters: Record<string, unknown>,
   key: string,
-): Record<string, unknown> | undefined {
+): ParameterConfig | undefined {
   const param = parameters[key];
-  return param && typeof param === "object" ? (param as Record<string, unknown>) : undefined;
+  return param && typeof param === "object" ? (param as ParameterConfig) : undefined;
 }
 
 function buildImageSchema(models: ImageModelCatalogItem[], t?: TranslationFn) {
@@ -215,9 +232,8 @@ function buildImageSchema(models: ImageModelCatalogItem[], t?: TranslationFn) {
     if (
       typeof data.modeChoice === "string" &&
       data.modeChoice.trim() &&
-      Array.isArray(modeConfig?.options) &&
-      modeConfig.options.length > 0 &&
-      !modeConfig.options.includes(data.modeChoice)
+      modeConfig?.options?.length &&
+      !hasRuntimeParameterOption(modeConfig.options, data.modeChoice)
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -419,6 +435,10 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
   const promptRequired = t ? t("promptRequired") : "프롬프트를 입력해주세요.";
   const labels = {
     speed: t ? t("labels.speed") : "속도",
+    chunkSize: "Chunk Size",
+    temperature: "Temperature",
+    topK: "Top K",
+    repetitionPenalty: "Repetition Penalty",
   };
   const rangeMessage = (label: string, min: number, max: number) =>
     t
@@ -433,6 +453,7 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
   const referenceTextRequired = t
     ? t("referenceTextRequired")
     : "레퍼런스 텍스트를 입력해주세요.";
+  const unsupportedSelection = "지원하지 않는 선택값입니다.";
 
   const schema = z.object({
     prompt: z.string().min(1, promptRequired),
@@ -442,6 +463,18 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
     seed: z.string().optional().or(z.literal("")),
     inputAudio: z.string().optional().or(z.literal("")),
     referenceText: z.string().optional().or(z.literal("")),
+    modeChoice: z.string().optional().or(z.literal("")),
+    language: z.string().optional().or(z.literal("")),
+    speaker: z.string().optional().or(z.literal("")),
+    streamMode: z.boolean().optional(),
+    referencePreset: z.string().optional().or(z.literal("")),
+    customInstruction: z.string().optional().or(z.literal("")),
+    voiceInstruction: z.string().optional().or(z.literal("")),
+    xvecOnly: z.boolean().optional(),
+    chunkSize: z.number().optional(),
+    temperature: z.number().optional(),
+    topK: z.number().optional(),
+    repetitionPenalty: z.number().optional(),
   });
 
   return schema.superRefine((data, ctx) => {
@@ -481,20 +514,30 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
       }
     }
 
-    const voiceConfig = getParamConfig(parameters, "voice");
-    if (
-      typeof data.voice === "string" &&
-      data.voice.trim() &&
-      Array.isArray(voiceConfig?.options) &&
-      voiceConfig.options.length > 0 &&
-      !voiceConfig.options.includes(data.voice)
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["voice"],
-        message: unsupportedVoice,
-      });
-    }
+    const validateOption = (
+      key: "voice" | "speaker" | "modeChoice" | "language" | "referencePreset",
+      value: string | undefined,
+      message = unsupportedSelection,
+    ) => {
+      if (!value?.trim()) return;
+      const config = getParamConfig(parameters, key);
+      if (
+        config?.options?.length &&
+        !hasRuntimeParameterOption(config.options, value)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message,
+        });
+      }
+    };
+
+    validateOption("voice", data.voice, unsupportedVoice);
+    validateOption("speaker", data.speaker);
+    validateOption("modeChoice", data.modeChoice);
+    validateOption("language", data.language);
+    validateOption("referencePreset", data.referencePreset);
 
     const inputAudio = data.inputAudio?.trim() ?? "";
     if (inputAudio && !Boolean(model.meta.supports_input_audio)) {
@@ -513,6 +556,52 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
         message: referenceTextRequired,
       });
     }
+
+    const validateNumeric = (
+      key: "chunkSize" | "temperature" | "topK" | "repetitionPenalty",
+      value: number | undefined,
+      label: string,
+    ) => {
+      if (typeof value !== "number") return;
+      const range = resolveRange(
+        getParamConfig(parameters, key),
+        key === "chunkSize"
+          ? audioFallbackRanges.chunkSize
+          : key === "temperature"
+            ? audioFallbackRanges.temperature
+            : key === "topK"
+              ? audioFallbackRanges.topK
+              : audioFallbackRanges.repetitionPenalty,
+      );
+      if (value < range.min || value > range.max) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: rangeMessage(label, range.min, range.max),
+        });
+        return;
+      }
+      if (range.step > 0) {
+        const offset = value - range.min;
+        const quotient = offset / range.step;
+        if (Math.abs(quotient - Math.round(quotient)) > 1e-6) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [key],
+            message: stepMessage(label, range.step),
+          });
+        }
+      }
+    };
+
+    validateNumeric("chunkSize", data.chunkSize, labels.chunkSize);
+    validateNumeric("temperature", data.temperature, labels.temperature);
+    validateNumeric("topK", data.topK, labels.topK);
+    validateNumeric(
+      "repetitionPenalty",
+      data.repetitionPenalty,
+      labels.repetitionPenalty,
+    );
   });
 }
 

--- a/src/server/model-catalog/generation-validation.ts
+++ b/src/server/model-catalog/generation-validation.ts
@@ -427,6 +427,12 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
   const stepMessage = (label: string, step: number) =>
     t ? t("step", { label, step }) : `${label}는 ${step} 단위로 입력해야 합니다.`;
   const unsupportedVoice = t ? t("unsupportedVoice") : "지원하지 않는 음성입니다.";
+  const inputAudioUnsupported = t
+    ? t("inputAudioUnsupported")
+    : "선택한 모델은 오디오 입력을 지원하지 않습니다.";
+  const referenceTextRequired = t
+    ? t("referenceTextRequired")
+    : "레퍼런스 텍스트를 입력해주세요.";
 
   const schema = z.object({
     prompt: z.string().min(1, promptRequired),
@@ -434,6 +440,8 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
     voice: z.string().optional().or(z.literal("")),
     speed: z.number().optional(),
     seed: z.string().optional().or(z.literal("")),
+    inputAudio: z.string().optional().or(z.literal("")),
+    referenceText: z.string().optional().or(z.literal("")),
   });
 
   return schema.superRefine((data, ctx) => {
@@ -485,6 +493,24 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
         code: z.ZodIssueCode.custom,
         path: ["voice"],
         message: unsupportedVoice,
+      });
+    }
+
+    const inputAudio = data.inputAudio?.trim() ?? "";
+    if (inputAudio && !Boolean(model.meta.supports_input_audio)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["inputAudio"],
+        message: inputAudioUnsupported,
+      });
+    }
+
+    const referenceTextConfig = getParamConfig(parameters, "referenceText");
+    if (referenceTextConfig?.required && inputAudio && !(data.referenceText?.trim())) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["referenceText"],
+        message: referenceTextRequired,
       });
     }
   });

--- a/src/server/model-catalog/handlers/update-model-catalog.ts
+++ b/src/server/model-catalog/handlers/update-model-catalog.ts
@@ -11,7 +11,7 @@ import {
 import { invalidateModelCatalogCache } from "@/server/model-catalog/catalog-service";
 
 const updatePayloadSchema = z.object({
-  type: z.enum(["image", "video"]).optional(),
+  type: z.enum(["image", "video", "audio"]).optional(),
   key: z.string().min(1).optional(),
   label: z.string().min(1).optional(),
   vendor: z.string().min(1).optional(),

--- a/src/server/model-catalog/handlers/update-model-catalog.ts
+++ b/src/server/model-catalog/handlers/update-model-catalog.ts
@@ -88,10 +88,12 @@ export async function updateModelCatalogHandler(params: {
     throw error;
   }
 
+  const data = validated.data;
+
   const updated = await prisma.$transaction(async (tx) => {
-    if (merged.isDefault) {
+    if (data.isDefault) {
       await tx.modelCatalog.updateMany({
-        where: { type: merged.type, isDefault: true, key: { not: merged.key } },
+        where: { type: data.type, isDefault: true, key: { not: data.key } },
         data: { isDefault: false },
       });
     }
@@ -99,15 +101,15 @@ export async function updateModelCatalogHandler(params: {
     return tx.modelCatalog.update({
       where: { key: params.key },
       data: {
-        type: merged.type,
-        label: merged.label,
-        vendor: merged.vendor,
-        provider: merged.provider,
-        providerConfig: merged.providerConfig as Prisma.InputJsonValue,
-        parameters: merged.parameters as Prisma.InputJsonValue,
-        meta: merged.meta as Prisma.InputJsonValue,
-        isActive: merged.isActive ?? true,
-        isDefault: merged.isDefault ?? false,
+        type: data.type,
+        label: data.label,
+        vendor: data.vendor,
+        provider: data.provider,
+        providerConfig: data.providerConfig as Prisma.InputJsonValue,
+        parameters: data.parameters as Prisma.InputJsonValue,
+        meta: data.meta as Prisma.InputJsonValue,
+        isActive: data.isActive ?? true,
+        isDefault: data.isDefault ?? false,
       },
     });
   });

--- a/src/server/model-catalog/runtime-models.ts
+++ b/src/server/model-catalog/runtime-models.ts
@@ -1,5 +1,6 @@
 import { getModelCatalog } from "@/server/model-catalog/catalog-service";
 import type {
+  AudioModelCatalogItem,
   ImageModelCatalogItem,
   VideoModelCatalogItem,
 } from "@/server/model-catalog/catalog-schema";
@@ -19,6 +20,8 @@ type ModelDefaults = {
   fps?: number;
   aspectRatio?: string;
   resolution?: number;
+  voice?: string;
+  speed?: number;
 };
 
 export type RuntimeImageModel = {
@@ -49,12 +52,23 @@ export type RuntimeVideoModel = {
   supportsInitImage: boolean;
 };
 
+export type RuntimeAudioModel = {
+  key: string;
+  isActive: boolean;
+  isDefault: boolean;
+  defaults: Required<Pick<ModelDefaults, "voice" | "speed">>;
+  concurrentLimit: number;
+  supportsInputAudio: boolean;
+};
+
 const DEFAULT_IMAGE_MODE_CHOICE = "Distilled (4 steps)";
 const DEFAULT_IMAGE_GUIDANCE_SCALE = 1;
 const DEFAULT_IMAGE_PROMPT_UPSAMPLING = false;
 
 const DEFAULT_VIDEO_ASPECT_RATIO = "16:9";
 const DEFAULT_VIDEO_RESOLUTION = 720;
+const DEFAULT_AUDIO_VOICE = "default";
+const DEFAULT_AUDIO_SPEED = 1;
 
 function getParamConfig(
   parameters: Record<string, unknown>,
@@ -157,6 +171,30 @@ function toVideoRuntimeModel(model: VideoModelCatalogItem): RuntimeVideoModel {
   };
 }
 
+function toAudioRuntimeModel(model: AudioModelCatalogItem): RuntimeAudioModel {
+  const parameters = model.parameters as Record<string, unknown>;
+  return {
+    key: model.key,
+    isActive: model.isActive,
+    isDefault: model.isDefault,
+    defaults: {
+      voice: getStringDefault(
+        getParamConfig(parameters, "voice"),
+        DEFAULT_AUDIO_VOICE,
+      ),
+      speed: getNumberDefault(
+        getParamConfig(parameters, "speed"),
+        model.meta.default_speed,
+      ),
+    },
+    concurrentLimit: resolveConcurrentLimit(model.meta.concurrent_limit),
+    supportsInputAudio: getBooleanDefault(
+      getParamConfig(parameters, "inputAudio"),
+      Boolean(model.meta.supports_input_audio),
+    ),
+  };
+}
+
 export function resolveDefaultModelKey<T extends { key: string; isDefault: boolean; isActive: boolean }>(
   models: T[],
 ) {
@@ -179,6 +217,9 @@ export async function getRuntimeCatalog(params: { includeInactive?: boolean } = 
   const videoModels = catalog
     .filter((item): item is VideoModelCatalogItem => item.type === "video")
     .map((model) => toVideoRuntimeModel(model));
+  const audioModels = catalog
+    .filter((item): item is AudioModelCatalogItem => item.type === "audio")
+    .map((model) => toAudioRuntimeModel(model));
 
-  return { imageModels, videoModels };
+  return { imageModels, videoModels, audioModels };
 }

--- a/src/server/model-catalog/runtime-models.ts
+++ b/src/server/model-catalog/runtime-models.ts
@@ -56,6 +56,7 @@ export type RuntimeAudioModel = {
   key: string;
   isActive: boolean;
   isDefault: boolean;
+  parameters?: Record<string, unknown>;
   defaults: Required<Pick<ModelDefaults, "voice" | "speed">>;
   concurrentLimit: number;
   supportsInputAudio: boolean;
@@ -177,6 +178,7 @@ function toAudioRuntimeModel(model: AudioModelCatalogItem): RuntimeAudioModel {
     key: model.key,
     isActive: model.isActive,
     isDefault: model.isDefault,
+    parameters,
     defaults: {
       voice: getStringDefault(
         getParamConfig(parameters, "voice"),

--- a/src/server/model-catalog/space-importer.test.ts
+++ b/src/server/model-catalog/space-importer.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockConnect = vi.hoisted(() => vi.fn());
+
+vi.mock("@gradio/client", () => ({
+  Client: {
+    connect: mockConnect,
+  },
+}));
+
+describe("importModelDraftFromSpace", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("오디오 생성 endpoint가 여러 개면 run_generation을 우선 선택하고 reference 입력 계약을 반영한다", async () => {
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/toggle_mode": {
+            parameters: [{ parameter_name: "mode", label: "Generation Mode" }],
+          },
+          "/run_generation": {
+            parameters: [
+              { parameter_name: "text", label: "Text" },
+              { parameter_name: "ref_audio_path", label: "Reference Audio" },
+              {
+                parameter_name: "ref_text",
+                label: "Reference Transcript (for advanced ICL mode)",
+              },
+            ],
+          },
+        },
+      }),
+      config: {
+        space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+        title: "Faster Qwen3 TTS",
+        components: [
+          { id: 1, type: "textbox", props: { label: "Text", lines: 4 } },
+          { id: 2, type: "audio", props: { label: "Reference Audio" } },
+          {
+            id: 3,
+            type: "textbox",
+            props: {
+              label: "Reference Transcript (for advanced ICL mode)",
+              lines: 4,
+              required: true,
+            },
+          },
+          { id: 4, type: "audio", props: { label: "Generated Audio" } },
+        ],
+        dependencies: [
+          {
+            api_name: "/toggle_mode",
+            inputs: [1],
+            outputs: [],
+          },
+          {
+            api_name: "/run_generation",
+            inputs: [1, 2, 3],
+            outputs: [4],
+          },
+        ],
+      },
+    });
+
+    const { importModelDraftFromSpace } = await import(
+      "@/server/model-catalog/space-importer"
+    );
+
+    const result = await importModelDraftFromSpace({
+      spaceUrl:
+        "https://huggingface.co/spaces/leey00nsu/qwen-3.5-tts-faster-gradio",
+    });
+
+    expect(result.resolvedApiName).toBe("/run_generation");
+    expect(result.draft.type).toBe("audio");
+    expect(result.draft.providerConfig.api_name).toBe("/run_generation");
+    expect(result.draft.meta.supports_input_audio).toBe(true);
+    expect(result.draft.parameters.inputAudio).toMatchObject({
+      ui: "upload",
+    });
+    expect(result.draft.parameters.referenceText).toMatchObject({
+      required: true,
+    });
+  });
+});

--- a/src/server/model-catalog/space-importer.test.ts
+++ b/src/server/model-catalog/space-importer.test.ts
@@ -78,11 +78,265 @@ describe("importModelDraftFromSpace", () => {
     expect(result.draft.type).toBe("audio");
     expect(result.draft.providerConfig.api_name).toBe("/run_generation");
     expect(result.draft.meta.supports_input_audio).toBe(true);
+    expect(result.draft.parameters.voice).toBeUndefined();
     expect(result.draft.parameters.inputAudio).toMatchObject({
       ui: "upload",
     });
     expect(result.draft.parameters.referenceText).toMatchObject({
       required: true,
+    });
+  });
+
+  it("mode 기반 TTS 입력을 importer가 audio parameter로 보존한다", async () => {
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/run_generation": {
+            parameters: [
+              { parameter_name: "text", label: "Text" },
+              {
+                parameter_name: "language",
+                label: "Language",
+                parameter_default: "English",
+              },
+              {
+                parameter_name: "mode",
+                label: "Generation Mode",
+                parameter_default: "voice_clone",
+              },
+              {
+                parameter_name: "stream_mode",
+                label: "Streaming",
+                parameter_default: true,
+              },
+              {
+                parameter_name: "ref_audio_path",
+                label: "Reference Audio",
+              },
+              {
+                parameter_name: "ref_preset",
+                label: "Reference Preset",
+                parameter_default: "ref_audio_3",
+              },
+              {
+                parameter_name: "ref_text",
+                label: "Reference Transcript (for advanced ICL mode)",
+              },
+              {
+                parameter_name: "speaker",
+                label: "Speaker",
+                parameter_default: "Vivian",
+              },
+              {
+                parameter_name: "custom_instruct",
+                label: "Custom Instruction",
+              },
+              {
+                parameter_name: "voice_instruct",
+                label: "Voice Instruction",
+              },
+              {
+                parameter_name: "xvec_only",
+                label: "xvec only",
+                parameter_default: false,
+              },
+              {
+                parameter_name: "chunk_size",
+                label: "Chunk Size",
+                parameter_default: 120,
+              },
+              {
+                parameter_name: "temperature",
+                label: "Temperature",
+                parameter_default: 0.7,
+              },
+              {
+                parameter_name: "top_k",
+                label: "Top K",
+                parameter_default: 20,
+              },
+              {
+                parameter_name: "repetition_penalty",
+                label: "Repetition Penalty",
+                parameter_default: 1.1,
+              },
+            ],
+          },
+        },
+      }),
+      config: {
+        space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+        title: "Faster Qwen3 TTS",
+        components: [
+          { id: 1, type: "textbox", props: { label: "Text", lines: 4 } },
+          {
+            id: 2,
+            type: "dropdown",
+            props: { label: "Language", choices: ["English", "Korean"], value: "English" },
+          },
+          {
+            id: 3,
+            type: "radio",
+            props: {
+              label: "Generation Mode",
+              choices: ["voice_clone", "custom", "voice_design"],
+              value: "voice_clone",
+            },
+          },
+          {
+            id: 4,
+            type: "checkbox",
+            props: { label: "Streaming", value: true },
+          },
+          { id: 5, type: "audio", props: { label: "Reference Audio" } },
+          {
+            id: 6,
+            type: "dropdown",
+            props: {
+              label: "Reference Preset",
+              choices: ["ref_audio_1", "ref_audio_3"],
+              value: "ref_audio_3",
+            },
+          },
+          {
+            id: 7,
+            type: "textbox",
+            props: {
+              label: "Reference Transcript (for advanced ICL mode)",
+              lines: 4,
+              required: true,
+            },
+          },
+          {
+            id: 8,
+            type: "dropdown",
+            props: {
+              label: "Speaker",
+              choices: ["Vivian", "Serena"],
+              value: "Vivian",
+            },
+          },
+          {
+            id: 9,
+            type: "textbox",
+            props: { label: "Custom Instruction", lines: 4 },
+          },
+          {
+            id: 10,
+            type: "textbox",
+            props: { label: "Voice Instruction", lines: 4 },
+          },
+          {
+            id: 11,
+            type: "checkbox",
+            props: { label: "xvec only", value: false },
+          },
+          {
+            id: 12,
+            type: "slider",
+            props: { label: "Chunk Size", minimum: 40, maximum: 200, step: 10, value: 120 },
+          },
+          {
+            id: 13,
+            type: "slider",
+            props: { label: "Temperature", minimum: 0.1, maximum: 1.2, step: 0.1, value: 0.7 },
+          },
+          {
+            id: 14,
+            type: "slider",
+            props: { label: "Top K", minimum: 1, maximum: 100, step: 1, value: 20 },
+          },
+          {
+            id: 15,
+            type: "slider",
+            props: {
+              label: "Repetition Penalty",
+              minimum: 1,
+              maximum: 2,
+              step: 0.1,
+              value: 1.1,
+            },
+          },
+          { id: 16, type: "audio", props: { label: "Generated Audio" } },
+        ],
+        dependencies: [
+          {
+            api_name: "/run_generation",
+            inputs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+            outputs: [16],
+          },
+        ],
+      },
+    });
+
+    const { importModelDraftFromSpace } = await import(
+      "@/server/model-catalog/space-importer"
+    );
+
+    const result = await importModelDraftFromSpace({
+      spaceUrl:
+        "https://huggingface.co/spaces/leey00nsu/qwen-3.5-tts-faster-gradio",
+    });
+
+    expect(result.draft.parameters.modeChoice).toMatchObject({
+      ui: "select",
+      default: "voice_clone",
+      options: [
+        { label: "voice_clone", value: "voice_clone" },
+        { label: "custom", value: "custom" },
+        { label: "voice_design", value: "voice_design" },
+      ],
+    });
+    expect(result.draft.parameters.language).toMatchObject({
+      ui: "select",
+      default: "English",
+      options: [
+        { label: "English", value: "English" },
+        { label: "Korean", value: "Korean" },
+      ],
+    });
+    expect(result.draft.parameters.speaker).toMatchObject({
+      ui: "select",
+      default: "Vivian",
+      options: [
+        { label: "Vivian", value: "Vivian" },
+        { label: "Serena", value: "Serena" },
+      ],
+    });
+    expect(result.draft.parameters.voice).toBeUndefined();
+    expect(result.draft.parameters.streamMode).toMatchObject({
+      ui: "toggle",
+      default: true,
+    });
+    expect(result.draft.parameters.referencePreset).toMatchObject({
+      ui: "select",
+      default: "ref_audio_3",
+    });
+    expect(result.draft.parameters.customInstruction).toMatchObject({
+      ui: "textarea",
+    });
+    expect(result.draft.parameters.voiceInstruction).toMatchObject({
+      ui: "textarea",
+    });
+    expect(result.draft.parameters.xvecOnly).toMatchObject({
+      ui: "toggle",
+      default: false,
+    });
+    expect(result.draft.parameters.chunkSize).toMatchObject({
+      ui: "range",
+      default: 120,
+    });
+    expect(result.draft.parameters.temperature).toMatchObject({
+      ui: "range",
+      default: 0.7,
+    });
+    expect(result.draft.parameters.topK).toMatchObject({
+      ui: "range",
+      default: 20,
+    });
+    expect(result.draft.parameters.repetitionPenalty).toMatchObject({
+      ui: "range",
+      default: 1.1,
     });
   });
 });

--- a/src/server/model-catalog/space-importer.ts
+++ b/src/server/model-catalog/space-importer.ts
@@ -1,4 +1,8 @@
 import { Client } from "@gradio/client";
+import {
+  normalizeRuntimeParameterOptions,
+  type RuntimeParameterOptionInput,
+} from "@/shared/model-catalog/parameter-options";
 
 type ModelType = "image" | "video" | "audio";
 
@@ -15,7 +19,7 @@ type ParameterConfig = {
   max?: number;
   step?: number;
   default?: string | number | boolean;
-  options?: Array<string | number>;
+  options?: RuntimeParameterOptionInput[];
 };
 
 type DraftPayload = {
@@ -102,7 +106,6 @@ const FALLBACK_VIDEO_PARAMETERS: Record<string, ParameterConfig> = {
 
 const FALLBACK_AUDIO_PARAMETERS: Record<string, ParameterConfig> = {
   prompt: { ui: "textarea", required: true },
-  voice: { ui: "input", default: "default" },
   speed: { ui: "range", min: 0.25, max: 4, step: 0.05, default: 1 },
   seed: { ui: "input", default: "" },
   inputAudio: { ui: "upload" },
@@ -127,13 +130,32 @@ function resolveParamKey(label?: string, paramName?: string, type?: string) {
   ) {
     return "referenceText";
   }
+  if (target.includes("reference preset") || target.includes("ref_preset")) {
+    return "referencePreset";
+  }
+  if (target.includes("custom instruction") || target.includes("custom_instruct")) {
+    return "customInstruction";
+  }
+  if (target.includes("voice instruction") || target.includes("voice_instruct")) {
+    return "voiceInstruction";
+  }
   if (target.includes("prompt")) return "prompt";
   if (target.includes("text") || target.includes("script") || target.includes("message")) return "prompt";
+  if (target.includes("language")) return "language";
+  if (target.includes("stream mode") || target.includes("stream_mode")) return "streamMode";
+  if (target.includes("xvec")) return "xvecOnly";
+  if (target.includes("chunk size") || target.includes("chunk_size")) return "chunkSize";
+  if (target.includes("temperature")) return "temperature";
+  if (target.includes("top k") || target.includes("top_k")) return "topK";
+  if (target.includes("repetition penalty") || target.includes("repetition_penalty")) {
+    return "repetitionPenalty";
+  }
   if (target.includes("width")) return "width";
   if (target.includes("height")) return "height";
   if (target.includes("guidance") || target.includes("cfg")) return "guidanceScale";
   if (target.includes("seed")) return "seed";
-  if (target.includes("voice") || target.includes("speaker") || target.includes("spk")) return "voice";
+  if (target.includes("speaker") || target.includes("spk")) return "speaker";
+  if (target.includes("voice")) return "voice";
   if (target.includes("speed") || target.includes("rate")) return "speed";
   if (target.includes("mode")) return "modeChoice";
   if (target.includes("upsample")) return "promptUpsampling";
@@ -227,10 +249,10 @@ function buildParamConfig(
   );
   const step = resolveNumber(componentProps.step, undefined);
   const optionsRaw =
-    (componentProps.choices as Array<string | number>) ??
-    (componentProps.options as Array<string | number>);
+    (componentProps.choices as RuntimeParameterOptionInput[]) ??
+    (componentProps.options as RuntimeParameterOptionInput[]);
 
-  const options = Array.isArray(optionsRaw) ? optionsRaw : undefined;
+  const options = normalizeRuntimeParameterOptions(optionsRaw);
   const value =
     componentProps.value ?? componentProps.default ?? defaultValue;
 

--- a/src/server/model-catalog/space-importer.ts
+++ b/src/server/model-catalog/space-importer.ts
@@ -39,6 +39,16 @@ type ImportResult = {
   warnings: string[];
 };
 
+type EndpointParameter = {
+  parameter_name?: string;
+  label?: string;
+  parameter_default?: unknown;
+};
+
+type EndpointInfo = {
+  parameters?: EndpointParameter[];
+};
+
 const DEFAULT_VENDOR = "HUGGINGFACE";
 const DEFAULT_PROVIDER = "hf_space";
 const CONNECT_TIMEOUT_MS = 15_000;
@@ -95,6 +105,8 @@ const FALLBACK_AUDIO_PARAMETERS: Record<string, ParameterConfig> = {
   voice: { ui: "input", default: "default" },
   speed: { ui: "range", min: 0.25, max: 4, step: 0.05, default: 1 },
   seed: { ui: "input", default: "" },
+  inputAudio: { ui: "upload" },
+  referenceText: { ui: "textarea" },
 };
 
 function normalizeApiName(name: string) {
@@ -107,6 +119,14 @@ function normalizeKey(value: string) {
 
 function resolveParamKey(label?: string, paramName?: string, type?: string) {
   const target = `${label ?? ""} ${paramName ?? ""}`.toLowerCase();
+  if (
+    target.includes("reference transcript") ||
+    target.includes("reference text") ||
+    target.includes("ref_text") ||
+    target.includes("ref text")
+  ) {
+    return "referenceText";
+  }
   if (target.includes("prompt")) return "prompt";
   if (target.includes("text") || target.includes("script") || target.includes("message")) return "prompt";
   if (target.includes("width")) return "width";
@@ -291,6 +311,47 @@ function getDefaultFromParam(param?: ParameterConfig) {
   return param?.default;
 }
 
+function scoreEndpoint(
+  apiName: string,
+  endpoint: EndpointInfo | undefined,
+  outputTypes: string[],
+) {
+  const normalizedName = apiName.toLowerCase();
+  const parameters = endpoint?.parameters ?? [];
+  let score = 0;
+
+  if (outputTypes.some((type) => type.includes("audio"))) score += 10;
+  if (
+    normalizedName.includes("run") ||
+    normalizedName.includes("generate") ||
+    normalizedName.includes("predict") ||
+    normalizedName.includes("synth")
+  ) {
+    score += 10;
+  }
+  if (
+    normalizedName.includes("toggle") ||
+    normalizedName.includes("refresh") ||
+    normalizedName.includes("load")
+  ) {
+    score -= 10;
+  }
+
+  for (const parameter of parameters) {
+    const target = `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`.toLowerCase();
+    if (target.includes("prompt") || target.includes("text")) score += 2;
+    if (
+      target.includes("reference audio") ||
+      target.includes("ref audio") ||
+      target.includes("ref_audio")
+    ) {
+      score += 4;
+    }
+  }
+
+  return score;
+}
+
 async function connectWithTimeout(
   spaceRef: string,
   clientOptions?: Parameters<typeof Client.connect>[1],
@@ -350,10 +411,40 @@ export async function importModelDraftFromSpace(
     throw new Error("SPACE_API_NOT_FOUND");
   }
 
+  const componentsById = new Map(config.components.map((component) => [component.id, component]));
+  const dependencyByApiName = new Map(
+    config.dependencies.map((dependency) => [
+      normalizeApiName(dependency.api_name ?? ""),
+      dependency,
+    ]),
+  );
+  const outputTypesByApiName = new Map<string, string[]>();
+  for (const apiName of apiNames) {
+    const dependency = dependencyByApiName.get(apiName);
+    const outputTypes = (dependency?.outputs ?? [])
+      .map((id) => componentsById.get(id))
+      .map((component) => (component ? resolveComponentType(component) : null))
+      .filter((type): type is string => Boolean(type));
+    outputTypesByApiName.set(apiName, outputTypes);
+  }
+
   const requested = payload.apiName ? normalizeApiName(payload.apiName) : "";
-  const resolvedApiName = requested && apiNames.includes(requested)
-    ? requested
-    : apiNames[0];
+  const resolvedApiName =
+    requested && apiNames.includes(requested)
+      ? requested
+      : [...apiNames].sort((left, right) => {
+          const leftScore = scoreEndpoint(
+            left,
+            named[left] ?? named[left.replace(/^\//, "")],
+            outputTypesByApiName.get(left) ?? [],
+          );
+          const rightScore = scoreEndpoint(
+            right,
+            named[right] ?? named[right.replace(/^\//, "")],
+            outputTypesByApiName.get(right) ?? [],
+          );
+          return rightScore - leftScore;
+        })[0];
 
   const endpoint = named[resolvedApiName] ?? named[resolvedApiName.replace(/^\//, "")];
   if (!endpoint) {
@@ -361,17 +452,12 @@ export async function importModelDraftFromSpace(
   }
 
   // 3) 엔드포인트 연결 컴포넌트 매핑
-  const dependency = config.dependencies.find(
-    (dep) => normalizeApiName(dep.api_name ?? "") === resolvedApiName,
-  );
-
-  const componentsById = new Map(config.components.map((component) => [component.id, component]));
+  const dependency = dependencyByApiName.get(resolvedApiName);
   const inputComponents = (dependency?.inputs ?? []).map((id) => componentsById.get(id));
-  const outputComponents = (dependency?.outputs ?? []).map((id) => componentsById.get(id));
-
-  const outputTypes = outputComponents
-    .map((component) => (component ? resolveComponentType(component) : null))
-    .filter((type): type is string => Boolean(type));
+  const outputComponents = (dependency?.outputs ?? []).map((id) =>
+    componentsById.get(id),
+  );
+  const outputTypes = outputTypesByApiName.get(resolvedApiName) ?? [];
 
   const parameters: Record<string, ParameterConfig> = {};
   const warnings: string[] = [];

--- a/src/server/model-catalog/space-importer.ts
+++ b/src/server/model-catalog/space-importer.ts
@@ -1,6 +1,6 @@
 import { Client } from "@gradio/client";
 
-type ModelType = "image" | "video";
+type ModelType = "image" | "video" | "audio";
 
 type ImportRequest = {
   spaceUrl: string;
@@ -63,6 +63,13 @@ const DEFAULT_VIDEO_META = {
   concurrent_limit: 1,
 };
 
+const DEFAULT_AUDIO_META = {
+  model_id: "owner/model",
+  default_speed: 1,
+  concurrent_limit: 1,
+  supports_input_audio: false,
+};
+
 const FALLBACK_IMAGE_PARAMETERS: Record<string, ParameterConfig> = {
   prompt: { ui: "textarea", required: true },
   width: { ui: "input", min: 512, max: 2048, step: 1, default: 1024 },
@@ -83,6 +90,13 @@ const FALLBACK_VIDEO_PARAMETERS: Record<string, ParameterConfig> = {
   fps: { ui: "hidden", min: 16, max: 16, step: 1, default: 16 },
 };
 
+const FALLBACK_AUDIO_PARAMETERS: Record<string, ParameterConfig> = {
+  prompt: { ui: "textarea", required: true },
+  voice: { ui: "input", default: "default" },
+  speed: { ui: "range", min: 0.25, max: 4, step: 0.05, default: 1 },
+  seed: { ui: "input", default: "" },
+};
+
 function normalizeApiName(name: string) {
   return name.startsWith("/") ? name : `/${name}`;
 }
@@ -94,10 +108,13 @@ function normalizeKey(value: string) {
 function resolveParamKey(label?: string, paramName?: string, type?: string) {
   const target = `${label ?? ""} ${paramName ?? ""}`.toLowerCase();
   if (target.includes("prompt")) return "prompt";
+  if (target.includes("text") || target.includes("script") || target.includes("message")) return "prompt";
   if (target.includes("width")) return "width";
   if (target.includes("height")) return "height";
   if (target.includes("guidance") || target.includes("cfg")) return "guidanceScale";
   if (target.includes("seed")) return "seed";
+  if (target.includes("voice") || target.includes("speaker") || target.includes("spk")) return "voice";
+  if (target.includes("speed") || target.includes("rate")) return "speed";
   if (target.includes("mode")) return "modeChoice";
   if (target.includes("upsample")) return "promptUpsampling";
   if (target.includes("image") && target.includes("count")) return "imageCount";
@@ -106,6 +123,10 @@ function resolveParamKey(label?: string, paramName?: string, type?: string) {
   if (target.includes("resolution")) return "resolution";
   if (target.includes("aspect")) return "aspectRatio";
   if (target.includes("init") && target.includes("image")) return "initImage";
+  if (target.includes("input") && target.includes("audio")) return "inputAudio";
+  if (target.includes("audio") && (type?.includes("audio") || type?.includes("file"))) {
+    return "inputAudio";
+  }
   if (target.includes("image") && (type?.includes("image") || type?.includes("gallery"))) {
     return "initImage";
   }
@@ -254,7 +275,13 @@ function buildParamConfig(
   };
 }
 
-function detectModelType(outputTypes: string[], hasVideoParam: boolean) {
+function detectModelType(
+  outputTypes: string[],
+  hasVideoParam: boolean,
+  hasAudioParam: boolean,
+) {
+  if (hasAudioParam) return "audio";
+  if (outputTypes.some((type) => type.includes("audio"))) return "audio";
   if (hasVideoParam) return "video";
   if (outputTypes.some((type) => type.includes("video"))) return "video";
   return "image";
@@ -349,7 +376,9 @@ export async function importModelDraftFromSpace(
   const parameters: Record<string, ParameterConfig> = {};
   const warnings: string[] = [];
   let hasVideoParam = false;
+  let hasAudioParam = false;
   let hasImageInput = false;
+  let hasAudioInput = false;
   let inputImagesFormat: "file_array" | "gallery" = "file_array";
 
   inputComponents.forEach((component, index) => {
@@ -368,12 +397,18 @@ export async function importModelDraftFromSpace(
     if (paramKey === "durationSec" || paramKey === "fps" || paramKey === "resolution" || paramKey === "aspectRatio") {
       hasVideoParam = true;
     }
+    if (paramKey === "voice" || paramKey === "speed" || paramKey === "inputAudio") {
+      hasAudioParam = true;
+    }
 
     if (componentType.includes("image") || componentType.includes("gallery")) {
       hasImageInput = true;
       if (componentType.includes("gallery")) {
         inputImagesFormat = "gallery";
       }
+    }
+    if (componentType.includes("audio")) {
+      hasAudioInput = true;
     }
 
     parameters[paramKey] = buildParamConfig(
@@ -390,10 +425,13 @@ export async function importModelDraftFromSpace(
     if (componentType && componentType.includes("video")) {
       hasVideoParam = true;
     }
+    if (componentType && componentType.includes("audio")) {
+      hasAudioParam = true;
+    }
   });
 
   // 4) 모델 타입/파라미터/메타 구성
-  const modelType = detectModelType(outputTypes, hasVideoParam);
+  const modelType = detectModelType(outputTypes, hasVideoParam, hasAudioParam);
   const spaceId = config.space_id || spaceRef;
   const key = normalizeKey(spaceId.replace("/", "-")) || normalizeKey(spaceUrl);
   const label = resolveString(config.title, spaceId);
@@ -409,11 +447,16 @@ export async function importModelDraftFromSpace(
   if (modelType === "video" && parameters.initImage) {
     parameters.initImage.ui = "upload";
   }
+  if (modelType === "audio" && parameters.inputAudio) {
+    parameters.inputAudio.ui = "upload";
+  }
 
   const normalizedParameters =
     modelType === "image"
       ? { ...FALLBACK_IMAGE_PARAMETERS, ...parameters }
-      : { ...FALLBACK_VIDEO_PARAMETERS, ...parameters };
+      : modelType === "video"
+        ? { ...FALLBACK_VIDEO_PARAMETERS, ...parameters }
+        : { ...FALLBACK_AUDIO_PARAMETERS, ...parameters };
 
   const width = resolveNumber(
     getDefaultFromParam(normalizedParameters.width),
@@ -439,6 +482,10 @@ export async function importModelDraftFromSpace(
     getDefaultFromParam(normalizedParameters.fps),
     DEFAULT_VIDEO_META.default_fps,
   );
+  const speed = resolveNumber(
+    getDefaultFromParam(normalizedParameters.speed),
+    DEFAULT_AUDIO_META.default_speed,
+  );
 
   const meta =
     modelType === "image"
@@ -450,18 +497,25 @@ export async function importModelDraftFromSpace(
           default_steps: steps,
           max_input_images: hasImageInput ? 1 : 0,
         }
-      : {
-          ...DEFAULT_VIDEO_META,
-          supports_init_image: hasImageInput,
-          t2v_model_id: spaceId,
-          i2v_model_id: null,
-          default_width: DEFAULT_VIDEO_META.default_width,
-          default_height: DEFAULT_VIDEO_META.default_height,
-          default_duration_sec: durationSec,
-          default_fps: fps,
-          default_steps: steps,
-          default_guidance_scale: guidanceScale,
-        };
+      : modelType === "video"
+        ? {
+            ...DEFAULT_VIDEO_META,
+            supports_init_image: hasImageInput,
+            t2v_model_id: spaceId,
+            i2v_model_id: null,
+            default_width: DEFAULT_VIDEO_META.default_width,
+            default_height: DEFAULT_VIDEO_META.default_height,
+            default_duration_sec: durationSec,
+            default_fps: fps,
+            default_steps: steps,
+            default_guidance_scale: guidanceScale,
+          }
+        : {
+            ...DEFAULT_AUDIO_META,
+            model_id: spaceId,
+            default_speed: speed,
+            supports_input_audio: hasAudioInput,
+          };
 
   const providerConfig: Record<string, unknown> = {
     space_id: spaceId,
@@ -471,6 +525,9 @@ export async function importModelDraftFromSpace(
 
   if (modelType === "image") {
     providerConfig.input_images_format = inputImagesFormat;
+  }
+  if (modelType === "audio" && hasAudioInput) {
+    providerConfig.input_audio_format = "file";
   }
 
   const draft: DraftPayload = {

--- a/src/server/monitoring/monitoring-query.test.ts
+++ b/src/server/monitoring/monitoring-query.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import { parseMonitoringQuery } from "@/server/monitoring/monitoring-query";
 
 describe("parseMonitoringQuery", () => {
+  it("audio 타입을 허용한다", () => {
+    const params = new URLSearchParams(
+      "from=2026-01-01&to=2026-01-02&type=audio",
+    );
+
+    const query = parseMonitoringQuery(params);
+
+    expect(query.type).toBe("audio");
+  });
+
   it("offset이 음수면 0으로 보정한다", () => {
     const params = new URLSearchParams(
       "from=2026-01-01&to=2026-01-02&offset=-10",

--- a/src/server/monitoring/monitoring-query.ts
+++ b/src/server/monitoring/monitoring-query.ts
@@ -1,4 +1,4 @@
-export type MonitoringType = "image" | "video" | "all";
+export type MonitoringType = "image" | "video" | "audio" | "all";
 export type MonitoringStatus = "pending" | "processing" | "completed" | "failed";
 export type MonitoringMetric = "requests" | "errors" | "latency";
 
@@ -28,7 +28,7 @@ const MAX_LIMIT = 200;
 const MAX_OFFSET = 10_000;
 const DEFAULT_TOP_LIMIT = 5;
 
-const TYPES = new Set<MonitoringType>(["image", "video", "all"]);
+const TYPES = new Set<MonitoringType>(["image", "video", "audio", "all"]);
 const STATUS = new Set<MonitoringStatus>([
   "pending",
   "processing",

--- a/src/server/monitoring/monitoring-sql.ts
+++ b/src/server/monitoring/monitoring-sql.ts
@@ -61,7 +61,10 @@ export function buildRawWhere(
   return Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}`;
 }
 
-export function buildBaseSelect(table: "ImageGeneration" | "VideoGeneration", where: Prisma.Sql) {
+export function buildBaseSelect(
+  table: "ImageGeneration" | "VideoGeneration" | "AudioGeneration",
+  where: Prisma.Sql,
+) {
   const tableName = Prisma.raw(`"${table}"`);
   return Prisma.sql`
     SELECT "createdAt", "updatedAt", "status"::text as "status", "modelKey", "apiKeyId"

--- a/src/server/monitoring/monitoring-where.ts
+++ b/src/server/monitoring/monitoring-where.ts
@@ -16,7 +16,12 @@ type WhereOptions = {
   includeQuery?: boolean;
 };
 
-function applyCommonFilters<T extends Prisma.ImageGenerationWhereInput | Prisma.VideoGenerationWhereInput>(
+function applyCommonFilters<
+  T extends
+    | Prisma.ImageGenerationWhereInput
+    | Prisma.VideoGenerationWhereInput
+    | Prisma.AudioGenerationWhereInput,
+>(
   where: T,
   filters: MonitoringWhereFilters,
   options?: WhereOptions,
@@ -79,5 +84,13 @@ export function buildVideoWhere(
   options?: WhereOptions,
 ): Prisma.VideoGenerationWhereInput {
   const where: Prisma.VideoGenerationWhereInput = {};
+  return applyCommonFilters(where, filters, options);
+}
+
+export function buildAudioWhere(
+  filters: MonitoringWhereFilters,
+  options?: WhereOptions,
+): Prisma.AudioGenerationWhereInput {
+  const where: Prisma.AudioGenerationWhereInput = {};
   return applyCommonFilters(where, filters, options);
 }

--- a/src/server/monitoring/overview.test.ts
+++ b/src/server/monitoring/overview.test.ts
@@ -5,6 +5,9 @@ import { prisma } from "@/server/db/prisma";
 
 vi.mock("@/server/db/prisma", () => ({
   prisma: {
+    audioGeneration: {
+      count: vi.fn(),
+    },
     imageGeneration: {
       count: vi.fn(),
     },
@@ -32,6 +35,7 @@ const baseQuery: MonitoringQuery = {
 describe("getMonitoringOverview", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (prisma.audioGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
   });
 
   it("활성/요청/오류율 지표를 계산한다", async () => {

--- a/src/server/monitoring/overview.ts
+++ b/src/server/monitoring/overview.ts
@@ -1,7 +1,11 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/server/db/prisma";
 import type { MonitoringQuery } from "@/server/monitoring/monitoring-query";
-import { buildImageWhere, buildVideoWhere } from "@/server/monitoring/monitoring-where";
+import {
+  buildAudioWhere,
+  buildImageWhere,
+  buildVideoWhere,
+} from "@/server/monitoring/monitoring-where";
 import {
   ACTIVE_STATUSES,
   FINISHED_STATUSES,
@@ -53,16 +57,25 @@ async function getActiveCount(query: MonitoringQuery) {
     });
   }
 
-  const [imageCount, videoCount] = await Promise.all([
+  if (query.type === "audio") {
+    return prisma.audioGeneration.count({
+      where: buildAudioWhere(baseFilters, { includeStatus: true }),
+    });
+  }
+
+  const [imageCount, videoCount, audioCount] = await Promise.all([
     prisma.imageGeneration.count({
       where: buildImageWhere(baseFilters, { includeStatus: true }),
     }),
     prisma.videoGeneration.count({
       where: buildVideoWhere(baseFilters, { includeStatus: true }),
     }),
+    prisma.audioGeneration.count({
+      where: buildAudioWhere(baseFilters, { includeStatus: true }),
+    }),
   ]);
 
-  return imageCount + videoCount;
+  return imageCount + videoCount + audioCount;
 }
 
 async function getMetrics(query: MonitoringQuery) {
@@ -79,13 +92,16 @@ async function getMetrics(query: MonitoringQuery) {
 
   const imageSelect = buildBaseSelect("ImageGeneration", where);
   const videoSelect = buildBaseSelect("VideoGeneration", where);
+  const audioSelect = buildBaseSelect("AudioGeneration", where);
 
   const baseQuery =
     query.type === "image"
       ? imageSelect
       : query.type === "video"
         ? videoSelect
-        : Prisma.sql`${imageSelect} UNION ALL ${videoSelect}`;
+        : query.type === "audio"
+          ? audioSelect
+          : Prisma.sql`${imageSelect} UNION ALL ${videoSelect} UNION ALL ${audioSelect}`;
 
   const rows = await prisma.$queryRaw<MetricRow[]>`
     SELECT

--- a/src/server/monitoring/queue-status.test.ts
+++ b/src/server/monitoring/queue-status.test.ts
@@ -1,6 +1,7 @@
 import { getQueueStatus } from "@/server/monitoring/queue-status";
 import { prisma } from "@/server/db/prisma";
 import type {
+  RuntimeAudioModel,
   RuntimeImageModel,
   RuntimeVideoModel,
 } from "@/server/model-catalog/runtime-models";
@@ -9,6 +10,9 @@ const mockGetRuntimeCatalog = vi.hoisted(() => vi.fn());
 
 vi.mock("@/server/db/prisma", () => ({
   prisma: {
+    audioGeneration: {
+      groupBy: vi.fn(),
+    },
     imageGeneration: {
       groupBy: vi.fn(),
     },
@@ -31,6 +35,19 @@ vi.mock("@/server/model-catalog/runtime-models", async () => {
 describe("getQueueStatus", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    const audioModels: RuntimeAudioModel[] = [
+      {
+        key: "qwen-tts",
+        isActive: true,
+        isDefault: true,
+        defaults: {
+          voice: "alloy",
+          speed: 1,
+        },
+        concurrentLimit: 1,
+        supportsInputAudio: false,
+      },
+    ];
     const imageModels: RuntimeImageModel[] = [
       {
         key: "z-image-turbo",
@@ -65,10 +82,13 @@ describe("getQueueStatus", () => {
         supportsInitImage: true,
       },
     ];
-    mockGetRuntimeCatalog.mockResolvedValue({ imageModels, videoModels });
+    mockGetRuntimeCatalog.mockResolvedValue({ audioModels, imageModels, videoModels });
   });
 
   it("모델별 pending/processing 수를 반환한다", async () => {
+    (prisma.audioGeneration.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { modelKey: "qwen-tts", status: "processing", _count: { _all: 3 } },
+    ]);
     (prisma.imageGeneration.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
       { modelKey: "z-image-turbo", status: "pending", _count: { _all: 1 } },
       { modelKey: "z-image-turbo", status: "processing", _count: { _all: 1 } },
@@ -85,9 +105,13 @@ describe("getQueueStatus", () => {
     const videoItem = result.items.find(
       (item) => item.type === "video" && item.model === "wan2-2-hf",
     );
+    const audioItem = result.items.find(
+      (item) => item.type === "audio" && item.model === "qwen-tts",
+    );
 
     expect(imageItem).toMatchObject({ pending: 1, processing: 1 });
     expect(videoItem).toMatchObject({ pending: 2, processing: 0 });
+    expect(audioItem).toMatchObject({ pending: 0, processing: 3 });
     expect(result.updatedAt).toEqual(expect.any(String));
   });
 });

--- a/src/server/monitoring/queue-status.ts
+++ b/src/server/monitoring/queue-status.ts
@@ -1,4 +1,8 @@
-import type { ImageGenerationStatus, VideoGenerationStatus } from "@prisma/client";
+import type {
+  AudioGenerationStatus,
+  ImageGenerationStatus,
+  VideoGenerationStatus,
+} from "@prisma/client";
 import { prisma } from "@/server/db/prisma";
 import {
   getRuntimeCatalog,
@@ -6,7 +10,7 @@ import {
 } from "@/server/model-catalog/runtime-models";
 
 export type QueueStatusItem = {
-  type: "image" | "video";
+  type: "audio" | "image" | "video";
   model: string;
   pending: number;
   processing: number;
@@ -27,6 +31,10 @@ const IMAGE_ACTIVE_STATUSES: ImageGenerationStatus[] = [
   "processing",
 ];
 const VIDEO_ACTIVE_STATUSES: VideoGenerationStatus[] = [
+  "pending",
+  "processing",
+];
+const AUDIO_ACTIVE_STATUSES: AudioGenerationStatus[] = [
   "pending",
   "processing",
 ];
@@ -74,8 +82,19 @@ type VideoQueueGroup = {
   _count: { _all: number };
 };
 
+type AudioQueueGroup = {
+  modelKey: string | null;
+  status: AudioGenerationStatus;
+  _count: { _all: number };
+};
+
 export async function getQueueStatus(): Promise<QueueStatusResponse> {
-  const [imageRows, videoRows, runtime] = await Promise.all([
+  const [audioRows, imageRows, videoRows, runtime] = await Promise.all([
+    prisma.audioGeneration.groupBy({
+      by: ["modelKey", "status"],
+      where: { status: { in: AUDIO_ACTIVE_STATUSES } },
+      _count: { _all: true },
+    }),
     prisma.imageGeneration.groupBy({
       by: ["modelKey", "status"],
       where: { status: { in: IMAGE_ACTIVE_STATUSES } },
@@ -89,19 +108,41 @@ export async function getQueueStatus(): Promise<QueueStatusResponse> {
     getRuntimeCatalog({ includeInactive: true }),
   ]);
 
+  const audioKeys = runtime.audioModels.map((model) => model.key);
   const imageKeys = runtime.imageModels.map((model) => model.key);
   const videoKeys = runtime.videoModels.map((model) => model.key);
+  const audioDefaultKey =
+    resolveDefaultModelKey(runtime.audioModels) ?? audioKeys[0];
   const imageDefaultKey =
     resolveDefaultModelKey(runtime.imageModels) ?? imageKeys[0];
   const videoDefaultKey =
     resolveDefaultModelKey(runtime.videoModels) ?? videoKeys[0];
 
+  const audioCounts = initCounts(
+    runtime.audioModels.filter((model) => model.isActive).map((model) => model.key),
+  );
   const imageCounts = initCounts(
     runtime.imageModels.filter((model) => model.isActive).map((model) => model.key),
   );
   const videoCounts = initCounts(
     runtime.videoModels.filter((model) => model.isActive).map((model) => model.key),
   );
+
+  for (const row of audioRows as AudioQueueGroup[]) {
+    const key = normalizeQueueModelKey(
+      row.modelKey,
+      audioKeys,
+      audioDefaultKey,
+    );
+    const counts = audioCounts.get(key) ?? { pending: 0, processing: 0 };
+    const count = row._count._all;
+    if (row.status === "pending") {
+      counts.pending += count;
+    } else {
+      counts.processing += count;
+    }
+    audioCounts.set(key, counts);
+  }
 
   for (const row of imageRows as ImageQueueGroup[]) {
     const key = normalizeQueueModelKey(
@@ -137,6 +178,10 @@ export async function getQueueStatus(): Promise<QueueStatusResponse> {
 
   return {
     updatedAt: new Date().toISOString(),
-    items: [...toItems("image", imageCounts), ...toItems("video", videoCounts)],
+    items: [
+      ...toItems("audio", audioCounts),
+      ...toItems("image", imageCounts),
+      ...toItems("video", videoCounts),
+    ],
   };
 }

--- a/src/server/monitoring/request-detail.test.ts
+++ b/src/server/monitoring/request-detail.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMonitoringRequestDetail } from "@/server/monitoring/request-detail";
+import { prisma } from "@/server/db/prisma";
+
+vi.mock("@/server/db/prisma", () => ({
+  prisma: {
+    imageGeneration: {
+      findUnique: vi.fn(),
+    },
+    videoGeneration: {
+      findUnique: vi.fn(),
+    },
+    audioGeneration: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+describe("getMonitoringRequestDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("audio 요청 상세를 오디오 asset으로 반환한다", async () => {
+    const createdAt = new Date("2026-01-10T10:00:00.000Z");
+    const updatedAt = new Date("2026-01-10T10:00:02.000Z");
+    (prisma.audioGeneration.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      requestId: "aud-1",
+      status: "completed",
+      modelKey: "qwen-tts",
+      prompt: "hello",
+      requestParams: {},
+      createdAt,
+      updatedAt,
+      progress: 100,
+      errorMessage: null,
+      audios: [
+        {
+          url: "https://cdn.example.com/audio.mp3",
+          durationSec: 4,
+        },
+      ],
+    });
+
+    const result = await getMonitoringRequestDetail("audio" as never, "aud-1");
+
+    expect(result).toMatchObject({
+      id: "aud-1",
+      type: "audio",
+      durationMs: 2000,
+      assets: [
+        {
+          url: "https://cdn.example.com/audio.mp3",
+          durationSec: 4,
+        },
+      ],
+    });
+  });
+});

--- a/src/server/monitoring/request-detail.test.ts
+++ b/src/server/monitoring/request-detail.test.ts
@@ -51,6 +51,8 @@ describe("getMonitoringRequestDetail", () => {
       id: "aud-1",
       type: "audio",
       durationMs: 2000,
+      errorMessage: null,
+      warningMessage: null,
       inputAudios: ["data:audio/wav;base64,UklGRg=="],
       referenceText: "reference words",
       assets: [
@@ -59,6 +61,38 @@ describe("getMonitoringRequestDetail", () => {
           durationSec: 4,
         },
       ],
+    });
+  });
+
+  it("completed audio 안내 메시지는 warning 으로 분리한다", async () => {
+    const createdAt = new Date("2026-01-10T10:00:00.000Z");
+    const updatedAt = new Date("2026-01-10T10:00:02.000Z");
+    (prisma.audioGeneration.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      requestId: "aud-2",
+      status: "completed",
+      modelKey: "qwen-tts",
+      prompt: "hello",
+      requestParams: {},
+      createdAt,
+      updatedAt,
+      progress: 100,
+      errorMessage: "오디오 저장소가 지정되지 않아 외부 저장소 업로드를 건너뛰고 inline 결과를 사용합니다.",
+      audios: [
+        {
+          url: "https://cdn.example.com/audio.mp3",
+          durationSec: 4,
+        },
+      ],
+    });
+
+    const result = await getMonitoringRequestDetail("audio" as never, "aud-2");
+
+    expect(result).toMatchObject({
+      id: "aud-2",
+      status: "completed",
+      errorMessage: null,
+      warningMessage:
+        "오디오 저장소가 지정되지 않아 외부 저장소 업로드를 건너뛰고 inline 결과를 사용합니다.",
     });
   });
 });

--- a/src/server/monitoring/request-detail.test.ts
+++ b/src/server/monitoring/request-detail.test.ts
@@ -29,7 +29,10 @@ describe("getMonitoringRequestDetail", () => {
       status: "completed",
       modelKey: "qwen-tts",
       prompt: "hello",
-      requestParams: {},
+      requestParams: {
+        inputAudio: "data:audio/wav;base64,UklGRg==",
+        referenceText: "reference words",
+      },
       createdAt,
       updatedAt,
       progress: 100,
@@ -48,6 +51,8 @@ describe("getMonitoringRequestDetail", () => {
       id: "aud-1",
       type: "audio",
       durationMs: 2000,
+      inputAudios: ["data:audio/wav;base64,UklGRg=="],
+      referenceText: "reference words",
       assets: [
         {
           url: "https://cdn.example.com/audio.mp3",

--- a/src/server/monitoring/request-detail.ts
+++ b/src/server/monitoring/request-detail.ts
@@ -10,7 +10,7 @@ export type MonitoringRequestAsset = {
 
 export type MonitoringRequestDetail = {
   id: string;
-  type: "image" | "video";
+  type: "image" | "video" | "audio";
   status: string;
   model: string | null;
   prompt: string;
@@ -31,7 +31,7 @@ function toDurationMs(createdAt: Date, updatedAt: Date, status: string) {
 }
 
 export async function getMonitoringRequestDetail(
-  type: "image" | "video",
+  type: "image" | "video" | "audio",
   requestId: string,
 ): Promise<MonitoringRequestDetail | null> {
   if (type === "image") {
@@ -76,6 +76,51 @@ export async function getMonitoringRequestDetail(
         width: image.width ?? null,
         height: image.height ?? null,
         durationSec: null,
+      })),
+    };
+  }
+
+  if (type === "audio") {
+    const record = await prisma.audioGeneration.findUnique({
+      where: { requestId },
+      select: {
+        requestId: true,
+        status: true,
+        modelKey: true,
+        prompt: true,
+        requestParams: true,
+        createdAt: true,
+        updatedAt: true,
+        progress: true,
+        errorMessage: true,
+        audios: {
+          select: {
+            url: true,
+            durationSec: true,
+          },
+        },
+      },
+    });
+
+    if (!record) return null;
+
+    return {
+      id: record.requestId,
+      type: "audio",
+      status: record.status,
+      model: record.modelKey ?? null,
+      prompt: record.prompt,
+      createdAt: record.createdAt.toISOString(),
+      updatedAt: record.updatedAt.toISOString(),
+      durationMs: toDurationMs(record.createdAt, record.updatedAt, record.status),
+      progress: record.progress,
+      errorMessage: record.errorMessage ?? null,
+      inputImages: extractInputImages(record.requestParams),
+      assets: record.audios.map((audio) => ({
+        url: audio.url,
+        width: null,
+        height: null,
+        durationSec: audio.durationSec ?? null,
       })),
     };
   }

--- a/src/server/monitoring/request-detail.ts
+++ b/src/server/monitoring/request-detail.ts
@@ -23,6 +23,7 @@ export type MonitoringRequestDetail = {
   durationMs: number | null;
   progress: number | null;
   errorMessage: string | null;
+  warningMessage: string | null;
   inputImages: string[];
   inputAudios: string[];
   referenceText: string | null;
@@ -34,6 +35,27 @@ const FINISHED_STATUSES = new Set(["completed", "failed"]);
 function toDurationMs(createdAt: Date, updatedAt: Date, status: string) {
   if (!FINISHED_STATUSES.has(status)) return null;
   return Math.max(0, updatedAt.getTime() - createdAt.getTime());
+}
+
+function splitDetailMessage(status: string, message: string | null) {
+  if (!message) {
+    return {
+      errorMessage: null,
+      warningMessage: null,
+    };
+  }
+
+  if (status === "completed") {
+    return {
+      errorMessage: null,
+      warningMessage: message,
+    };
+  }
+
+  return {
+    errorMessage: message,
+    warningMessage: null,
+  };
 }
 
 export async function getMonitoringRequestDetail(
@@ -65,6 +87,8 @@ export async function getMonitoringRequestDetail(
 
     if (!record) return null;
 
+    const messages = splitDetailMessage(record.status, record.errorMessage);
+
     return {
       id: record.requestId,
       type: "image",
@@ -75,7 +99,8 @@ export async function getMonitoringRequestDetail(
       updatedAt: record.updatedAt.toISOString(),
       durationMs: toDurationMs(record.createdAt, record.updatedAt, record.status),
       progress: record.progress,
-      errorMessage: record.errorMessage ?? null,
+      errorMessage: messages.errorMessage,
+      warningMessage: messages.warningMessage,
       inputImages: extractInputImages(record.requestParams),
       inputAudios: [],
       referenceText: null,
@@ -112,6 +137,8 @@ export async function getMonitoringRequestDetail(
 
     if (!record) return null;
 
+    const messages = splitDetailMessage(record.status, record.errorMessage);
+
     return {
       id: record.requestId,
       type: "audio",
@@ -122,7 +149,8 @@ export async function getMonitoringRequestDetail(
       updatedAt: record.updatedAt.toISOString(),
       durationMs: toDurationMs(record.createdAt, record.updatedAt, record.status),
       progress: record.progress,
-      errorMessage: record.errorMessage ?? null,
+      errorMessage: messages.errorMessage,
+      warningMessage: messages.warningMessage,
       inputImages: extractInputImages(record.requestParams),
       inputAudios: extractInputAudios(record.requestParams),
       referenceText: extractReferenceText(record.requestParams),
@@ -160,6 +188,8 @@ export async function getMonitoringRequestDetail(
 
   if (!record) return null;
 
+  const messages = splitDetailMessage(record.status, record.errorMessage);
+
   return {
     id: record.requestId,
     type: "video",
@@ -170,7 +200,8 @@ export async function getMonitoringRequestDetail(
     updatedAt: record.updatedAt.toISOString(),
     durationMs: toDurationMs(record.createdAt, record.updatedAt, record.status),
     progress: record.progress,
-    errorMessage: record.errorMessage ?? null,
+    errorMessage: messages.errorMessage,
+    warningMessage: messages.warningMessage,
     inputImages: extractInputImages(record.requestParams),
     inputAudios: [],
     referenceText: null,

--- a/src/server/monitoring/request-detail.ts
+++ b/src/server/monitoring/request-detail.ts
@@ -1,5 +1,9 @@
 import { prisma } from "@/server/db/prisma";
-import { extractInputImages } from "@/server/history/lib/history-query";
+import {
+  extractInputAudios,
+  extractInputImages,
+  extractReferenceText,
+} from "@/server/history/lib/history-query";
 
 export type MonitoringRequestAsset = {
   url: string;
@@ -20,6 +24,8 @@ export type MonitoringRequestDetail = {
   progress: number | null;
   errorMessage: string | null;
   inputImages: string[];
+  inputAudios: string[];
+  referenceText: string | null;
   assets: MonitoringRequestAsset[];
 };
 
@@ -71,6 +77,8 @@ export async function getMonitoringRequestDetail(
       progress: record.progress,
       errorMessage: record.errorMessage ?? null,
       inputImages: extractInputImages(record.requestParams),
+      inputAudios: [],
+      referenceText: null,
       assets: record.images.map((image) => ({
         url: image.url,
         width: image.width ?? null,
@@ -116,6 +124,8 @@ export async function getMonitoringRequestDetail(
       progress: record.progress,
       errorMessage: record.errorMessage ?? null,
       inputImages: extractInputImages(record.requestParams),
+      inputAudios: extractInputAudios(record.requestParams),
+      referenceText: extractReferenceText(record.requestParams),
       assets: record.audios.map((audio) => ({
         url: audio.url,
         width: null,
@@ -162,6 +172,8 @@ export async function getMonitoringRequestDetail(
     progress: record.progress,
     errorMessage: record.errorMessage ?? null,
     inputImages: extractInputImages(record.requestParams),
+    inputAudios: [],
+    referenceText: null,
     assets: record.videos.map((video) => ({
       url: video.url,
       width: video.width ?? null,

--- a/src/server/monitoring/requests.test.ts
+++ b/src/server/monitoring/requests.test.ts
@@ -9,6 +9,10 @@ vi.mock("@/server/db/prisma", () => ({
       findMany: vi.fn(),
       count: vi.fn(),
     },
+    audioGeneration: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
     videoGeneration: {
       findMany: vi.fn(),
       count: vi.fn(),
@@ -60,6 +64,8 @@ function createRecord(params: {
 describe("getMonitoringRequests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (prisma.audioGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(0);
+    (prisma.audioGeneration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   });
 
   it("API Key 표시와 duration을 계산한다", async () => {
@@ -183,6 +189,43 @@ describe("getMonitoringRequests", () => {
     expect(result.items[1].id).toBe("vid-1");
     expect(result.items[1].apiKeyLabel).toBe("UI");
     expect(result.items[1].durationMs).toBeNull();
+  });
+
+  it("type=all에서 audio 요청도 병합한다", async () => {
+    const query: MonitoringQuery = {
+      ...baseQuery,
+      type: "all",
+      limit: 10,
+      offset: 0,
+    };
+    (prisma.imageGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+    (prisma.videoGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+    (prisma.audioGeneration.count as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+    (prisma.imageGeneration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      createRecord({
+        requestId: "img-1",
+        createdAt: new Date("2026-01-04T10:00:00Z"),
+      }),
+    ]);
+    (prisma.videoGeneration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      createRecord({
+        requestId: "vid-1",
+        createdAt: new Date("2026-01-04T09:59:00Z"),
+      }),
+    ]);
+    (prisma.audioGeneration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      createRecord({
+        requestId: "aud-1",
+        createdAt: new Date("2026-01-04T09:58:00Z"),
+        apiKeyId: null,
+      }),
+    ]);
+
+    const result = await getMonitoringRequests(query);
+
+    expect(result.total).toBe(3);
+    expect(result.items.map((item) => item.type)).toEqual(["image", "video", "audio"]);
+    expect(result.items[2]?.apiKeyLabel).toBe("UI");
   });
 
   it("offset이 total 이상이면 빈 items를 반환하고 total은 유지한다", async () => {

--- a/src/server/monitoring/requests.ts
+++ b/src/server/monitoring/requests.ts
@@ -1,10 +1,14 @@
 import { prisma } from "@/server/db/prisma";
 import type { MonitoringQuery } from "@/server/monitoring/monitoring-query";
-import { buildImageWhere, buildVideoWhere } from "@/server/monitoring/monitoring-where";
+import {
+  buildAudioWhere,
+  buildImageWhere,
+  buildVideoWhere,
+} from "@/server/monitoring/monitoring-where";
 
 export type MonitoringRequestItem = {
   id: string;
-  type: "image" | "video";
+  type: "image" | "video" | "audio";
   status: string;
   model: string | null;
   createdAt: string;
@@ -26,7 +30,7 @@ const ORDER_BY = [
   { requestId: "desc" as const },
 ];
 
-type RequestType = "image" | "video";
+type RequestType = "image" | "video" | "audio";
 
 type RequestRecordBase = {
   requestId: string;
@@ -166,6 +170,36 @@ export async function getMonitoringRequests(
     };
   }
 
+  if (query.type === "audio") {
+    const where = buildAudioWhere(filters, {
+      includeDate: true,
+      includeStatus: true,
+      includeQuery: true,
+    });
+    const [total, records] = await Promise.all([
+      prisma.audioGeneration.count({ where }),
+      prisma.audioGeneration.findMany({
+        where,
+        orderBy: ORDER_BY,
+        skip: offset,
+        take: limit,
+        select,
+      }),
+    ]);
+
+    const items = records.map((record) =>
+      toMonitoringRequestItem({ ...record, type: "audio" }),
+    );
+
+    return {
+      updatedAt: new Date().toISOString(),
+      items,
+      total,
+      limit,
+      offset,
+    };
+  }
+
   const imageWhere = buildImageWhere(filters, {
     includeDate: true,
     includeStatus: true,
@@ -176,11 +210,24 @@ export async function getMonitoringRequests(
     includeStatus: true,
     includeQuery: true,
   });
+  const audioWhere = buildAudioWhere(filters, {
+    includeDate: true,
+    includeStatus: true,
+    includeQuery: true,
+  });
   const take = limit + offset;
 
-  const [imageTotal, videoTotal, imageRecords, videoRecords] = await Promise.all([
+  const [
+    imageTotal,
+    videoTotal,
+    audioTotal,
+    imageRecords,
+    videoRecords,
+    audioRecords,
+  ] = await Promise.all([
     prisma.imageGeneration.count({ where: imageWhere }),
     prisma.videoGeneration.count({ where: videoWhere }),
+    prisma.audioGeneration.count({ where: audioWhere }),
     prisma.imageGeneration.findMany({
       where: imageWhere,
       orderBy: ORDER_BY,
@@ -189,6 +236,12 @@ export async function getMonitoringRequests(
     }),
     prisma.videoGeneration.findMany({
       where: videoWhere,
+      orderBy: ORDER_BY,
+      take,
+      select,
+    }),
+    prisma.audioGeneration.findMany({
+      where: audioWhere,
       orderBy: ORDER_BY,
       take,
       select,
@@ -204,6 +257,10 @@ export async function getMonitoringRequests(
       ...record,
       type: "video" as const,
     })),
+    ...audioRecords.map((record) => ({
+      ...record,
+      type: "audio" as const,
+    })),
   ].sort(compareRecords);
 
   const items = mergedRecords
@@ -213,7 +270,7 @@ export async function getMonitoringRequests(
   return {
     updatedAt: new Date().toISOString(),
     items,
-    total: imageTotal + videoTotal,
+    total: imageTotal + videoTotal + audioTotal,
     limit,
     offset,
   };

--- a/src/server/monitoring/stats.ts
+++ b/src/server/monitoring/stats.ts
@@ -47,13 +47,16 @@ export async function getMonitoringStats(
   const where = buildRawWhere(filters, { includeDate: true, includeStatus: true });
   const imageSelect = buildBaseSelect("ImageGeneration", where);
   const videoSelect = buildBaseSelect("VideoGeneration", where);
+  const audioSelect = buildBaseSelect("AudioGeneration", where);
 
   const baseQuery =
     query.type === "image"
       ? imageSelect
       : query.type === "video"
         ? videoSelect
-        : Prisma.sql`${imageSelect} UNION ALL ${videoSelect}`;
+        : query.type === "audio"
+          ? audioSelect
+          : Prisma.sql`${imageSelect} UNION ALL ${videoSelect} UNION ALL ${audioSelect}`;
 
   const rows = await prisma.$queryRaw<RawStatsRow[]>`
     SELECT

--- a/src/server/monitoring/top.ts
+++ b/src/server/monitoring/top.ts
@@ -65,13 +65,16 @@ async function queryTopByModel(query: MonitoringQuery, limit: number) {
   const where = buildRawWhere(filters, { includeDate: true, includeStatus: true });
   const imageSelect = buildBaseSelect("ImageGeneration", where);
   const videoSelect = buildBaseSelect("VideoGeneration", where);
+  const audioSelect = buildBaseSelect("AudioGeneration", where);
 
   const baseQuery =
     query.type === "image"
       ? imageSelect
       : query.type === "video"
         ? videoSelect
-        : Prisma.sql`${imageSelect} UNION ALL ${videoSelect}`;
+        : query.type === "audio"
+          ? audioSelect
+          : Prisma.sql`${imageSelect} UNION ALL ${videoSelect} UNION ALL ${audioSelect}`;
 
   const orderBy = resolveOrder(query.metric);
 
@@ -113,13 +116,16 @@ async function queryTopByApiKey(query: MonitoringQuery, limit: number) {
   const where = buildRawWhere(filters, { includeDate: true, includeStatus: true });
   const imageSelect = buildBaseSelect("ImageGeneration", where);
   const videoSelect = buildBaseSelect("VideoGeneration", where);
+  const audioSelect = buildBaseSelect("AudioGeneration", where);
 
   const baseQuery =
     query.type === "image"
       ? imageSelect
       : query.type === "video"
         ? videoSelect
-        : Prisma.sql`${imageSelect} UNION ALL ${videoSelect}`;
+        : query.type === "audio"
+          ? audioSelect
+          : Prisma.sql`${imageSelect} UNION ALL ${videoSelect} UNION ALL ${audioSelect}`;
 
   const orderBy = resolveOrder(query.metric);
 

--- a/src/server/video-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/video-generation/adapters/hf-space-adapter.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockConnect = vi.hoisted(() => vi.fn());
+const mockGetModelCatalog = vi.hoisted(() => vi.fn());
+
+vi.mock("@gradio/client", () => ({
+  Client: {
+    connect: mockConnect,
+  },
+  handle_file: vi.fn((value) => ({ mockedFile: value })),
+}));
+
+vi.mock("@/server/model-catalog/catalog-service", () => ({
+  getModelCatalog: mockGetModelCatalog,
+}));
+
+describe("hfSpaceVideoAdapter", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("path 기반 HF Space 결과 비디오를 gradio_api/file 경로로 다운로드한다", async () => {
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "video-model-1",
+        type: "video",
+        key: "hf-video",
+        label: "HF Video",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "demo/video-space",
+          api_name: "/generate_video",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+        },
+        meta: {
+          concurrent_limit: 1,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    mockConnect.mockResolvedValue({
+      predict: vi.fn().mockResolvedValue({
+        data: [{ path: "/tmp/generated.mp4" }],
+      }),
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "video/mp4" }),
+        arrayBuffer: async () => Uint8Array.from([0, 0, 0, 24]).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceVideoAdapter } = await import(
+      "@/server/video-generation/adapters/hf-space-adapter"
+    );
+
+    const result = await hfSpaceVideoAdapter.generate({
+      prompt: "hello video",
+      model: "hf-video",
+      durationSec: 3.5,
+      fps: 16,
+      guidanceScale: 1,
+      steps: 6,
+      seed: "",
+      aspectRatio: "16:9",
+      resolution: 720,
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://demo-video-space.hf.space/gradio_api/file=/tmp/generated.mp4",
+      expect.objectContaining({}),
+    );
+    expect(result).toEqual({
+      videos: ["data:video/mp4;base64,AAAAGA=="],
+      meta: {
+        duration_sec: 3.5,
+        fps: 16,
+      },
+    });
+  });
+});

--- a/src/server/video-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/video-generation/adapters/hf-space-adapter.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockConnect = vi.hoisted(() => vi.fn());
 const mockGetModelCatalog = vi.hoisted(() => vi.fn());
@@ -18,6 +18,10 @@ describe("hfSpaceVideoAdapter", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("path 기반 HF Space 결과 비디오를 gradio_api/file 경로로 다운로드한다", async () => {

--- a/src/server/video-generation/adapters/hf-space-adapter.ts
+++ b/src/server/video-generation/adapters/hf-space-adapter.ts
@@ -2,6 +2,10 @@ import { Client, handle_file } from "@gradio/client";
 import { z } from "zod";
 import type { VideoGenerationFormValues } from "@/features/video-generation/model/video-generation-schema";
 import type { VideoGenerationAdapter } from "@/server/video-generation/adapters/types";
+import {
+  resolveHfSpaceFileReference,
+  selectPreferredHfSpaceFileReference,
+} from "@/server/hf-space/file-reference-resolver";
 import { getModelCatalog } from "@/server/model-catalog/catalog-service";
 import type { VideoModelCatalogItem } from "@/server/model-catalog/catalog-schema";
 import {
@@ -264,45 +268,16 @@ async function resolveInitImageBuffer(source: string) {
   }
 }
 
-function extractFileUrl(file: unknown) {
-  if (!file) return null;
-  if (typeof file === "string") return file;
-  if (typeof file !== "object") return null;
-  const candidate = file as {
-    url?: unknown;
-    path?: unknown;
-    name?: unknown;
-    data?: unknown;
-  };
-  if (typeof candidate.data === "string" && candidate.data.startsWith("data:")) {
-    return candidate.data;
-  }
-  if (typeof candidate.url === "string") return candidate.url;
-  if (typeof candidate.path === "string") return candidate.path;
-  if (typeof candidate.name === "string") return candidate.name;
-  return null;
-}
-
-function normalizeFileUrl(fileUrl: string, spaceUrl: string) {
-  if (fileUrl.startsWith("data:")) return fileUrl;
-  if (fileUrl.startsWith("http://") || fileUrl.startsWith("https://")) {
-    return fileUrl;
-  }
-  if (fileUrl.startsWith("/")) {
-    return `${spaceUrl}${fileUrl}`;
-  }
-  if (fileUrl.startsWith("file=")) {
-    return `${spaceUrl}/${fileUrl}`;
-  }
-  return `${spaceUrl}/file=${fileUrl}`;
-}
-
 async function fetchVideoDataUrl(
-  fileUrl: string,
+  fileRef: string | ReturnType<typeof resolveHfSpaceFileReference>,
   spaceUrl: string,
   timeoutMs: number = FILE_FETCH_TIMEOUT_MS
 ) {
-  const normalized = normalizeFileUrl(fileUrl, spaceUrl);
+  const resolved =
+    typeof fileRef === "string"
+      ? resolveHfSpaceFileReference(fileRef, spaceUrl)
+      : fileRef;
+  const normalized = resolved.normalizedUrl;
   if (normalized.startsWith("data:")) {
     return normalized;
   }
@@ -460,13 +435,16 @@ export const hfSpaceVideoAdapter: VideoGenerationAdapter = {
     }
     const data = Array.isArray(result?.data) ? result.data : result;
     const videoFile = Array.isArray(data) ? data[0] : data;
-    const fileUrl = extractFileUrl(videoFile);
-    if (!fileUrl) {
+    const fileRef = selectPreferredHfSpaceFileReference(videoFile, {
+      spaceUrl: config.spaceUrl,
+      maxDepth: 4,
+    });
+    if (!fileRef) {
       throw new Error("HF_SPACE_RESPONSE_INVALID");
     }
 
     const dataUrl = await fetchVideoDataUrl(
-      fileUrl,
+      fileRef,
       config.spaceUrl,
       Math.min(config.timeoutMs, FILE_FETCH_TIMEOUT_MS)
     );

--- a/src/shared/config/navigation.ts
+++ b/src/shared/config/navigation.ts
@@ -1,6 +1,7 @@
 export const dashboardNavigation = [
   { key: "image", href: "/image" },
   { key: "video", href: "/video" },
+  { key: "audio", href: "/audio" },
   { key: "history", href: "/history" },
   { key: "monitoring", href: "/monitoring" },
   { key: "model", href: "/model" },

--- a/src/shared/i18n/messages/en.json
+++ b/src/shared/i18n/messages/en.json
@@ -9,6 +9,7 @@
   "nav": {
     "image": "Image",
     "video": "Video",
+    "audio": "Audio",
     "history": "History",
     "monitoring": "Monitoring",
     "monitoringQueue": "Monitoring",
@@ -233,6 +234,19 @@
       },
       "sizeNotice": "This space does not support changing resolution or aspect ratio. If an image is provided, its aspect ratio is used; text-only uses the default resolution."
     },
+    "audio": {
+      "title": {
+        "leading": "Audio",
+        "accent": "Generation"
+      },
+      "subtitle": "Generate speech from text",
+      "promptPlaceholder": "Describe or paste the text you want spoken...",
+      "voiceLabel": "Voice",
+      "voiceUnset": "Default voice",
+      "voicePlaceholder": "e.g. alloy",
+      "speedLabel": "Speed",
+      "seedPlaceholder": "Optional"
+    },
     "errors": {
       "requestFailed": "Request failed.",
       "pollFailed": "Status check failed.",
@@ -274,6 +288,17 @@
           "steps": "Steps",
           "guidanceScale": "Guidance",
           "fps": "FPS"
+        }
+      },
+      "audio": {
+        "promptRequired": "Please enter a prompt.",
+        "invalidModel": "Unsupported model.",
+        "noModels": "No audio models are registered.",
+        "range": "{label} must be between {min} and {max}.",
+        "unsupportedVoice": "Unsupported voice.",
+        "inputAudioUnsupported": "The selected model does not support audio input.",
+        "labels": {
+          "speed": "Speed"
         }
       }
     }

--- a/src/shared/i18n/messages/en.json
+++ b/src/shared/i18n/messages/en.json
@@ -433,6 +433,8 @@
       "detailPrompt": "Prompt",
       "detailInputs": "Input Images",
       "detailInputsEmpty": "No input images.",
+      "detailAudioInputs": "Input Audio",
+      "detailAudioInputsEmpty": "No input audio.",
       "detailResults": "Results",
       "detailEmpty": "No outputs available.",
       "detailRequestId": "Request ID",

--- a/src/shared/i18n/messages/en.json
+++ b/src/shared/i18n/messages/en.json
@@ -244,6 +244,8 @@
       "voiceLabel": "Voice",
       "voiceUnset": "Default voice",
       "voicePlaceholder": "e.g. alloy",
+      "referenceTextLabel": "Reference Text",
+      "referenceTextPlaceholder": "Enter the transcript for the reference audio...",
       "speedLabel": "Speed",
       "seedPlaceholder": "Optional"
     },
@@ -297,6 +299,7 @@
         "range": "{label} must be between {min} and {max}.",
         "unsupportedVoice": "Unsupported voice.",
         "inputAudioUnsupported": "The selected model does not support audio input.",
+        "referenceTextRequired": "Please enter the reference text.",
         "labels": {
           "speed": "Speed"
         }

--- a/src/shared/i18n/messages/en.json
+++ b/src/shared/i18n/messages/en.json
@@ -660,6 +660,7 @@
         "errors": "Errors",
         "images": "Images",
         "videos": "Videos",
+        "audio": "Audio",
         "models": "Models"
       }
     },
@@ -697,17 +698,20 @@
       "exampleFieldMessage": "Required field."
     },
     "openapi": {
-      "infoDescription": "External REST API documentation for leesfield. Provides image/video generation and model listing.",
+      "infoDescription": "External REST API documentation for leesfield. Provides image/video/audio generation and model listing.",
       "tags": {
         "images": "Image generation",
         "videos": "Video generation",
+        "audio": "Audio generation",
         "models": "Model catalog"
       },
       "paths": {
         "imageGeneration": "Creates an image generation request.",
         "videoGeneration": "Creates a video generation request.",
+        "audioGeneration": "Creates an audio generation request.",
         "imageStatus": "Fetches the image generation result.",
         "videoStatus": "Fetches the video generation result.",
+        "audioStatus": "Fetches the audio generation result.",
         "models": "Fetches available generation models."
       }
     },

--- a/src/shared/i18n/messages/en.json
+++ b/src/shared/i18n/messages/en.json
@@ -326,7 +326,8 @@
     },
     "types": {
       "image": "IMAGE",
-      "video": "VIDEO"
+      "video": "VIDEO",
+      "audio": "AUDIO"
     },
     "actions": {
       "reusePrompt": "Reuse Prompt",

--- a/src/shared/i18n/messages/en.json
+++ b/src/shared/i18n/messages/en.json
@@ -44,6 +44,7 @@
       "all": "All",
       "images": "Images",
       "videos": "Videos",
+      "audios": "Audio",
       "total": "TOTAL: {total}",
       "sort": "SORT: {order}",
       "dateDesc": "Newest",
@@ -446,7 +447,8 @@
     "card": {
       "type": {
         "image": "IMAGE",
-        "video": "VIDEO"
+        "video": "VIDEO",
+        "audio": "AUDIO"
       },
       "default": "DEFAULT",
       "inactive": "INACTIVE",
@@ -454,7 +456,9 @@
       "meta": {
         "provider": "PROVIDER",
         "pipeline": "PIPELINE",
+        "model": "MODEL",
         "size": "SIZE",
+        "speed": "SPEED",
         "input": "INPUT",
         "mode": "MODE",
         "modality": "MODALITY",
@@ -465,7 +469,9 @@
       "t2i": "Text to Image",
       "i2i": "Image to Image",
       "t2v": "Text to Video",
-      "i2v": "Image to Video"
+      "i2v": "Image to Video",
+      "t2a": "Text to Audio",
+      "a2a": "Audio to Audio"
     },
     "admin": {
       "toolbar": {

--- a/src/shared/i18n/messages/en.json
+++ b/src/shared/i18n/messages/en.json
@@ -446,6 +446,7 @@
       "detailDuration": "Duration",
       "detailProgress": "Progress",
       "detailError": "Error",
+      "detailWarning": "Warning",
       "detailFetchError": "Failed to load request detail.",
       "detailClose": "Close",
       "columns": {

--- a/src/shared/i18n/messages/ko.json
+++ b/src/shared/i18n/messages/ko.json
@@ -433,6 +433,8 @@
       "detailPrompt": "프롬프트",
       "detailInputs": "입력 이미지",
       "detailInputsEmpty": "입력 이미지가 없습니다.",
+      "detailAudioInputs": "입력 오디오",
+      "detailAudioInputsEmpty": "입력 오디오가 없습니다.",
       "detailResults": "결과",
       "detailEmpty": "결과가 없습니다.",
       "detailRequestId": "요청 ID",

--- a/src/shared/i18n/messages/ko.json
+++ b/src/shared/i18n/messages/ko.json
@@ -9,6 +9,7 @@
   "nav": {
     "image": "이미지",
     "video": "비디오",
+    "audio": "오디오",
     "history": "히스토리",
     "monitoring": "모니터링",
     "monitoringQueue": "모니터링",
@@ -233,6 +234,19 @@
       },
       "sizeNotice": "이 스페이스는 해상도/비율 변경을 지원하지 않습니다. 이미지 입력이 있으면 그 비율을 참고하며, 텍스트 전용은 기본 해상도로 생성됩니다."
     },
+    "audio": {
+      "title": {
+        "leading": "오디오",
+        "accent": "생성"
+      },
+      "subtitle": "텍스트로 음성을 생성합니다",
+      "promptPlaceholder": "생성할 음성 내용을 자연스럽게 입력하세요...",
+      "voiceLabel": "보이스",
+      "voiceUnset": "기본 보이스",
+      "voicePlaceholder": "예: alloy",
+      "speedLabel": "속도",
+      "seedPlaceholder": "선택 사항"
+    },
     "errors": {
       "requestFailed": "요청에 실패했습니다.",
       "pollFailed": "상태 조회에 실패했습니다.",
@@ -274,6 +288,17 @@
           "steps": "스텝",
           "guidanceScale": "가이던스",
           "fps": "FPS"
+        }
+      },
+      "audio": {
+        "promptRequired": "프롬프트를 입력해주세요.",
+        "invalidModel": "지원하지 않는 모델입니다.",
+        "noModels": "등록된 오디오 모델이 없습니다.",
+        "range": "{label}는 {min}~{max} 범위여야 합니다.",
+        "unsupportedVoice": "지원하지 않는 음성입니다.",
+        "inputAudioUnsupported": "선택한 모델은 오디오 입력을 지원하지 않습니다.",
+        "labels": {
+          "speed": "속도"
         }
       }
     }

--- a/src/shared/i18n/messages/ko.json
+++ b/src/shared/i18n/messages/ko.json
@@ -660,6 +660,7 @@
         "errors": "오류",
         "images": "이미지",
         "videos": "비디오",
+        "audio": "오디오",
         "models": "모델"
       }
     },
@@ -697,17 +698,20 @@
       "exampleFieldMessage": "필수 입력입니다."
     },
     "openapi": {
-      "infoDescription": "leesfield 외부 REST API 문서입니다. 이미지/비디오 생성과 모델 조회를 제공합니다.",
+      "infoDescription": "leesfield 외부 REST API 문서입니다. 이미지/비디오/오디오 생성과 모델 조회를 제공합니다.",
       "tags": {
         "images": "이미지 생성",
         "videos": "비디오 생성",
+        "audio": "오디오 생성",
         "models": "모델 목록"
       },
       "paths": {
         "imageGeneration": "이미지 생성 요청을 생성합니다.",
         "videoGeneration": "비디오 생성 요청을 생성합니다.",
+        "audioGeneration": "오디오 생성 요청을 생성합니다.",
         "imageStatus": "이미지 생성 결과를 조회합니다.",
         "videoStatus": "비디오 생성 결과를 조회합니다.",
+        "audioStatus": "오디오 생성 결과를 조회합니다.",
         "models": "사용 가능한 생성 모델 목록을 조회합니다."
       }
     },

--- a/src/shared/i18n/messages/ko.json
+++ b/src/shared/i18n/messages/ko.json
@@ -446,6 +446,7 @@
       "detailDuration": "소요 시간",
       "detailProgress": "진행률",
       "detailError": "오류",
+      "detailWarning": "경고",
       "detailFetchError": "요청 상세를 불러오지 못했습니다.",
       "detailClose": "닫기",
       "columns": {

--- a/src/shared/i18n/messages/ko.json
+++ b/src/shared/i18n/messages/ko.json
@@ -38,12 +38,13 @@
       "reset": "리셋",
       "comingSoon": "준비 중"
     },
-  "labels": {
-    "filterOptions": "필터 옵션",
-    "searchPlaceholder": "검색...",
-    "all": "전체",
-    "images": "이미지",
+    "labels": {
+      "filterOptions": "필터 옵션",
+      "searchPlaceholder": "검색...",
+      "all": "전체",
+      "images": "이미지",
       "videos": "비디오",
+      "audios": "오디오",
       "total": "총 {total}",
       "sort": "정렬: {order}",
       "dateDesc": "최신순",
@@ -446,7 +447,8 @@
     "card": {
       "type": {
         "image": "이미지",
-        "video": "비디오"
+        "video": "비디오",
+        "audio": "오디오"
       },
       "default": "기본",
       "inactive": "비활성",
@@ -454,7 +456,9 @@
       "meta": {
         "provider": "제공자",
         "pipeline": "파이프라인",
+        "model": "모델",
         "size": "크기",
+        "speed": "속도",
         "input": "입력",
         "mode": "모드",
         "modality": "모달리티",
@@ -465,7 +469,9 @@
       "t2i": "텍스트 → 이미지",
       "i2i": "이미지 → 이미지",
       "t2v": "텍스트 → 비디오",
-      "i2v": "이미지 → 비디오"
+      "i2v": "이미지 → 비디오",
+      "t2a": "텍스트 → 오디오",
+      "a2a": "오디오 → 오디오"
     },
     "admin": {
       "toolbar": {

--- a/src/shared/i18n/messages/ko.json
+++ b/src/shared/i18n/messages/ko.json
@@ -326,7 +326,8 @@
     },
     "types": {
       "image": "이미지",
-      "video": "비디오"
+      "video": "비디오",
+      "audio": "오디오"
     },
     "actions": {
       "reusePrompt": "프롬프트 재사용",

--- a/src/shared/i18n/messages/ko.json
+++ b/src/shared/i18n/messages/ko.json
@@ -244,6 +244,8 @@
       "voiceLabel": "보이스",
       "voiceUnset": "기본 보이스",
       "voicePlaceholder": "예: alloy",
+      "referenceTextLabel": "레퍼런스 텍스트",
+      "referenceTextPlaceholder": "레퍼런스 오디오의 텍스트를 입력하세요...",
       "speedLabel": "속도",
       "seedPlaceholder": "선택 사항"
     },
@@ -297,6 +299,7 @@
         "range": "{label}는 {min}~{max} 범위여야 합니다.",
         "unsupportedVoice": "지원하지 않는 음성입니다.",
         "inputAudioUnsupported": "선택한 모델은 오디오 입력을 지원하지 않습니다.",
+        "referenceTextRequired": "레퍼런스 텍스트를 입력해주세요.",
         "labels": {
           "speed": "속도"
         }

--- a/src/shared/lib/hooks/use-runtime-model-catalog.ts
+++ b/src/shared/lib/hooks/use-runtime-model-catalog.ts
@@ -3,11 +3,13 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type {
+  RuntimeAudioModel,
   RuntimeImageModel,
   RuntimeModelBase,
   RuntimeVideoModel,
 } from "@/shared/model-catalog/runtime-utils";
 import {
+  isRuntimeAudioModel,
   isRuntimeImageModel,
   isRuntimeVideoModel,
 } from "@/shared/model-catalog/runtime-utils";
@@ -73,11 +75,16 @@ export function useRuntimeModelCatalog(
     () => items.filter(isRuntimeVideoModel),
     [items],
   );
+  const audioModels = useMemo<RuntimeAudioModel[]>(
+    () => items.filter(isRuntimeAudioModel),
+    [items],
+  );
 
   return {
     items,
     imageModels,
     videoModels,
+    audioModels,
     isLoading: enabled ? queryResult.isLoading : false,
     error: !enabled
       ? null

--- a/src/shared/model-catalog/modality.ts
+++ b/src/shared/model-catalog/modality.ts
@@ -1,4 +1,4 @@
-export type ModelModality = "T2I" | "I2I" | "T2V" | "I2V";
+export type ModelModality = "T2I" | "I2I" | "T2V" | "I2V" | "T2A" | "A2A";
 
 type ImageModalitySource =
   | { maxInputImages?: number | null }
@@ -14,6 +14,14 @@ type VideoModalitySource =
       supports_init_image?: boolean;
       t2v_model_id?: string | null;
       i2v_model_id?: string | null;
+    };
+
+type AudioModalitySource =
+  | {
+      supportsInputAudio?: boolean;
+    }
+  | {
+      supports_input_audio?: boolean;
     };
 
 function resolveNumber(value: unknown) {
@@ -80,6 +88,24 @@ export function resolveVideoModalities(source?: VideoModalitySource): ModelModal
 
   if (modalities.length === 0) {
     modalities.push("T2V");
+  }
+
+  return modalities;
+}
+
+export function resolveAudioModalities(source?: AudioModalitySource): ModelModality[] {
+  const modalities: ModelModality[] = ["T2A"];
+  if (!source || typeof source !== "object") return modalities;
+
+  const supportsInputAudio =
+    "supportsInputAudio" in source
+      ? resolveBoolean(source.supportsInputAudio)
+      : "supports_input_audio" in source
+        ? resolveBoolean(source.supports_input_audio)
+        : false;
+
+  if (supportsInputAudio) {
+    modalities.push("A2A");
   }
 
   return modalities;

--- a/src/shared/model-catalog/parameter-options.ts
+++ b/src/shared/model-catalog/parameter-options.ts
@@ -1,0 +1,96 @@
+export type RuntimeParameterOptionValue = string | number;
+
+export type RuntimeParameterOption = {
+  label: string;
+  value: RuntimeParameterOptionValue;
+};
+
+export type RuntimeParameterOptionInput =
+  | RuntimeParameterOptionValue
+  | [string, RuntimeParameterOptionValue]
+  | RuntimeParameterOption;
+
+export function isRuntimeParameterOptionValue(
+  value: unknown,
+): value is RuntimeParameterOptionValue {
+  return typeof value === "string" || typeof value === "number";
+}
+
+export function isRuntimeParameterOption(
+  value: unknown,
+): value is RuntimeParameterOption {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.label === "string" &&
+    candidate.label.trim().length > 0 &&
+    isRuntimeParameterOptionValue(candidate.value)
+  );
+}
+
+export function normalizeRuntimeParameterOption(
+  value: unknown,
+): RuntimeParameterOption | null {
+  if (isRuntimeParameterOption(value)) {
+    return {
+      label: value.label,
+      value: value.value,
+    };
+  }
+
+  if (Array.isArray(value) && value.length === 2) {
+    const [label, optionValue] = value;
+    if (typeof label === "string" && label.trim() && isRuntimeParameterOptionValue(optionValue)) {
+      return {
+        label,
+        value: optionValue,
+      };
+    }
+  }
+
+  if (isRuntimeParameterOptionValue(value)) {
+    return {
+      label: String(value),
+      value,
+    };
+  }
+
+  return null;
+}
+
+export function normalizeRuntimeParameterOptions(
+  options: unknown,
+): RuntimeParameterOption[] | undefined {
+  if (!Array.isArray(options)) {
+    return undefined;
+  }
+
+  const normalized = options
+    .map((option) => normalizeRuntimeParameterOption(option))
+    .filter((option): option is RuntimeParameterOption => option !== null);
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function getRuntimeParameterOptionValue(option: unknown) {
+  return normalizeRuntimeParameterOption(option)?.value;
+}
+
+export function getRuntimeParameterOptionLabel(option: unknown) {
+  return normalizeRuntimeParameterOption(option)?.label ?? "";
+}
+
+export function hasRuntimeParameterOption(
+  options: unknown,
+  value: string | number,
+) {
+  const normalized = normalizeRuntimeParameterOptions(options);
+  if (!normalized?.length) {
+    return false;
+  }
+
+  return normalized.some((option) => option.value === value);
+}

--- a/src/shared/model-catalog/runtime-schema.ts
+++ b/src/shared/model-catalog/runtime-schema.ts
@@ -15,6 +15,7 @@ import {
   resolveRuntimeImageMaxInputImages,
   resolveRuntimeVideoSupportsInitImage,
 } from "@/shared/model-catalog/runtime-utils";
+import { hasRuntimeParameterOption } from "@/shared/model-catalog/parameter-options";
 
 type TranslationFn = (
   key: string,
@@ -161,9 +162,8 @@ export function createRuntimeImageSchema(
     if (
       typeof data.modeChoice === "string" &&
       data.modeChoice.trim() &&
-      Array.isArray(modeConfig?.options) &&
-      modeConfig.options.length > 0 &&
-      !modeConfig.options.includes(data.modeChoice)
+      modeConfig?.options?.length &&
+      !hasRuntimeParameterOption(modeConfig.options, data.modeChoice)
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -329,8 +329,8 @@ export function createRuntimeVideoSchema(
     validateRange(data.fps, fpsRange, ["fps"], labels.fps);
 
     const aspectOptions = getRuntimeVideoParamConfig(model, "aspectRatio")?.options;
-    if (Array.isArray(aspectOptions) && aspectOptions.length > 0) {
-      if (!aspectOptions.includes(data.aspectRatio)) {
+    if (aspectOptions?.length) {
+      if (!hasRuntimeParameterOption(aspectOptions, data.aspectRatio)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["aspectRatio"],
@@ -340,8 +340,8 @@ export function createRuntimeVideoSchema(
     }
 
     const resolutionOptions = getRuntimeVideoParamConfig(model, "resolution")?.options;
-    if (Array.isArray(resolutionOptions) && resolutionOptions.length > 0) {
-      if (!resolutionOptions.includes(data.resolution)) {
+    if (resolutionOptions?.length) {
+      if (!hasRuntimeParameterOption(resolutionOptions, data.resolution)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["resolution"],
@@ -363,6 +363,10 @@ export function createRuntimeAudioSchema(
   const promptRequired = t ? t("promptRequired") : "프롬프트를 입력해주세요.";
   const labels = {
     speed: t ? t("labels.speed") : "속도",
+    chunkSize: "Chunk Size",
+    temperature: "Temperature",
+    topK: "Top K",
+    repetitionPenalty: "Repetition Penalty",
   };
   const rangeMessage = (label: string, min: number, max: number) =>
     t
@@ -381,6 +385,7 @@ export function createRuntimeAudioSchema(
   const referenceTextRequired = t
     ? t("referenceTextRequired")
     : "레퍼런스 텍스트를 입력해주세요.";
+  const unsupportedSelection = "지원하지 않는 선택값입니다.";
 
   const schema = z.object({
     prompt: z.string().min(1, promptRequired),
@@ -390,6 +395,18 @@ export function createRuntimeAudioSchema(
     seed: z.string().optional().or(z.literal("")),
     inputAudio: z.string().optional().or(z.literal("")),
     referenceText: z.string().optional().or(z.literal("")),
+    modeChoice: z.string().optional().or(z.literal("")),
+    language: z.string().optional().or(z.literal("")),
+    speaker: z.string().optional().or(z.literal("")),
+    streamMode: z.boolean().optional(),
+    referencePreset: z.string().optional().or(z.literal("")),
+    customInstruction: z.string().optional().or(z.literal("")),
+    voiceInstruction: z.string().optional().or(z.literal("")),
+    xvecOnly: z.boolean().optional(),
+    chunkSize: z.number().optional(),
+    temperature: z.number().optional(),
+    topK: z.number().optional(),
+    repetitionPenalty: z.number().optional(),
   });
 
   return schema.superRefine((data, ctx) => {
@@ -424,20 +441,30 @@ export function createRuntimeAudioSchema(
       }
     }
 
-    const voiceConfig = getRuntimeAudioParamConfig(model, "voice");
-    if (
-      typeof data.voice === "string" &&
-      data.voice.trim() &&
-      Array.isArray(voiceConfig?.options) &&
-      voiceConfig.options.length > 0 &&
-      !voiceConfig.options.includes(data.voice)
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["voice"],
-        message: unsupportedVoice,
-      });
-    }
+    const validateOption = (
+      key: "voice" | "speaker" | "modeChoice" | "language" | "referencePreset",
+      value: string | undefined,
+      message = unsupportedSelection,
+    ) => {
+      if (!value?.trim()) return;
+      const config = getRuntimeAudioParamConfig(model, key);
+      if (
+        config?.options?.length &&
+        !hasRuntimeParameterOption(config.options, value)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message,
+        });
+      }
+    };
+
+    validateOption("voice", data.voice, unsupportedVoice);
+    validateOption("speaker", data.speaker);
+    validateOption("modeChoice", data.modeChoice);
+    validateOption("language", data.language);
+    validateOption("referencePreset", data.referencePreset);
 
     if (data.inputAudio?.trim() && !resolveRuntimeAudioSupportsInputAudio(model)) {
       ctx.addIssue({
@@ -459,5 +486,42 @@ export function createRuntimeAudioSchema(
         message: referenceTextRequired,
       });
     }
+
+    const validateNumeric = (
+      key: "chunkSize" | "temperature" | "topK" | "repetitionPenalty",
+      value: number | undefined,
+      label: string,
+    ) => {
+      if (typeof value !== "number") return;
+      const range = getRuntimeAudioParamRange(model, key);
+      if (value < range.min || value > range.max) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: rangeMessage(label, range.min, range.max),
+        });
+        return;
+      }
+      if (range.step > 0) {
+        const offset = value - range.min;
+        const quotient = offset / range.step;
+        if (Math.abs(quotient - Math.round(quotient)) > 1e-6) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [key],
+            message: stepMessage(label, range.step),
+          });
+        }
+      }
+    };
+
+    validateNumeric("chunkSize", data.chunkSize, labels.chunkSize);
+    validateNumeric("temperature", data.temperature, labels.temperature);
+    validateNumeric("topK", data.topK, labels.topK);
+    validateNumeric(
+      "repetitionPenalty",
+      data.repetitionPenalty,
+      labels.repetitionPenalty,
+    );
   });
 }

--- a/src/shared/model-catalog/runtime-schema.ts
+++ b/src/shared/model-catalog/runtime-schema.ts
@@ -1,13 +1,17 @@
 import { z } from "zod";
 import type {
+  RuntimeAudioModel,
   RuntimeImageModel,
   RuntimeVideoModel,
 } from "@/shared/model-catalog/runtime-utils";
 import {
+  getRuntimeAudioParamConfig,
+  getRuntimeAudioParamRange,
   getRuntimeImageParamConfig,
   getRuntimeImageParamRange,
   getRuntimeVideoParamConfig,
   getRuntimeVideoParamRange,
+  resolveRuntimeAudioSupportsInputAudio,
   resolveRuntimeImageMaxInputImages,
   resolveRuntimeVideoSupportsInitImage,
 } from "@/shared/model-catalog/runtime-utils";
@@ -348,3 +352,95 @@ export function createRuntimeVideoSchema(
   });
 }
 
+export function createRuntimeAudioSchema(
+  models: RuntimeAudioModel[],
+  t?: TranslationFn,
+) {
+  const modelMap = new Map(models.map((model) => [model.key, model]));
+  const invalidModelMessage = t
+    ? t("invalidModel")
+    : "지원하지 않는 모델입니다.";
+  const promptRequired = t ? t("promptRequired") : "프롬프트를 입력해주세요.";
+  const labels = {
+    speed: t ? t("labels.speed") : "속도",
+  };
+  const rangeMessage = (label: string, min: number, max: number) =>
+    t
+      ? t("range", { label, min, max })
+      : `${label}는 ${min}~${max} 범위여야 합니다.`;
+  const stepMessage = (label: string, step: number) =>
+    t
+      ? t("step", { label, step })
+      : `${label}는 ${step} 단위로 입력해야 합니다.`;
+  const unsupportedVoice = t
+    ? t("unsupportedVoice")
+    : "지원하지 않는 음성입니다.";
+  const inputAudioUnsupported = t
+    ? t("inputAudioUnsupported")
+    : "선택한 모델은 오디오 입력을 지원하지 않습니다.";
+
+  const schema = z.object({
+    prompt: z.string().min(1, promptRequired),
+    model: z.string().min(1),
+    voice: z.string().optional().or(z.literal("")),
+    speed: z.number().optional(),
+    seed: z.string().optional().or(z.literal("")),
+    inputAudio: z.string().optional().or(z.literal("")),
+  });
+
+  return schema.superRefine((data, ctx) => {
+    const model = modelMap.get(data.model);
+    if (!model) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["model"],
+        message: invalidModelMessage,
+      });
+      return;
+    }
+
+    if (typeof data.speed === "number") {
+      const speedRange = getRuntimeAudioParamRange(model, "speed");
+      if (data.speed < speedRange.min || data.speed > speedRange.max) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["speed"],
+          message: rangeMessage(labels.speed, speedRange.min, speedRange.max),
+        });
+      } else if (speedRange.step > 0) {
+        const offset = data.speed - speedRange.min;
+        const quotient = offset / speedRange.step;
+        if (Math.abs(quotient - Math.round(quotient)) > 1e-6) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["speed"],
+            message: stepMessage(labels.speed, speedRange.step),
+          });
+        }
+      }
+    }
+
+    const voiceConfig = getRuntimeAudioParamConfig(model, "voice");
+    if (
+      typeof data.voice === "string" &&
+      data.voice.trim() &&
+      Array.isArray(voiceConfig?.options) &&
+      voiceConfig.options.length > 0 &&
+      !voiceConfig.options.includes(data.voice)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["voice"],
+        message: unsupportedVoice,
+      });
+    }
+
+    if (data.inputAudio?.trim() && !resolveRuntimeAudioSupportsInputAudio(model)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["inputAudio"],
+        message: inputAudioUnsupported,
+      });
+    }
+  });
+}

--- a/src/shared/model-catalog/runtime-schema.ts
+++ b/src/shared/model-catalog/runtime-schema.ts
@@ -378,6 +378,9 @@ export function createRuntimeAudioSchema(
   const inputAudioUnsupported = t
     ? t("inputAudioUnsupported")
     : "선택한 모델은 오디오 입력을 지원하지 않습니다.";
+  const referenceTextRequired = t
+    ? t("referenceTextRequired")
+    : "레퍼런스 텍스트를 입력해주세요.";
 
   const schema = z.object({
     prompt: z.string().min(1, promptRequired),
@@ -386,6 +389,7 @@ export function createRuntimeAudioSchema(
     speed: z.number().optional(),
     seed: z.string().optional().or(z.literal("")),
     inputAudio: z.string().optional().or(z.literal("")),
+    referenceText: z.string().optional().or(z.literal("")),
   });
 
   return schema.superRefine((data, ctx) => {
@@ -440,6 +444,19 @@ export function createRuntimeAudioSchema(
         code: z.ZodIssueCode.custom,
         path: ["inputAudio"],
         message: inputAudioUnsupported,
+      });
+    }
+
+    const referenceTextConfig = getRuntimeAudioParamConfig(model, "referenceText");
+    if (
+      referenceTextConfig?.required &&
+      data.inputAudio?.trim() &&
+      !(data.referenceText?.trim())
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["referenceText"],
+        message: referenceTextRequired,
       });
     }
   });

--- a/src/shared/model-catalog/runtime-utils.ts
+++ b/src/shared/model-catalog/runtime-utils.ts
@@ -1,4 +1,4 @@
-export type RuntimeModelType = "image" | "video";
+export type RuntimeModelType = "image" | "video" | "audio";
 
 export type RuntimeParameterValue = string | number | boolean;
 export type RuntimeParameterOption = string | number;
@@ -37,6 +37,13 @@ export type RuntimeVideoParameterKey =
   | "resolution"
   | "fps";
 
+export type RuntimeAudioParameterKey =
+  | "prompt"
+  | "voice"
+  | "speed"
+  | "seed"
+  | "inputAudio";
+
 export type RuntimeImageParameters = Partial<
   Record<RuntimeImageParameterKey, RuntimeParameterConfig>
 > &
@@ -44,6 +51,11 @@ export type RuntimeImageParameters = Partial<
 
 export type RuntimeVideoParameters = Partial<
   Record<RuntimeVideoParameterKey, RuntimeParameterConfig>
+> &
+  Record<string, unknown>;
+
+export type RuntimeAudioParameters = Partial<
+  Record<RuntimeAudioParameterKey, RuntimeParameterConfig>
 > &
   Record<string, unknown>;
 
@@ -69,6 +81,14 @@ export type RuntimeVideoMeta = {
   default_steps?: number;
   default_guidance_scale?: number;
   concurrent_limit?: number | null;
+  [key: string]: unknown;
+};
+
+export type RuntimeAudioMeta = {
+  model_id?: string;
+  default_speed?: number;
+  concurrent_limit?: number | null;
+  supports_input_audio?: boolean;
   [key: string]: unknown;
 };
 
@@ -98,6 +118,12 @@ export type RuntimeVideoModel = Omit<RuntimeModelBase, "type" | "parameters" | "
   meta: RuntimeVideoMeta;
 };
 
+export type RuntimeAudioModel = Omit<RuntimeModelBase, "type" | "parameters" | "meta"> & {
+  type: "audio";
+  parameters: RuntimeAudioParameters;
+  meta: RuntimeAudioMeta;
+};
+
 export type NumericRange = {
   min: number;
   max: number;
@@ -124,11 +150,17 @@ const videoFallbackRanges: Record<
   fps: { min: 1, max: 60, step: 1 },
 };
 
+const audioFallbackRanges: Record<"speed", NumericRange> = {
+  speed: { min: 0.25, max: 4, step: 0.05 },
+};
+
 const DEFAULT_IMAGE_MODE_CHOICE = "Distilled (4 steps)";
 const DEFAULT_IMAGE_GUIDANCE_SCALE = 1;
 const DEFAULT_IMAGE_PROMPT_UPSAMPLING = false;
 const DEFAULT_VIDEO_ASPECT_RATIO = "16:9";
 const DEFAULT_VIDEO_RESOLUTION = 720;
+const DEFAULT_AUDIO_VOICE = "default";
+const DEFAULT_AUDIO_SPEED = 1;
 
 function resolveNumber(value: unknown, fallback: number) {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
@@ -167,6 +199,10 @@ export function isRuntimeImageModel(item: RuntimeModelBase): item is RuntimeImag
 
 export function isRuntimeVideoModel(item: RuntimeModelBase): item is RuntimeVideoModel {
   return item.type === "video";
+}
+
+export function isRuntimeAudioModel(item: RuntimeModelBase): item is RuntimeAudioModel {
+  return item.type === "audio";
 }
 
 export function resolveRuntimeDefaultModelKey<T extends { key: string; isDefault: boolean; isActive: boolean }>(
@@ -225,6 +261,21 @@ export function getRuntimeVideoParamRange(
             ? videoFallbackRanges.fps
             : videoFallbackRanges.steps;
   return resolveRange(getRuntimeVideoParamConfig(model, key), fallback);
+}
+
+export function getRuntimeAudioParamConfig(
+  model: RuntimeAudioModel | undefined,
+  key: RuntimeAudioParameterKey,
+) {
+  return resolveParamConfig(model?.parameters, key);
+}
+
+export function getRuntimeAudioParamRange(
+  model: RuntimeAudioModel | undefined,
+  key: RuntimeAudioParameterKey,
+): NumericRange {
+  const fallback = key === "speed" ? audioFallbackRanges.speed : audioFallbackRanges.speed;
+  return resolveRange(getRuntimeAudioParamConfig(model, key), fallback);
 }
 
 export function resolveRuntimeImageDefaults(model: RuntimeImageModel) {
@@ -287,6 +338,20 @@ export function resolveRuntimeVideoDefaults(model: RuntimeVideoModel) {
   };
 }
 
+export function resolveRuntimeAudioDefaults(model: RuntimeAudioModel) {
+  const defaults = model.meta ?? {};
+  return {
+    voice: resolveString(
+      getRuntimeAudioParamConfig(model, "voice")?.default,
+      DEFAULT_AUDIO_VOICE,
+    ),
+    speed: resolveNumber(
+      getRuntimeAudioParamConfig(model, "speed")?.default,
+      resolveNumber(defaults.default_speed, DEFAULT_AUDIO_SPEED),
+    ),
+  };
+}
+
 export function resolveRuntimeImageMaxInputImages(
   model: RuntimeImageModel | undefined,
 ) {
@@ -297,4 +362,10 @@ export function resolveRuntimeVideoSupportsInitImage(
   model: RuntimeVideoModel | undefined,
 ) {
   return resolveBoolean(model?.meta?.supports_init_image, false);
+}
+
+export function resolveRuntimeAudioSupportsInputAudio(
+  model: RuntimeAudioModel | undefined,
+) {
+  return resolveBoolean(model?.meta?.supports_input_audio, false);
 }

--- a/src/shared/model-catalog/runtime-utils.ts
+++ b/src/shared/model-catalog/runtime-utils.ts
@@ -42,7 +42,8 @@ export type RuntimeAudioParameterKey =
   | "voice"
   | "speed"
   | "seed"
-  | "inputAudio";
+  | "inputAudio"
+  | "referenceText";
 
 export type RuntimeImageParameters = Partial<
   Record<RuntimeImageParameterKey, RuntimeParameterConfig>

--- a/src/shared/model-catalog/runtime-utils.ts
+++ b/src/shared/model-catalog/runtime-utils.ts
@@ -1,7 +1,13 @@
+import {
+  getRuntimeParameterOptionValue,
+  normalizeRuntimeParameterOptions,
+  type RuntimeParameterOption,
+  type RuntimeParameterOptionInput,
+} from "@/shared/model-catalog/parameter-options";
+
 export type RuntimeModelType = "image" | "video" | "audio";
 
 export type RuntimeParameterValue = string | number | boolean;
-export type RuntimeParameterOption = string | number;
 
 export type RuntimeParameterConfig = {
   ui?: string;
@@ -11,8 +17,15 @@ export type RuntimeParameterConfig = {
   max?: number;
   step?: number;
   default?: RuntimeParameterValue;
-  options?: RuntimeParameterOption[];
+  options?: RuntimeParameterOptionInput[];
   [key: string]: unknown;
+};
+
+export type NormalizedRuntimeParameterConfig = Omit<
+  RuntimeParameterConfig,
+  "options"
+> & {
+  options?: RuntimeParameterOption[];
 };
 
 export type RuntimeImageParameterKey =
@@ -40,10 +53,22 @@ export type RuntimeVideoParameterKey =
 export type RuntimeAudioParameterKey =
   | "prompt"
   | "voice"
+  | "speaker"
   | "speed"
   | "seed"
   | "inputAudio"
-  | "referenceText";
+  | "referenceText"
+  | "modeChoice"
+  | "language"
+  | "streamMode"
+  | "referencePreset"
+  | "customInstruction"
+  | "voiceInstruction"
+  | "xvecOnly"
+  | "chunkSize"
+  | "temperature"
+  | "topK"
+  | "repetitionPenalty";
 
 export type RuntimeImageParameters = Partial<
   Record<RuntimeImageParameterKey, RuntimeParameterConfig>
@@ -151,8 +176,15 @@ const videoFallbackRanges: Record<
   fps: { min: 1, max: 60, step: 1 },
 };
 
-const audioFallbackRanges: Record<"speed", NumericRange> = {
+const audioFallbackRanges: Record<
+  "speed" | "chunkSize" | "temperature" | "topK" | "repetitionPenalty",
+  NumericRange
+> = {
   speed: { min: 0.25, max: 4, step: 0.05 },
+  chunkSize: { min: 40, max: 200, step: 10 },
+  temperature: { min: 0.1, max: 1.2, step: 0.1 },
+  topK: { min: 1, max: 100, step: 1 },
+  repetitionPenalty: { min: 1, max: 2, step: 0.1 },
 };
 
 const DEFAULT_IMAGE_MODE_CHOICE = "Distilled (4 steps)";
@@ -162,6 +194,8 @@ const DEFAULT_VIDEO_ASPECT_RATIO = "16:9";
 const DEFAULT_VIDEO_RESOLUTION = 720;
 const DEFAULT_AUDIO_VOICE = "default";
 const DEFAULT_AUDIO_SPEED = 1;
+const DEFAULT_AUDIO_STREAM_MODE = false;
+const DEFAULT_AUDIO_XVEC_ONLY = false;
 
 function resolveNumber(value: unknown, fallback: number) {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
@@ -175,12 +209,40 @@ function resolveBoolean(value: unknown, fallback: boolean) {
   return typeof value === "boolean" ? value : fallback;
 }
 
+function resolveOptionValue(
+  param: NormalizedRuntimeParameterConfig | undefined,
+  fallback = "",
+) {
+  const options = param?.options ?? [];
+  const defaultValue = param?.default;
+  if (
+    (typeof defaultValue === "string" || typeof defaultValue === "number") &&
+    (!options.length || options.some((option) => option.value === defaultValue))
+  ) {
+    return String(defaultValue);
+  }
+  const firstOption = options[0];
+  const firstValue = getRuntimeParameterOptionValue(firstOption);
+  if (typeof firstValue === "string" || typeof firstValue === "number") {
+    return String(firstValue);
+  }
+  return fallback;
+}
+
 function resolveParamConfig(
   parameters: Record<string, unknown> | undefined,
   key: string,
-) {
+): NormalizedRuntimeParameterConfig | undefined {
   const param = parameters?.[key];
-  return param && typeof param === "object" ? (param as RuntimeParameterConfig) : undefined;
+  if (!param || typeof param !== "object" || Array.isArray(param)) {
+    return undefined;
+  }
+
+  const config = param as RuntimeParameterConfig;
+  return {
+    ...config,
+    options: normalizeRuntimeParameterOptions(config.options),
+  };
 }
 
 function resolveRange(
@@ -275,7 +337,16 @@ export function getRuntimeAudioParamRange(
   model: RuntimeAudioModel | undefined,
   key: RuntimeAudioParameterKey,
 ): NumericRange {
-  const fallback = key === "speed" ? audioFallbackRanges.speed : audioFallbackRanges.speed;
+  const fallback =
+    key === "chunkSize"
+      ? audioFallbackRanges.chunkSize
+      : key === "temperature"
+        ? audioFallbackRanges.temperature
+        : key === "topK"
+          ? audioFallbackRanges.topK
+          : key === "repetitionPenalty"
+            ? audioFallbackRanges.repetitionPenalty
+            : audioFallbackRanges.speed;
   return resolveRange(getRuntimeAudioParamConfig(model, key), fallback);
 }
 
@@ -341,14 +412,63 @@ export function resolveRuntimeVideoDefaults(model: RuntimeVideoModel) {
 
 export function resolveRuntimeAudioDefaults(model: RuntimeAudioModel) {
   const defaults = model.meta ?? {};
+  const voiceConfig = getRuntimeAudioParamConfig(model, "voice");
+  const speakerConfig = getRuntimeAudioParamConfig(model, "speaker");
+  const modeConfig = getRuntimeAudioParamConfig(model, "modeChoice");
+  const languageConfig = getRuntimeAudioParamConfig(model, "language");
+  const referencePresetConfig = getRuntimeAudioParamConfig(model, "referencePreset");
+  const streamModeConfig = getRuntimeAudioParamConfig(model, "streamMode");
+  const xvecOnlyConfig = getRuntimeAudioParamConfig(model, "xvecOnly");
+  const chunkSizeConfig = getRuntimeAudioParamConfig(model, "chunkSize");
+  const temperatureConfig = getRuntimeAudioParamConfig(model, "temperature");
+  const topKConfig = getRuntimeAudioParamConfig(model, "topK");
+  const repetitionPenaltyConfig = getRuntimeAudioParamConfig(
+    model,
+    "repetitionPenalty",
+  );
   return {
-    voice: resolveString(
-      getRuntimeAudioParamConfig(model, "voice")?.default,
-      DEFAULT_AUDIO_VOICE,
+    voice: voiceConfig
+      ? resolveString(voiceConfig.default, DEFAULT_AUDIO_VOICE)
+      : "",
+    speaker: resolveOptionValue(
+      speakerConfig,
+      resolveOptionValue(voiceConfig, DEFAULT_AUDIO_VOICE),
     ),
     speed: resolveNumber(
       getRuntimeAudioParamConfig(model, "speed")?.default,
       resolveNumber(defaults.default_speed, DEFAULT_AUDIO_SPEED),
+    ),
+    modeChoice: resolveOptionValue(modeConfig),
+    language: resolveOptionValue(languageConfig),
+    streamMode: resolveBoolean(
+      streamModeConfig?.default,
+      DEFAULT_AUDIO_STREAM_MODE,
+    ),
+    referencePreset: resolveOptionValue(referencePresetConfig),
+    customInstruction: resolveString(
+      getRuntimeAudioParamConfig(model, "customInstruction")?.default,
+      "",
+    ),
+    voiceInstruction: resolveString(
+      getRuntimeAudioParamConfig(model, "voiceInstruction")?.default,
+      "",
+    ),
+    xvecOnly: resolveBoolean(
+      xvecOnlyConfig?.default,
+      DEFAULT_AUDIO_XVEC_ONLY,
+    ),
+    chunkSize: resolveNumber(
+      chunkSizeConfig?.default,
+      audioFallbackRanges.chunkSize.min,
+    ),
+    temperature: resolveNumber(
+      temperatureConfig?.default,
+      audioFallbackRanges.temperature.min,
+    ),
+    topK: resolveNumber(topKConfig?.default, audioFallbackRanges.topK.min),
+    repetitionPenalty: resolveNumber(
+      repetitionPenaltyConfig?.default,
+      audioFallbackRanges.repetitionPenalty.min,
     ),
   };
 }

--- a/src/widgets/api-docs/lib/api-docs-metadata.ts
+++ b/src/widgets/api-docs/lib/api-docs-metadata.ts
@@ -1,5 +1,6 @@
 import {
   AlertTriangle,
+  AudioLines,
   BookOpen,
   Boxes,
   Film,
@@ -30,12 +31,14 @@ export const generalNavItems: ApiDocsNavDefinition[] = [
 export const fallbackEndpointItems: ApiDocsNavDefinition[] = [
   { id: "images", icon: ImageIcon },
   { id: "videos", icon: Film },
+  { id: "audio", icon: AudioLines },
   { id: "models", icon: Boxes },
 ];
 
 export const tagIdMap: Record<string, string> = {
   Images: "images",
   Videos: "videos",
+  Audio: "audio",
   Models: "models",
 };
 
@@ -43,6 +46,7 @@ export function getEndpointIcon(section: ApiSection): LucideIcon {
   const key = section.id.toLowerCase();
   if (key.includes("image")) return ImageIcon;
   if (key.includes("video")) return Film;
+  if (key.includes("audio")) return AudioLines;
   if (key.includes("model")) return Boxes;
   return BookOpen;
 }

--- a/src/widgets/api-docs/ui/api-docs-endpoints-section.test.tsx
+++ b/src/widgets/api-docs/ui/api-docs-endpoints-section.test.tsx
@@ -69,8 +69,6 @@ describe("ApiDocsEndpointsSection", () => {
     const copyButton = screen.getByRole("button", { name: "코드 복사" });
     await user.click(copyButton);
 
-    expect(
-      await screen.findByRole("button", { name: "복사됨" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "복사됨" })).toBeTruthy();
   });
 });

--- a/src/widgets/api-docs/ui/api-docs-widget.test.tsx
+++ b/src/widgets/api-docs/ui/api-docs-widget.test.tsx
@@ -15,11 +15,12 @@ describe("ApiDocsWidget", () => {
 
     renderWithIntl(<ApiDocsWidget openApiDocument={openApiDocument} />);
 
-    expect(document.getElementById("introduction")).toBeInTheDocument();
-    expect(document.getElementById("authentication")).toBeInTheDocument();
-    expect(document.getElementById("errors")).toBeInTheDocument();
-    expect(document.getElementById("images")).toBeInTheDocument();
-    expect(document.getElementById("videos")).toBeInTheDocument();
-    expect(document.getElementById("models")).toBeInTheDocument();
+    expect(document.getElementById("introduction")).toBeTruthy();
+    expect(document.getElementById("authentication")).toBeTruthy();
+    expect(document.getElementById("errors")).toBeTruthy();
+    expect(document.getElementById("images")).toBeTruthy();
+    expect(document.getElementById("videos")).toBeTruthy();
+    expect(document.getElementById("audio")).toBeTruthy();
+    expect(document.getElementById("models")).toBeTruthy();
   });
 });

--- a/src/widgets/header/ui/header.test.tsx
+++ b/src/widgets/header/ui/header.test.tsx
@@ -1,0 +1,44 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, vi } from "vitest";
+import { Header } from "@/widgets/header/ui/header";
+import { renderWithIntl } from "@/test-utils/intl";
+
+vi.mock("next/image", () => ({
+  default: ({
+    priority: _priority,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { priority?: boolean }) => (
+    <img {...props} alt={props.alt ?? ""} />
+  ),
+}));
+
+vi.mock("@/features/auth/logout/api/logout-action", () => ({
+  logoutAction: vi.fn(),
+}));
+
+vi.mock("@/shared/ui/language-switcher", () => ({
+  LanguageSwitcher: () => <div data-testid="language-switcher" />,
+}));
+
+describe("Header", () => {
+  it("대시보드 네비게이션에 Audio 링크를 노출한다", () => {
+    const { container } = renderWithIntl(
+      <Header isAuthenticated userEmail="admin@example.com" />,
+    );
+
+    expect(container.querySelectorAll('a[href="/audio"]').length).toBeGreaterThan(0);
+  });
+
+  it("모바일 메뉴를 열면 Audio 링크가 보인다", async () => {
+    const user = userEvent.setup();
+    const { container } = renderWithIntl(
+      <Header isAuthenticated userEmail="admin@example.com" />,
+    );
+
+    expect(container.querySelectorAll('a[href="/audio"]').length).toBe(1);
+    await user.click(screen.getByRole("button", { name: /메뉴/i }));
+
+    expect(container.ownerDocument.querySelectorAll('a[href="/audio"]').length).toBeGreaterThan(1);
+  });
+});

--- a/src/widgets/header/ui/header.tsx
+++ b/src/widgets/header/ui/header.tsx
@@ -9,6 +9,7 @@ import {
   Clapperboard,
   History,
   Image as ImageIcon,
+  AudioLines,
   KeyRound,
   Activity,
   LogIn,
@@ -40,6 +41,7 @@ type HeaderProps = {
 const headerIcons: Record<string, typeof ImageIcon> = {
   "/image": ImageIcon,
   "/video": Clapperboard,
+  "/audio": AudioLines,
   "/history": History,
   "/monitoring": Activity,
   "/model": Boxes,


### PR DESCRIPTION
# PR Draft: audio-generation-hf-space

## 메타데이터

- **상태**: Ready
  - 값: Draft | Ready
- **Base**: main
- **작성일**: 2026-03-06

## 개요

- 변경 목적:
  - 기존 `image|video` 중심 생성 파이프라인을 `audio`까지 확장하고, HF Space 기반 TTS/voice clone 모델을 모델 관리, 생성 UI, API, 워커, 히스토리, 모니터링, API Docs 전 구간에서 1급 모달리티로 지원한다.
- 사용자 영향:
  - 관리자는 `audio` 모델을 직접 등록/수입할 수 있고, 사용자는 `/audio`에서 텍스트 음성 생성, reference audio/reference text 기반 voice clone, 생성 결과 재생/히스토리 조회까지 수행할 수 있다.

## 변경 사항

- [x] 오디오 생성 도메인/DB/워커/API를 추가해 `audio` 요청이 `pending -> processing -> completed|failed` 흐름으로 처리되도록 확장했다.
- [x] HF Space audio adapter와 공통 file reference resolver를 구현해 `data url`, `absolute url`, `gradio_api/file=...`, `space path`, `FileData(url/path)`를 image/video/audio 공통 규칙으로 처리하도록 정리했다.
- [x] `/audio` 화면, 네비게이션, i18n, history/monitoring, API Docs/OpenAPI를 audio 모달리티에 맞게 확장했다.
- [x] `qwen-3.5-tts-faster-gradio` 지원을 위해 mode 기반 TTS 파라미터 시스템(`modeChoice`, `language`, `speaker`, advanced settings`)과 reference audio/reference text 입력 계약을 일반화했다.
- [x] `AUDIO_STORAGE_PROVIDER`, inline fallback 결과 저장, audio 전용 라벨/운영 문서를 정비해 `completed but empty result`와 운영 설정 누락 문제를 줄였다.
- [x] pre-PR 리뷰에서 확인된 monitoring 상세 warning/error 표기 문제를 수정하고 재검증했다.

## 테스트

- [x] `pnpm -C leesfield-fe test` -> `61 files, 197 tests passed`
- [x] `pnpm -C leesfield-fe lint` -> `0 errors, 15 warnings`
- [x] `pnpm -C leesfield-fe tsc --noEmit` -> `통과`
- [x] `pnpm -C leesfield-fe build` -> `next build 성공`
- [x] `pnpm -C leesfield-fe vitest run src/server/monitoring/request-detail.test.ts src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx src/features/monitoring-dashboard/ui/monitoring-request-table.test.tsx src/features/generation-history/ui/history-item.audio.test.tsx` -> `4 files, 8 tests passed`

## 스크린샷 / 다이어그램

```mermaid
sequenceDiagram
    participant U as User
    participant UI as /audio UI
    participant API as Audio API
    participant W as Generation Worker
    participant HF as HF Space
    participant DB as Prisma/Storage

    U->>UI: prompt + optional reference audio/text 입력
    UI->>API: audio generation 요청
    API->>DB: pending request 저장
    W->>DB: pending request claim
    W->>HF: /run_generation 호출
    HF-->>W: audio file refs 반환
    W->>DB: 결과 audio 저장 / completed 갱신
    UI->>API: 상태 polling
    API-->>UI: completed + audio result
    UI-->>U: player / history / monitoring 노출
```

## 관련 문서

- Spec: `docs/features/F041-audio-generation-hf-space/spec.md`
- Plan: `docs/features/F041-audio-generation-hf-space/plan.md`
- Tasks: `docs/features/F041-audio-generation-hf-space/tasks.md`
- Decisions: `docs/features/F041-audio-generation-hf-space/decisions.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 오디오 생성 기능 추가: UI(페이지·폼), 클라이언트 API, 서버 엔드포인트, 작업 처리 및 모니터링/히스토리 통합
  * 오디오 모델 카탈로그·런타임·파라미터 및 레퍼런스 오디오 지원
  * 오디오 스토리지 업로드 흐름(Leemage) 및 스토리지 선택/경고 처리

* **문서**
  * README 및 예제 환경설정에 AUDIO_STORAGE_PROVIDER 및 오디오 관련 설정/설명 추가

* **테스트**
  * 오디오 관련 단위·통합 테스트 대규모 추가 (API, 어댑터, UI 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->