### PR TITLE
`feat(#81): audio-download-mime-fix (오디오 저장/다운로드 .bin 회귀 수정)`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-table": "^8.21.3",
     "bcryptjs": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-query':
         specifier: ^5.90.16
         version: 5.90.16(react@19.2.3)
@@ -1228,6 +1231,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -4894,6 +4910,26 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.7)(react@19.2.3)':
     dependencies:

--- a/src/app/api/audio-generation/[requestId]/download/route.test.ts
+++ b/src/app/api/audio-generation/[requestId]/download/route.test.ts
@@ -72,4 +72,60 @@ describe("GET /api/audio-generation/[requestId]/download", () => {
     );
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
   });
+
+  it("upstream body 읽기가 timeout을 넘기면 502를 반환한다", async () => {
+    vi.useFakeTimers();
+    const wavHeader = Uint8Array.from([
+      0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00,
+      0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20,
+    ]);
+
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockGetAudioGenerationByRequestId.mockResolvedValue({
+      audios: [
+        {
+          url: "https://cdn.example.com/generated/request-id-1.wav",
+          durationSec: 1.2,
+        },
+      ],
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_input, init?: RequestInit) => {
+        const signal = init?.signal;
+        return {
+          ok: true,
+          headers: new Headers({
+            "content-type": "application/octet-stream",
+          }),
+          arrayBuffer: () =>
+            new Promise<ArrayBuffer>((resolve, reject) => {
+              const abortError = Object.assign(new Error("aborted"), {
+                name: "AbortError",
+              });
+              signal?.addEventListener("abort", () => reject(abortError), {
+                once: true,
+              });
+              setTimeout(() => resolve(wavHeader.buffer), 20_000);
+            }),
+        } as Response;
+      },
+    );
+
+    const responsePromise = GET(
+      new Request(
+        "http://localhost/api/audio-generation/request-id/download?index=0",
+      ),
+      { params: Promise.resolve({ requestId: "request-id" }) },
+    );
+
+    await vi.advanceTimersByTimeAsync(10_001);
+    const response = await responsePromise;
+    const payload = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(payload.message).toBe("AUDIO_FETCH_TIMEOUT");
+  });
 });

--- a/src/app/api/audio-generation/[requestId]/download/route.test.ts
+++ b/src/app/api/audio-generation/[requestId]/download/route.test.ts
@@ -1,0 +1,75 @@
+import { GET } from "@/app/api/audio-generation/[requestId]/download/route";
+
+const mockGetSession = vi.hoisted(() => vi.fn());
+const mockGetAudioGenerationByRequestId = vi.hoisted(() => vi.fn());
+
+vi.mock("@/server/auth/session", () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock("@/server/audio-generation/audio-generation-repository", () => ({
+  getAudioGenerationByRequestId: mockGetAudioGenerationByRequestId,
+}));
+
+describe("GET /api/audio-generation/[requestId]/download", () => {
+  beforeEach(() => {
+    mockGetSession.mockReset();
+    mockGetAudioGenerationByRequestId.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("로그인하지 않은 경우 401을 반환한다", async () => {
+    mockGetSession.mockResolvedValue({ isLoggedIn: false });
+
+    const response = await GET(
+      new Request("http://localhost/api/audio-generation/request-id/download"),
+      { params: Promise.resolve({ requestId: "request-id" }) },
+    );
+
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.message).toBe("UNAUTHORIZED");
+  });
+
+  it("다운로드 응답에 실제 오디오 확장자와 헤더를 설정한다", async () => {
+    const wavHeader = Uint8Array.from([
+      0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00,
+      0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20,
+    ]);
+
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockGetAudioGenerationByRequestId.mockResolvedValue({
+      audios: [
+        {
+          url: "https://cdn.example.com/generated/request-id-1.wav",
+          durationSec: 1.2,
+        },
+      ],
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(wavHeader, {
+        headers: {
+          "content-type": "application/octet-stream",
+        },
+      }),
+    );
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/audio-generation/request-id/download?index=0",
+      ),
+      { params: Promise.resolve({ requestId: "request-id" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("audio/wav");
+    expect(response.headers.get("Content-Disposition")).toBe(
+      'attachment; filename="request-id-1.wav"',
+    );
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+});

--- a/src/app/api/audio-generation/[requestId]/download/route.ts
+++ b/src/app/api/audio-generation/[requestId]/download/route.ts
@@ -45,16 +45,41 @@ export async function GET(request: Request, { params }: RouteContext) {
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 10_000);
-  let upstreamResponse: Response;
 
   try {
-    upstreamResponse = await fetch(audio.url, {
+    const upstreamResponse = await fetch(audio.url, {
       cache: "no-store",
       signal: controller.signal,
     });
+    if (!upstreamResponse.ok) {
+      return NextResponse.json(
+        { message: "AUDIO_FETCH_FAILED" },
+        { status: 502 },
+      );
+    }
+
+    const buffer = Buffer.from(await upstreamResponse.arrayBuffer());
+    const contentType = resolveAudioMime({
+      contentType: upstreamResponse.headers.get("content-type"),
+      sourceUrl: audio.url,
+      buffer,
+    });
+    const extension = resolveAudioExtension(contentType);
+    const filename = `${requestId}-${index + 1}.${extension}`;
+
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": contentType,
+        "Content-Disposition": `attachment; filename=\"${filename}\"`,
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
   } catch (error) {
-    clearTimeout(timeoutId);
-    if (error instanceof Error && error.name === "AbortError") {
+    if (
+      error instanceof Error &&
+      (error.name === "AbortError" || controller.signal.aborted)
+    ) {
       return NextResponse.json(
         { message: "AUDIO_FETCH_TIMEOUT" },
         { status: 502 },
@@ -67,29 +92,4 @@ export async function GET(request: Request, { params }: RouteContext) {
   } finally {
     clearTimeout(timeoutId);
   }
-
-  if (!upstreamResponse.ok) {
-    return NextResponse.json(
-      { message: "AUDIO_FETCH_FAILED" },
-      { status: 502 },
-    );
-  }
-
-  const buffer = Buffer.from(await upstreamResponse.arrayBuffer());
-  const contentType = resolveAudioMime({
-    contentType: upstreamResponse.headers.get("content-type"),
-    sourceUrl: audio.url,
-    buffer,
-  });
-  const extension = resolveAudioExtension(contentType);
-  const filename = `${requestId}-${index + 1}.${extension}`;
-
-  return new Response(buffer, {
-    headers: {
-      "Content-Type": contentType,
-      "Content-Disposition": `attachment; filename=\"${filename}\"`,
-      "Cache-Control": "no-store",
-      "X-Content-Type-Options": "nosniff",
-    },
-  });
 }

--- a/src/app/api/audio-generation/[requestId]/download/route.ts
+++ b/src/app/api/audio-generation/[requestId]/download/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/server/auth/session";
+import { getAudioGenerationByRequestId } from "@/server/audio-generation/audio-generation-repository";
+import {
+  resolveAudioExtension,
+  resolveAudioMime,
+} from "@/shared/lib/audio-file";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type RouteContext = {
+  params: Promise<{
+    requestId: string;
+  }>;
+};
+
+export async function GET(request: Request, { params }: RouteContext) {
+  const session = await getSession();
+
+  if (!session.isLoggedIn || !session.adminEmail) {
+    return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  const { requestId } = await params;
+  const { searchParams } = new URL(request.url);
+  const indexParam = searchParams.get("index") ?? "0";
+  const index = Number(indexParam);
+
+  if (!Number.isInteger(index) || index < 0) {
+    return NextResponse.json({ message: "INVALID_INDEX" }, { status: 400 });
+  }
+
+  const record = await getAudioGenerationByRequestId(requestId, session.adminEmail);
+
+  if (!record) {
+    return NextResponse.json({ message: "NOT_FOUND" }, { status: 404 });
+  }
+
+  const audio = record.audios[index];
+
+  if (!audio) {
+    return NextResponse.json({ message: "NOT_FOUND" }, { status: 404 });
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+  let upstreamResponse: Response;
+
+  try {
+    upstreamResponse = await fetch(audio.url, {
+      cache: "no-store",
+      signal: controller.signal,
+    });
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === "AbortError") {
+      return NextResponse.json(
+        { message: "AUDIO_FETCH_TIMEOUT" },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json(
+      { message: "AUDIO_FETCH_FAILED" },
+      { status: 502 },
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!upstreamResponse.ok) {
+    return NextResponse.json(
+      { message: "AUDIO_FETCH_FAILED" },
+      { status: 502 },
+    );
+  }
+
+  const buffer = Buffer.from(await upstreamResponse.arrayBuffer());
+  const contentType = resolveAudioMime({
+    contentType: upstreamResponse.headers.get("content-type"),
+    sourceUrl: audio.url,
+    buffer,
+  });
+  const extension = resolveAudioExtension(contentType);
+  const filename = `${requestId}-${index + 1}.${extension}`;
+
+  return new Response(buffer, {
+    headers: {
+      "Content-Type": contentType,
+      "Content-Disposition": `attachment; filename=\"${filename}\"`,
+      "Cache-Control": "no-store",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -213,14 +213,13 @@ describe("AudioGenerationForm", () => {
 
     expect(container.querySelector("audio")).not.toBeNull();
     expect(screen.getByText(/#1/i)).not.toBeNull();
-    expect(
-      container.querySelector('a[href="https://example.com/generated.mp3"]'),
-    ).not.toBeNull();
-    expect(
-      container.querySelector(
-        'a[href="/api/audio-generation/request-id/download?index=0"]',
-      ),
-    ).not.toBeNull();
+    const openLink = container.querySelector('a[title="열기"]');
+    const downloadLink = container.querySelector('a[title="다운로드"]');
+
+    expect(openLink?.getAttribute("href")).toBe("https://example.com/generated.mp3");
+    expect(downloadLink?.getAttribute("href")).toBe(
+      "/api/audio-generation/request-id/download?index=0",
+    );
   });
 
   it("비로그인 상태에서 로그인 게이트를 표시한다", async () => {

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { AudioGenerationForm } from "@/features/audio-generation/ui/audio-generation-form";
@@ -458,9 +458,9 @@ describe("AudioGenerationForm", () => {
     expect(screen.getByText("Top K")).not.toBeNull();
     expect(screen.getByText("Repetition Penalty")).not.toBeNull();
 
-    await user.type(
+    fireEvent.change(
       screen.getByPlaceholderText("생성할 음성 내용을 자연스럽게 입력하세요..."),
-      "hello qwen",
+      { target: { value: "hello qwen" } },
     );
     await user.upload(
       screen.getByLabelText("Reference Audio"),
@@ -468,9 +468,9 @@ describe("AudioGenerationForm", () => {
         type: "audio/wav",
       }),
     );
-    await user.type(
+    fireEvent.change(
       screen.getByPlaceholderText("레퍼런스 오디오의 텍스트를 입력하세요..."),
-      "reference transcript",
+      { target: { value: "reference transcript" } },
     );
     await user.click(screen.getByRole("button", { name: "생성" }));
 
@@ -491,5 +491,5 @@ describe("AudioGenerationForm", () => {
         }),
       );
     });
-  });
+  }, 15_000);
 });

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -222,6 +222,33 @@ describe("AudioGenerationForm", () => {
     );
   });
 
+  it("requestId가 없으면 다운로드 링크를 직접 자산 URL로 노출하지 않는다", async () => {
+    mockUseAudioGeneration.mockReturnValue({
+      state: {
+        status: "completed",
+        progress: 100,
+        result: {
+          audios: [
+            {
+              url: "https://example.com/generated.mp3",
+              durationSec: 7,
+            },
+          ],
+        },
+      },
+      startGeneration: vi.fn(),
+      reset: vi.fn(),
+    });
+
+    const { container } = renderWithIntl(
+      <AudioGenerationForm isAuthenticated />,
+    );
+    await waitForModels();
+
+    expect(container.querySelector('a[title="열기"]')).not.toBeNull();
+    expect(container.querySelector('a[title="다운로드"]')).toBeNull();
+  });
+
   it("비로그인 상태에서 로그인 게이트를 표시한다", async () => {
     mockUseAudioGeneration.mockReturnValue({
       state: { status: "idle", progress: 0 },

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -216,6 +216,11 @@ describe("AudioGenerationForm", () => {
     expect(
       container.querySelector('a[href="https://example.com/generated.mp3"]'),
     ).not.toBeNull();
+    expect(
+      container.querySelector(
+        'a[href="/api/audio-generation/request-id/download?index=0"]',
+      ),
+    ).not.toBeNull();
   });
 
   it("비로그인 상태에서 로그인 게이트를 표시한다", async () => {

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -886,7 +886,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
                 {resultAudios.map((audio, index) => {
                   const downloadUrl = state.requestId
                     ? `/api/audio-generation/${state.requestId}/download?index=${index}`
-                    : audio.url;
+                    : null;
 
                   return (
                   <div
@@ -909,14 +909,16 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
                       >
                         <ExternalLink className="h-4 w-4" />
                       </a>
-                      <a
-                        href={downloadUrl}
-                        download
-                        className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-surface-dark/80 text-gray-200 transition-colors hover:border-primary hover:text-white"
-                        title={tActions("download")}
-                      >
-                        <Download className="h-4 w-4" />
-                      </a>
+                      {downloadUrl ? (
+                        <a
+                          href={downloadUrl}
+                          download
+                          className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-surface-dark/80 text-gray-200 transition-colors hover:border-primary hover:text-white"
+                          title={tActions("download")}
+                        >
+                          <Download className="h-4 w-4" />
+                        </a>
+                      ) : null}
                     </div>
                   </div>
                   );

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -883,7 +883,12 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
 
             {hasResults && resultAudios.length > 0 ? (
               <div className="flex flex-col gap-2">
-                {resultAudios.map((audio, index) => (
+                {resultAudios.map((audio, index) => {
+                  const downloadUrl = state.requestId
+                    ? `/api/audio-generation/${state.requestId}/download?index=${index}`
+                    : audio.url;
+
+                  return (
                   <div
                     key={`${audio.url}-${index}`}
                     className="flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-surface-dark/60 px-3 py-2"
@@ -905,7 +910,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
                         <ExternalLink className="h-4 w-4" />
                       </a>
                       <a
-                        href={audio.url}
+                        href={downloadUrl}
                         download
                         className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-surface-dark/80 text-gray-200 transition-colors hover:border-primary hover:text-white"
                         title={tActions("download")}
@@ -914,7 +919,8 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
                       </a>
                     </div>
                   </div>
-                ))}
+                  );
+                })}
               </div>
             ) : null}
 

--- a/src/features/generation-history/ui/history-item.audio.test.tsx
+++ b/src/features/generation-history/ui/history-item.audio.test.tsx
@@ -7,6 +7,7 @@ import { renderWithIntl } from "@/test-utils/intl";
 const mockPush = vi.hoisted(() => vi.fn());
 const mockToastSuccess = vi.hoisted(() => vi.fn());
 const originalClipboard = window.navigator.clipboard;
+const originalExecCommand = document.execCommand;
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -25,6 +26,15 @@ describe("HistoryItem audio", () => {
   afterEach(() => {
     mockToastSuccess.mockReset();
     vi.restoreAllMocks();
+    if (originalExecCommand) {
+      Object.defineProperty(document, "execCommand", {
+        value: originalExecCommand,
+        configurable: true,
+      });
+    } else {
+      // @ts-expect-error - cleanup optional test stub
+      delete document.execCommand;
+    }
     if (originalClipboard) {
       Object.defineProperty(window.navigator, "clipboard", {
         value: originalClipboard,
@@ -146,5 +156,9 @@ describe("HistoryItem audio", () => {
     expect(execCommandSpy).toHaveBeenCalledWith("copy");
     expect(mockToastSuccess).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "프롬프트 복사" })).toBeTruthy();
+  });
+
+  it("clipboard fallback 테스트가 document.execCommand 오염을 남기지 않는다", () => {
+    expect(document.execCommand).toBe(originalExecCommand);
   });
 });

--- a/src/features/generation-history/ui/history-item.audio.test.tsx
+++ b/src/features/generation-history/ui/history-item.audio.test.tsx
@@ -34,6 +34,11 @@ describe("HistoryItem audio", () => {
     );
 
     expect(document.querySelector("audio")).not.toBeNull();
+    expect(
+      document.querySelector(
+        'a[href="/api/audio-generation/item-audio-1/download?index=0"]',
+      ),
+    ).not.toBeNull();
 
     await user.click(screen.getByRole("button", { name: "프롬프트 재사용" }));
 

--- a/src/features/generation-history/ui/history-item.audio.test.tsx
+++ b/src/features/generation-history/ui/history-item.audio.test.tsx
@@ -1,11 +1,12 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { HistoryItem } from "@/features/generation-history/ui/history-item";
 import { renderWithIntl } from "@/test-utils/intl";
 
 const mockPush = vi.hoisted(() => vi.fn());
 const mockToastSuccess = vi.hoisted(() => vi.fn());
+const originalClipboard = window.navigator.clipboard;
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -21,6 +22,20 @@ vi.mock("sonner", () => ({
 }));
 
 describe("HistoryItem audio", () => {
+  afterEach(() => {
+    mockToastSuccess.mockReset();
+    vi.restoreAllMocks();
+    if (originalClipboard) {
+      Object.defineProperty(window.navigator, "clipboard", {
+        value: originalClipboard,
+        configurable: true,
+      });
+    } else {
+      // @ts-expect-error - cleanup optional test stub
+      delete window.navigator.clipboard;
+    }
+  });
+
   it("audio 항목은 /audio 재사용 경로와 오디오 프리뷰를 사용한다", async () => {
     const user = userEvent.setup();
     renderWithIntl(
@@ -92,5 +107,44 @@ describe("HistoryItem audio", () => {
     expect(mockPush).toHaveBeenCalledWith(
       "/audio?prompt=hello+audio&model=qwen-tts&referenceText=reference+words",
     );
+  });
+
+  it("clipboard fallback이 false를 반환하면 복사 성공 상태를 표시하지 않는다", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window.navigator, "clipboard", {
+      value: {
+        writeText: vi.fn().mockRejectedValue(new Error("clipboard unavailable")),
+      },
+      configurable: true,
+    });
+    const execCommandSpy = vi.fn().mockReturnValue(false);
+    Object.defineProperty(document, "execCommand", {
+      value: execCommandSpy,
+      configurable: true,
+    });
+
+    renderWithIntl(
+      <HistoryItem
+        item={{
+          id: "item-audio-2",
+          type: "audio" as never,
+          status: "completed",
+          prompt: "copy me",
+          model: "qwen-tts",
+          createdAt: "2026-02-03T00:00:00.000Z",
+          resultUrl: "https://example.com/result.mp3",
+          thumbnailUrl: null,
+          inputAudios: [],
+          referenceText: null,
+          errorMessage: null,
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "프롬프트 복사" }));
+
+    expect(execCommandSpy).toHaveBeenCalledWith("copy");
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "프롬프트 복사" })).toBeTruthy();
   });
 });

--- a/src/features/generation-history/ui/history-item.tsx
+++ b/src/features/generation-history/ui/history-item.tsx
@@ -28,6 +28,12 @@ import { Button } from "@/shared/ui/button";
 import { Badge } from "@/shared/ui/badge";
 import { Skeleton } from "@/shared/ui/skeleton";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/shared/ui/tooltip";
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -130,6 +136,7 @@ export function HistoryItem({
       : item.type === "audio" && item.resultUrl
         ? `/api/audio-generation/${item.id}/download?index=0`
       : item.resultUrl;
+  const copyLabel = isCopied ? tCommonActions("copied") : tActions("copyPrompt");
   const dateFormatter = useMemo(
     () =>
       new Intl.DateTimeFormat(locale, {
@@ -297,10 +304,12 @@ export function HistoryItem({
   const handleCopyPrompt = async () => {
     const text = item.prompt.trim();
     if (!text) return;
+    const successMessage = tCommonActions("copied");
 
     try {
       await navigator.clipboard.writeText(text);
       setIsCopied(true);
+      toast.success(successMessage);
       return;
     } catch {
       // fallback below
@@ -316,6 +325,7 @@ export function HistoryItem({
       document.execCommand("copy");
       document.body.removeChild(textarea);
       setIsCopied(true);
+      toast.success(successMessage);
     } catch {
       setIsCopied(false);
     }
@@ -426,72 +436,6 @@ export function HistoryItem({
           </div>
         )}
 
-        {showActions && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-black/60 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-            <Button
-              type="button"
-              className="h-auto rounded-full bg-primary px-6 py-3 text-xs font-bold uppercase tracking-wider text-black shadow-[0_0_20px_rgba(212,240,50,0.3)] transition-all hover:bg-primary-dark hover:shadow-[0_0_28px_rgba(212,240,50,0.45)]"
-              onClick={handleReusePrompt}
-            >
-              <RotateCcw className="h-4 w-4" />
-              {tActions("reusePrompt")}
-            </Button>
-            <Button
-              type="button"
-              onClick={handleCopyPrompt}
-              variant="outline"
-              className="h-auto rounded-full border-white/20 bg-black/40 px-5 py-2 text-[11px] font-bold uppercase tracking-wider text-white hover:border-primary/60 hover:text-primary"
-            >
-              <Copy className="h-4 w-4" />
-              {isCopied ? tCommonActions("copied") : tActions("copyPrompt")}
-            </Button>
-            <div className="flex gap-2">
-              {downloadUrl ? (
-                <a
-                  href={downloadUrl}
-                  download={item.type === "image" ? undefined : true}
-                  className="flex h-9 w-9 items-center justify-center rounded-full border border-white/20 bg-black/50 text-white backdrop-blur-md transition-colors hover:border-white hover:bg-black"
-                  aria-label={tCommonActions("download")}
-                >
-                  <Download className="h-4 w-4" />
-                </a>
-              ) : (
-                <Button
-                  type="button"
-                  disabled
-                  variant="ghost"
-                  size="icon"
-                  className="h-9 w-9 rounded-full border border-white/20 bg-black/50 text-white opacity-50"
-                  aria-label={tCommonActions("download")}
-                >
-                  <Download className="h-4 w-4" />
-                </Button>
-              )}
-              {item.resultUrl ? (
-                <a
-                  href={item.resultUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="flex h-9 w-9 items-center justify-center rounded-full border border-white/20 bg-black/50 text-white backdrop-blur-md transition-colors hover:border-white hover:bg-black"
-                  aria-label={tCommonActions("open")}
-                >
-                  <Maximize2 className="h-4 w-4" />
-                </a>
-              ) : (
-                <Button
-                  type="button"
-                  disabled
-                  variant="ghost"
-                  size="icon"
-                  className="h-9 w-9 rounded-full border border-white/20 bg-black/50 text-white opacity-50"
-                  aria-label={tCommonActions("open")}
-                >
-                  <Maximize2 className="h-4 w-4" />
-                </Button>
-              )}
-            </div>
-          </div>
-        )}
       </div>
 
       <div className="flex flex-col gap-3 border-t border-white/5 bg-surface-dark p-4 transition-colors group-hover:bg-surface-lighter">
@@ -534,7 +478,96 @@ export function HistoryItem({
             ))}
           </div>
         ) : null}
-        <div className="flex items-center justify-between border-t border-white/5 pt-3">
+        {showActions ? (
+          <TooltipProvider>
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/8 bg-white/[0.03] px-3 py-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+              {downloadUrl ? (
+                <Button
+                  asChild
+                  className="h-10 rounded-full bg-primary px-4 text-[11px] font-black uppercase tracking-[0.18em] text-black shadow-[0_10px_24px_rgba(212,240,50,0.18)] transition-all hover:bg-primary-dark hover:shadow-[0_14px_28px_rgba(212,240,50,0.28)]"
+                >
+                  <a
+                    href={downloadUrl}
+                    download={item.type === "image" ? undefined : true}
+                    aria-label={tCommonActions("download")}
+                  >
+                    <Download className="h-4 w-4" />
+                    {tCommonActions("download")}
+                  </a>
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  disabled
+                  className="h-10 rounded-full bg-primary px-4 text-[11px] font-black uppercase tracking-[0.18em] text-black"
+                >
+                  <Download className="h-4 w-4" />
+                  {tCommonActions("download")}
+                </Button>
+              )}
+              <div className="flex items-center gap-1 rounded-full border border-white/10 bg-black/35 p-1.5 backdrop-blur-md">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      onClick={handleReusePrompt}
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 rounded-full text-gray-300 hover:bg-white/10 hover:text-white"
+                      aria-label={tActions("reusePrompt")}
+                    >
+                      <RotateCcw className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{tActions("reusePrompt")}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      onClick={handleCopyPrompt}
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 rounded-full text-gray-300 hover:bg-white/10 hover:text-white"
+                      aria-label={copyLabel}
+                    >
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{copyLabel}</TooltipContent>
+                </Tooltip>
+                {item.resultUrl ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <a
+                        href={item.resultUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex h-8 w-8 items-center justify-center rounded-full text-gray-300 transition-colors hover:bg-white/10 hover:text-white focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none"
+                        aria-label={tCommonActions("open")}
+                      >
+                        <Maximize2 className="h-4 w-4" />
+                      </a>
+                    </TooltipTrigger>
+                    <TooltipContent>{tCommonActions("open")}</TooltipContent>
+                  </Tooltip>
+                ) : (
+                  <Button
+                    type="button"
+                    disabled
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 rounded-full text-gray-300 opacity-40"
+                    aria-label={tCommonActions("open")}
+                  >
+                    <Maximize2 className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </div>
+          </TooltipProvider>
+        ) : null}
+        <div className="flex items-center justify-between border-t border-white/5 pt-4">
           <div className="flex items-center gap-3">
             {item.model ? (
               <Badge variant="primary" className="px-2 py-0.5">
@@ -561,7 +594,7 @@ export function HistoryItem({
                   size="icon-sm"
                   disabled={!canDelete || deleteMutation.isPending}
                   className={cn(
-                    "h-8 w-8 rounded-lg text-gray-500 hover:bg-white/5 hover:text-white",
+                    "h-8 w-8 rounded-full border border-transparent text-gray-500 transition-colors hover:border-white/10 hover:bg-white/5 hover:text-white",
                     canDelete && "hover:text-red-300"
                   )}
                   aria-label={tCommonActions("remove")}

--- a/src/features/generation-history/ui/history-item.tsx
+++ b/src/features/generation-history/ui/history-item.tsx
@@ -127,6 +127,8 @@ export function HistoryItem({
   const downloadUrl =
     item.type === "image" && item.resultUrl
       ? `/api/image-generation/${item.id}/download?index=0`
+      : item.type === "audio" && item.resultUrl
+        ? `/api/audio-generation/${item.id}/download?index=0`
       : item.resultUrl;
   const dateFormatter = useMemo(
     () =>

--- a/src/features/generation-history/ui/history-item.tsx
+++ b/src/features/generation-history/ui/history-item.tsx
@@ -321,11 +321,18 @@ export function HistoryItem({
       textarea.style.position = "fixed";
       textarea.style.opacity = "0";
       document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand("copy");
-      document.body.removeChild(textarea);
-      setIsCopied(true);
-      toast.success(successMessage);
+      try {
+        textarea.select();
+        const copied = document.execCommand("copy");
+        if (!copied) {
+          setIsCopied(false);
+          return;
+        }
+        setIsCopied(true);
+        toast.success(successMessage);
+      } finally {
+        document.body.removeChild(textarea);
+      }
     } catch {
       setIsCopied(false);
     }

--- a/src/features/generation-history/ui/history-item.video.test.tsx
+++ b/src/features/generation-history/ui/history-item.video.test.tsx
@@ -5,7 +5,6 @@ import { HistoryItem } from "@/features/generation-history/ui/history-item";
 import { renderWithIntl } from "@/test-utils/intl";
 
 const mockPush = vi.hoisted(() => vi.fn());
-const mockToastSuccess = vi.hoisted(() => vi.fn());
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -13,40 +12,28 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
-    success: mockToastSuccess,
-    error: vi.fn(),
-  },
-}));
-
-describe("HistoryItem audio", () => {
-  it("audio 항목은 /audio 재사용 경로와 오디오 프리뷰를 사용한다", async () => {
+describe("HistoryItem video", () => {
+  it("video 항목은 플레이어 위 전체 오버레이 없이 /video 재사용 경로를 사용한다", async () => {
     const user = userEvent.setup();
+
     renderWithIntl(
       <HistoryItem
         item={{
-          id: "item-audio-1",
-          type: "audio" as never,
+          id: "item-video-1",
+          type: "video" as never,
           status: "completed",
-          prompt: "hello audio",
-          model: "qwen-tts",
+          prompt: "hello video",
+          model: "wan-video",
           createdAt: "2026-02-03T00:00:00.000Z",
-          resultUrl: "https://example.com/result.mp3",
+          resultUrl: "https://example.com/result.mp4",
           thumbnailUrl: null,
-          inputAudios: ["data:audio/wav;base64,UklGRg=="],
-          referenceText: "reference words",
+          inputImages: ["https://example.com/init.png"],
           errorMessage: null,
         }}
       />,
     );
 
-    expect(document.querySelector("audio")).not.toBeNull();
-    expect(
-      document.querySelector(
-        'a[href="/api/audio-generation/item-audio-1/download?index=0"]',
-      ),
-    ).not.toBeNull();
+    expect(document.querySelector("video")).not.toBeNull();
     const reuseButton = screen.getByRole("button", { name: "프롬프트 재사용" });
     const downloadLink = screen.getByRole("link", { name: "다운로드" });
     const copyButton = screen.getByRole("button", { name: "프롬프트 복사" });
@@ -76,9 +63,6 @@ describe("HistoryItem audio", () => {
       ),
     ).toBe(true);
 
-    await user.click(copyButton);
-    expect(mockToastSuccess).toHaveBeenCalledWith("복사됨");
-
     await user.tab();
     expect(openLink).toHaveFocus();
     expect(
@@ -90,7 +74,7 @@ describe("HistoryItem audio", () => {
     await user.click(reuseButton);
 
     expect(mockPush).toHaveBeenCalledWith(
-      "/audio?prompt=hello+audio&model=qwen-tts&referenceText=reference+words",
+      "/video?prompt=hello+video&model=wan-video&initImage=https%3A%2F%2Fexample.com%2Finit.png",
     );
   });
 });

--- a/src/features/monitoring-dashboard/ui/monitoring-request-table.test.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-table.test.tsx
@@ -114,12 +114,12 @@ describe("MonitoringRequestTable", () => {
     expect(onOffsetChange).toHaveBeenCalledWith(100);
 
     await user.click(screen.getByRole("combobox"));
-    await user.keyboard("{End}{Enter}");
+    await user.click(await screen.findByRole("option", { name: "100" }));
 
     await waitFor(() => {
       expect(onLimitChange).toHaveBeenCalledWith(100);
     });
-  }, 10_000);
+  }, 20_000);
 
   it("행 선택 시 상세 모달을 연다", async () => {
     const user = userEvent.setup();

--- a/src/screens/model-management/ui/model-management-screen.test.tsx
+++ b/src/screens/model-management/ui/model-management-screen.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -262,9 +262,14 @@ describe("ModelManagementScreen", () => {
     await screen.findAllByText(audioModel!.label);
 
     await user.click(screen.getByRole("button", { name: "모델 추가" }));
-    await user.type(
+    fireEvent.change(
       screen.getByPlaceholderText("https://huggingface.co/spaces/owner/space"),
-      "https://huggingface.co/spaces/leey00nsu/qwen-3.5-tts-faster-gradio",
+      {
+        target: {
+          value:
+            "https://huggingface.co/spaces/leey00nsu/qwen-3.5-tts-faster-gradio",
+        },
+      },
     );
     await user.click(screen.getByRole("button", { name: "가져오기" }));
 
@@ -274,5 +279,5 @@ describe("ModelManagementScreen", () => {
       expect(screen.getByDisplayValue(/referenceText/)).toBeTruthy();
       expect(screen.getByDisplayValue(/inputAudio/)).toBeTruthy();
     });
-  });
+  }, 15_000);
 });

--- a/src/server/audio-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.test.ts
@@ -488,7 +488,7 @@ describe("hfSpaceAudioAdapter", () => {
       expect.objectContaining({}),
     );
     expect(result).toEqual({
-      audios: ["data:application/octet-stream;base64,UklGRg=="],
+      audios: ["data:audio/wav;base64,UklGRg=="],
       meta: { duration_sec: undefined },
     });
   });

--- a/src/server/audio-generation/adapters/hf-space-adapter.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.ts
@@ -13,6 +13,7 @@ import {
   resolveRuntimeAudioDefaults,
   type RuntimeAudioModel,
 } from "@/shared/model-catalog/runtime-utils";
+import { resolveAudioMime } from "@/shared/lib/audio-file";
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 const STATUS_CHECK_TTL_MS = 30_000;
@@ -524,7 +525,11 @@ async function fetchAudioDataUrl(
       throw new Error("HF_SPACE_AUDIO_FETCH_FAILED");
     }
     const buffer = Buffer.from(await response.arrayBuffer());
-    const contentType = response.headers.get("content-type") ?? "audio/mpeg";
+    const contentType = resolveAudioMime({
+      contentType: response.headers.get("content-type"),
+      sourceUrl: normalized,
+      buffer,
+    });
     return `data:${contentType};base64,${buffer.toString("base64")}`;
   } catch (error) {
     if (controller.signal.aborted) {

--- a/src/server/audio-generation/storage/adapters/leemage-storage-adapter.test.ts
+++ b/src/server/audio-generation/storage/adapters/leemage-storage-adapter.test.ts
@@ -1,0 +1,63 @@
+import { audioGenerationDefaults } from "@/features/audio-generation/model/audio-generation-schema";
+
+const baseEnv = {
+  LEEMAGE_API_KEY: process.env.LEEMAGE_API_KEY,
+  LEEMAGE_PROJECT_ID: process.env.LEEMAGE_PROJECT_ID,
+  LEEMAGE_BASE_URL: process.env.LEEMAGE_BASE_URL,
+};
+
+function createWavDataUrl(contentType = "application/octet-stream") {
+  const wavHeader = Buffer.from([
+    0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00,
+    0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20,
+  ]);
+  return `data:${contentType};base64,${wavHeader.toString("base64")}`;
+}
+
+describe("leemageAudioStorageAdapter", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unmock("leemage-sdk");
+    Object.assign(process.env, baseEnv);
+  });
+
+  it("octet-stream data URL도 실제 오디오 확장자로 업로드한다", async () => {
+    const mockUpload = vi.fn().mockResolvedValue({
+      url: "https://cdn.example.com/request-id-1.wav",
+    });
+
+    vi.resetModules();
+    vi.doMock("leemage-sdk", () => ({
+      LeemageClient: class {
+        files = { upload: mockUpload };
+      },
+    }));
+
+    Object.assign(process.env, {
+      LEEMAGE_API_KEY: "test-key",
+      LEEMAGE_PROJECT_ID: "project-id",
+    });
+
+    const { leemageAudioStorageAdapter } = await import(
+      "@/server/audio-generation/storage/adapters/leemage-storage-adapter"
+    );
+
+    await leemageAudioStorageAdapter.uploadAudios(
+      {
+        ...audioGenerationDefaults,
+        prompt: "hello",
+        model: "qwen-tts",
+      },
+      "request-id",
+      [createWavDataUrl()],
+      { duration_sec: 1.5 },
+    );
+
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+    expect(mockUpload.mock.calls[0]?.[1]).toMatchObject({
+      name: "request-id-1.wav",
+      type: "audio/wav",
+    });
+  });
+});

--- a/src/server/audio-generation/storage/adapters/leemage-storage-adapter.ts
+++ b/src/server/audio-generation/storage/adapters/leemage-storage-adapter.ts
@@ -7,6 +7,10 @@ import type {
   AudioStorageMeta,
   AudioStorageResult,
 } from "@/server/audio-generation/storage/storage-adapter";
+import {
+  resolveAudioExtension,
+  resolveAudioMime,
+} from "@/shared/lib/audio-file";
 
 const MISSING_LEEMAGE_MESSAGE =
   "Leemage 저장소 설정이 없어 결과가 히스토리에 저장되지 않습니다.";
@@ -98,17 +102,6 @@ function parseDataUrl(dataUrl: string) {
   return { contentType, buffer };
 }
 
-function resolveAudioExtension(contentType: string) {
-  if (contentType === "audio/mpeg") return "mp3";
-  if (contentType === "audio/wav" || contentType === "audio/x-wav") return "wav";
-  if (contentType === "audio/flac") return "flac";
-  if (contentType === "audio/ogg") return "ogg";
-  if (contentType === "audio/aac") return "aac";
-  if (contentType === "audio/mp4") return "m4a";
-  if (contentType === "audio/webm") return "webm";
-  return "bin";
-}
-
 function resolveDurationSec(
   payload: AudioGenerationFormValues,
   meta?: AudioStorageMeta,
@@ -155,9 +148,10 @@ async function uploadGeneratedAudios(
     const uploads = await Promise.all(
       dataUrls.map((dataUrl, index) => {
         const { contentType, buffer } = parseDataUrl(dataUrl);
-        const extension = resolveAudioExtension(contentType);
+        const resolvedContentType = resolveAudioMime({ contentType, buffer });
+        const extension = resolveAudioExtension(resolvedContentType);
         const name = `${requestId}-${index + 1}.${extension}`;
-        const file = buildUploadFile(buffer, name, contentType);
+        const file = buildUploadFile(buffer, name, resolvedContentType);
         return client.files.upload(projectId, file);
       }),
     );

--- a/src/shared/lib/audio-file.test.ts
+++ b/src/shared/lib/audio-file.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAudioExtension,
+  resolveAudioMime,
+} from "@/shared/lib/audio-file";
+
+describe("audio-file", () => {
+  it("octet-stream과 WAV 시그니처가 함께 오면 audio/wav로 정규화한다", () => {
+    const mime = resolveAudioMime({
+      contentType: "application/octet-stream",
+      sourceUrl:
+        "https://example.com/gradio_api/file=/tmp/generated/audio.wav",
+      buffer: Buffer.from([82, 73, 70, 70, 0, 0, 0, 0, 87, 65, 86, 69]),
+    });
+
+    expect(mime).toBe("audio/wav");
+    expect(resolveAudioExtension(mime)).toBe("wav");
+  });
+
+  it("명시적 audio MIME은 그대로 유지한다", () => {
+    expect(
+      resolveAudioMime({
+        contentType: "audio/mpeg",
+        sourceUrl: "https://example.com/result.mp3",
+        buffer: Buffer.from([73, 68, 51]),
+      }),
+    ).toBe("audio/mpeg");
+  });
+});

--- a/src/shared/lib/audio-file.ts
+++ b/src/shared/lib/audio-file.ts
@@ -1,0 +1,131 @@
+const AUDIO_MIME_TO_EXTENSION = {
+  "audio/aac": "aac",
+  "audio/flac": "flac",
+  "audio/mpeg": "mp3",
+  "audio/mp4": "m4a",
+  "audio/ogg": "ogg",
+  "audio/wav": "wav",
+  "audio/webm": "webm",
+} as const;
+
+const EXTENSION_TO_AUDIO_MIME: Record<string, keyof typeof AUDIO_MIME_TO_EXTENSION> = {
+  aac: "audio/aac",
+  flac: "audio/flac",
+  m4a: "audio/mp4",
+  mp3: "audio/mpeg",
+  oga: "audio/ogg",
+  ogg: "audio/ogg",
+  wav: "audio/wav",
+  wave: "audio/wav",
+  weba: "audio/webm",
+  webm: "audio/webm",
+};
+
+function canonicalizeAudioMime(contentType?: string | null) {
+  const normalized = contentType?.split(";")[0]?.trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "audio/x-wav") return "audio/wav";
+  if (normalized in AUDIO_MIME_TO_EXTENSION) {
+    return normalized as keyof typeof AUDIO_MIME_TO_EXTENSION;
+  }
+  return null;
+}
+
+function resolveMimeFromPath(source?: string | null) {
+  if (!source) return null;
+  const normalized = source.trim();
+  if (!normalized) return null;
+
+  const [withoutHash] = normalized.split("#");
+  const [withoutQuery] = withoutHash.split("?");
+  const leaf = withoutQuery.split("/").pop() ?? withoutQuery;
+  const fileLike = leaf.includes("=") ? leaf.split("=").pop() ?? leaf : leaf;
+  const extension = fileLike.includes(".")
+    ? fileLike.split(".").pop()?.toLowerCase()
+    : undefined;
+
+  if (!extension) return null;
+  return EXTENSION_TO_AUDIO_MIME[extension] ?? null;
+}
+
+function resolveMimeFromBuffer(buffer?: Uint8Array | Buffer | null) {
+  if (!buffer || buffer.length < 4) return null;
+
+  if (
+    buffer.length >= 12 &&
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x41 &&
+    buffer[10] === 0x56 &&
+    buffer[11] === 0x45
+  ) {
+    return "audio/wav";
+  }
+
+  if (buffer[0] === 0x66 && buffer[1] === 0x4c && buffer[2] === 0x61 && buffer[3] === 0x43) {
+    return "audio/flac";
+  }
+
+  if (buffer[0] === 0x4f && buffer[1] === 0x67 && buffer[2] === 0x67 && buffer[3] === 0x53) {
+    return "audio/ogg";
+  }
+
+  if (buffer[0] === 0x49 && buffer[1] === 0x44 && buffer[2] === 0x33) {
+    return "audio/mpeg";
+  }
+
+  if (buffer[0] === 0xff && buffer.length >= 2) {
+    const secondByte = buffer[1];
+    if (secondByte === 0xf1 || secondByte === 0xf9) {
+      return "audio/aac";
+    }
+    if ((secondByte & 0xe0) === 0xe0) {
+      return "audio/mpeg";
+    }
+  }
+
+  if (buffer[0] === 0x1a && buffer[1] === 0x45 && buffer[2] === 0xdf && buffer[3] === 0xa3) {
+    return "audio/webm";
+  }
+
+  if (
+    buffer.length >= 12 &&
+    buffer[4] === 0x66 &&
+    buffer[5] === 0x74 &&
+    buffer[6] === 0x79 &&
+    buffer[7] === 0x70
+  ) {
+    return "audio/mp4";
+  }
+
+  return null;
+}
+
+export function resolveAudioMime({
+  contentType,
+  sourceUrl,
+  fileName,
+  buffer,
+}: {
+  contentType?: string | null;
+  sourceUrl?: string | null;
+  fileName?: string | null;
+  buffer?: Uint8Array | Buffer | null;
+}) {
+  return (
+    canonicalizeAudioMime(contentType) ??
+    resolveMimeFromPath(fileName) ??
+    resolveMimeFromPath(sourceUrl) ??
+    resolveMimeFromBuffer(buffer) ??
+    "application/octet-stream"
+  );
+}
+
+export function resolveAudioExtension(contentType?: string | null) {
+  const canonicalMime = canonicalizeAudioMime(contentType);
+  if (!canonicalMime) return "bin";
+  return AUDIO_MIME_TO_EXTENSION[canonicalMime];
+}

--- a/src/shared/ui/tooltip.tsx
+++ b/src/shared/ui/tooltip.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { cn } from "@/shared/lib/utils";
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 8, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      data-slot="tooltip-content"
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-full border border-white/10 bg-black/95 px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-white shadow-lg",
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };


### PR DESCRIPTION
# PR Draft: audio-download-mime-fix

## 개요

- 변경 목적:
  - HF Space 오디오 응답이 `application/octet-stream`으로 내려와도 저장 단계에서 실제 포맷으로 MIME/확장자를 정규화하고, 다운로드 경로를 통일해 `.bin` 저장 회귀를 없앤다.
- 사용자 영향:
  - `/audio`와 History에서 받은 오디오가 `.wav`, `.mp3` 등 실제 확장자로 저장된다.
  - History 카드에서 오디오/비디오 플레이어가 액션 레이어에 가로막히지 않고, 다운로드/재사용/복사/열기 액션이 분리된 구조로 동작한다.

## 변경 사항

- [x] `src/shared/lib/audio-file.ts`를 추가해 헤더, URL/path, 파일 시그니처를 기반으로 canonical audio MIME/확장자를 추론하도록 정리했다.
- [x] HF Space adapter와 Leemage storage adapter를 수정해 `application/octet-stream` 응답도 정규화된 오디오 MIME 기준으로 저장 파일명을 결정하도록 바꿨다.
- [x] `GET /api/audio-generation/[requestId]/download` route를 추가하고 `/audio` 화면 및 History audio 다운로드가 공통 route를 사용하도록 맞췄다.
- [x] History 카드 액션 UI를 미디어 영역과 분리해 플레이어 클릭 차단을 제거하고, `다운로드` CTA + utility group(`재사용/복사/열기`) 구조로 재배치했다.
- [x] shadcn/Radix tooltip wrapper를 추가하고, 프롬프트 복사 성공 시 toast를 띄우도록 정리했으며 fallback copy 성공 판정도 보수적으로 수정했다.

## 테스트

- [x] `pnpm test src/shared/lib/audio-file.test.ts src/server/audio-generation/adapters/hf-space-adapter.test.ts src/server/audio-generation/storage/adapters/leemage-storage-adapter.test.ts src/server/audio-generation/audio-generation.test.ts 'src/app/api/audio-generation/[requestId]/download/route.test.ts' src/features/audio-generation/ui/audio-generation-form.test.tsx src/features/generation-history/ui/history-item.audio.test.tsx` → `PASS (7 files, 22 tests)`
- [x] `pnpm test src/features/generation-history/ui/history-item.audio.test.tsx src/features/generation-history/ui/history-item.video.test.tsx` → `PASS (2 files, 2 tests)`
- [x] `pnpm test src/features/generation-history/ui/history-item.test.tsx src/features/generation-history/ui/history-item.audio.test.tsx src/features/generation-history/ui/history-item.video.test.tsx src/features/generation-history/ui/history-list.test.tsx` → `PASS (4 files, 8 tests)`
- [x] `pnpm test src/features/generation-history/ui/history-item.audio.test.tsx src/features/audio-generation/ui/audio-generation-form.test.tsx` → `PASS (2 files, 9 tests)`

## 아키텍처 다이어그램

```mermaid
sequenceDiagram
    participant User
    participant UI as /audio or History UI
    participant DownloadAPI as Audio Download API
    participant Storage as Stored Asset

    User->>UI: download / play / reuse action
    UI->>DownloadAPI: /api/audio-generation/{requestId}/download?index=n
    DownloadAPI->>Storage: fetch stored audio
    Storage-->>DownloadAPI: file + headers
    DownloadAPI->>DownloadAPI: infer canonical MIME / extension
    DownloadAPI-->>UI: attachment filename + normalized content-type
    UI-->>User: correct extension download
```

## 관련 문서

- Spec: `docs/features/F042-audio-download-mime-fix/spec.md`
- Plan: `docs/features/F042-audio-download-mime-fix/plan.md`
- Tasks: `docs/features/F042-audio-download-mime-fix/tasks.md`
- Decisions: `docs/features/F042-audio-download-mime-fix/decisions.md`

Closes #81


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 생성된 오디오 파일을 직접 다운로드할 수 있는 엔드포인트 추가
  * 히스토리 항목에서 툴팁 기반의 작업 메뉴(다운로드, 열기, 재사용, 복사) 제공

* **개선 사항**
  * 오디오 MIME/확장자 판별 개선으로 파일 처리 정확도 향상
  * 복사 동작에 대한 피드백(성공 토스트) 및 클립보드 폴백 처리 향상
  * 접근성 및 키보드 포커스 순서 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->