### PR TITLE
feat(#83): history-responsive-audio-detail-fixes (header/history 반응형 및 상세 정보 정합성 수정)

### DIFF
--- a/src/features/generation-history/ui/history-item.test.tsx
+++ b/src/features/generation-history/ui/history-item.test.tsx
@@ -7,14 +7,26 @@ import {
 } from "@/features/generation-history/ui/history-item";
 import { renderWithIntl } from "@/test-utils/intl";
 
+const mockUseMonitoringRequestDetail = vi.fn();
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: vi.fn(),
   }),
 }));
 
+vi.mock("@/features/monitoring-dashboard/hook/use-monitoring-dashboard", () => ({
+  useMonitoringRequestDetail: (...args: unknown[]) => mockUseMonitoringRequestDetail(...args),
+}));
+
 describe("HistoryItem", () => {
   it("이미지 로딩 전에는 스켈레톤을 표시하고, 로딩 완료 후에는 이미지를 표시한다", async () => {
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+
     renderWithIntl(
       <HistoryItem
         item={{
@@ -44,6 +56,12 @@ describe("HistoryItem", () => {
   });
 
   it("이미지 로딩 실패 시 fallback UI를 표시한다", async () => {
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+
     renderWithIntl(
       <HistoryItem
         item={{
@@ -79,6 +97,11 @@ describe("HistoryItem", () => {
     const longPrompt = Array.from({ length: 200 })
       .map(() => "a")
       .join("");
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
 
     renderWithIntl(
       <HistoryItem
@@ -105,6 +128,11 @@ describe("HistoryItem", () => {
   it("프롬프트가 짧아도 더보기 버튼으로 모달을 열 수 있다", async () => {
     const user = userEvent.setup();
     const prompt = "short prompt";
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
 
     renderWithIntl(
       <HistoryItem
@@ -129,6 +157,12 @@ describe("HistoryItem", () => {
   });
 
   it("HistoryItemSkeleton 핵심 placeholder 구조를 렌더링한다", () => {
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+
     const { container } = renderWithIntl(<HistoryItemSkeleton />);
 
     const root = screen.getByTestId("history-item-skeleton");
@@ -156,5 +190,60 @@ describe("HistoryItem", () => {
     expect(within(actions).getByTestId("history-item-skeleton-action-2")).toBeInTheDocument();
 
     expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(13);
+  });
+
+  it("더보기 모달에서 fetched detail의 duration/progress/asset duration을 표시한다", async () => {
+    const user = userEvent.setup();
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: {
+        id: "video-1",
+        type: "video",
+        status: "processing",
+        model: "wan-2.2",
+        prompt: "server prompt",
+        createdAt: "2026-02-03T00:00:00.000Z",
+        updatedAt: "2026-02-03T00:00:03.000Z",
+        durationMs: 2500,
+        progress: 75,
+        errorMessage: null,
+        warningMessage: null,
+        inputImages: [],
+        inputAudios: [],
+        referenceText: null,
+        assets: [
+          {
+            url: "https://example.com/video.mp4",
+            width: 1280,
+            height: 720,
+            durationSec: 4,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithIntl(
+      <HistoryItem
+        item={{
+          id: "video-1",
+          type: "video",
+          status: "processing",
+          prompt: "seed prompt",
+          model: "wan-2.2",
+          createdAt: "2026-02-03T00:00:00.000Z",
+          resultUrl: "https://example.com/video.mp4",
+          thumbnailUrl: null,
+          errorMessage: null,
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "더보기" }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("2.5s")).toBeInTheDocument();
+    expect(within(dialog).getByText("75%")).toBeInTheDocument();
+    expect(within(dialog).getByText("4s")).toBeInTheDocument();
   });
 });

--- a/src/features/generation-history/ui/history-item.test.tsx
+++ b/src/features/generation-history/ui/history-item.test.tsx
@@ -20,6 +20,34 @@ vi.mock("@/features/monitoring-dashboard/hook/use-monitoring-dashboard", () => (
 }));
 
 describe("HistoryItem", () => {
+  it("비디오 히스토리 카드는 바로 재생 가능한 컨트롤을 노출한다", () => {
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithIntl(
+      <HistoryItem
+        item={{
+          id: "video-preview-1",
+          type: "video",
+          status: "completed",
+          prompt: "video prompt",
+          model: null,
+          createdAt: "2026-02-03T00:00:00.000Z",
+          resultUrl: "https://example.com/video.mp4",
+          thumbnailUrl: null,
+          errorMessage: null,
+        }}
+      />,
+    );
+
+    const video = document.querySelector("video");
+    expect(video).toBeTruthy();
+    expect(video).toHaveAttribute("controls");
+  });
+
   it("이미지 로딩 전에는 스켈레톤을 표시하고, 로딩 완료 후에는 이미지를 표시한다", async () => {
     mockUseMonitoringRequestDetail.mockReturnValue({
       data: null,

--- a/src/features/generation-history/ui/history-item.tsx
+++ b/src/features/generation-history/ui/history-item.tsx
@@ -352,6 +352,7 @@ export function HistoryItem({
             <video
               src={previewUrl}
               className="h-full w-full object-contain"
+              controls
               muted
               loop
               playsInline

--- a/src/features/generation-history/ui/history-list.test.tsx
+++ b/src/features/generation-history/ui/history-list.test.tsx
@@ -1,9 +1,69 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { HistoryList } from "@/features/generation-history/ui/history-list";
 import { renderWithIntl } from "@/test-utils/intl";
 
+const originalMatchMedia = window.matchMedia;
+
+function mockMatchMedia({
+  isMdUp,
+  isXlUp,
+}: {
+  isMdUp: boolean;
+  isXlUp: boolean;
+}) {
+  window.matchMedia = vi.fn((query: string) => {
+    const matches =
+      query === "(min-width: 1280px)"
+        ? isXlUp
+        : query === "(min-width: 768px)"
+          ? isMdUp
+          : false;
+
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+  }) as typeof window.matchMedia;
+}
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+  vi.restoreAllMocks();
+});
+
 describe("HistoryList", () => {
-  it("uses grid layout for loading skeletons", () => {
+  it.each([
+    {
+      name: "small viewport",
+      media: { isMdUp: false, isXlUp: false },
+      expectedColumns: 2,
+      expectedItemsPerColumn: [5, 4],
+    },
+    {
+      name: "medium viewport",
+      media: { isMdUp: true, isXlUp: false },
+      expectedColumns: 3,
+      expectedItemsPerColumn: [3, 3, 3],
+    },
+    {
+      name: "xl viewport",
+      media: { isMdUp: true, isXlUp: true },
+      expectedColumns: 4,
+      expectedItemsPerColumn: [3, 2, 2, 2],
+    },
+  ])("uses responsive skeleton columns for $name", ({
+    media,
+    expectedColumns,
+    expectedItemsPerColumn,
+  }) => {
+    mockMatchMedia(media);
+
     const { container } = renderWithIntl(<HistoryList items={[]} isLoading />);
 
     const wrapper = container.firstElementChild;
@@ -14,23 +74,11 @@ describe("HistoryList", () => {
     expect(wrapper).toHaveClass("xl:grid-cols-4");
     expect(wrapper).not.toHaveClass("columns-1");
 
-    expect(wrapper?.children.length).toBe(4);
+    expect(wrapper?.children.length).toBe(expectedColumns);
     Array.from(wrapper?.children ?? []).forEach((column, index) => {
-      if (index < 2) {
-        expect(column).toHaveClass("grid");
-        expect(column.children.length).toBe(index === 0 ? 3 : 2);
-        return;
-      }
-      if (index === 2) {
-        expect(column).toHaveClass("hidden");
-        expect(column).toHaveClass("md:grid");
-        expect(column).not.toHaveClass("xl:hidden");
-        expect(column.children.length).toBe(2);
-        return;
-      }
-      expect(column).toHaveClass("hidden");
-      expect(column).toHaveClass("xl:grid");
-      expect(column.children.length).toBe(2);
+      expect(column).toHaveClass("grid");
+      expect(column).not.toHaveClass("hidden");
+      expect(column.children.length).toBe(expectedItemsPerColumn[index]);
     });
   });
 });

--- a/src/features/generation-history/ui/history-list.test.tsx
+++ b/src/features/generation-history/ui/history-list.test.tsx
@@ -2,6 +2,20 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { HistoryList } from "@/features/generation-history/ui/history-list";
 import { renderWithIntl } from "@/test-utils/intl";
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock("@/features/monitoring-dashboard/hook/use-monitoring-dashboard", () => ({
+  useMonitoringRequestDetail: () => ({
+    data: null,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
 const originalMatchMedia = window.matchMedia;
 
 function mockMatchMedia({
@@ -38,6 +52,30 @@ afterEach(() => {
 });
 
 describe("HistoryList", () => {
+  it("keeps history columns top-aligned so video cards do not leave empty gaps", () => {
+    mockMatchMedia({ isMdUp: true, isXlUp: false });
+
+    const items = Array.from({ length: 3 }, (_, index) => ({
+      id: `item-${index + 1}`,
+      type: "video" as const,
+      status: "completed" as const,
+      prompt: `prompt-${index + 1}`,
+      model: null,
+      createdAt: "2026-02-03T00:00:00.000Z",
+      resultUrl: "https://example.com/video.mp4",
+      thumbnailUrl: null,
+      errorMessage: null,
+    }));
+
+    const { container } = renderWithIntl(<HistoryList items={items} />);
+    const wrapper = container.firstElementChild;
+
+    Array.from(wrapper?.children ?? []).forEach((column) => {
+      expect(column).toHaveClass("self-start");
+      expect(column).toHaveClass("content-start");
+    });
+  });
+
   it.each([
     {
       name: "small viewport",

--- a/src/features/generation-history/ui/history-list.tsx
+++ b/src/features/generation-history/ui/history-list.tsx
@@ -77,7 +77,7 @@ export function HistoryList({
         {skeletonColumns.map((column, columnIndex) => (
           <div
             key={`history-skeleton-column-${columnIndex}`}
-            className="grid gap-4"
+            className="grid self-start content-start gap-4"
           >
             {column.map((index) => (
               <HistoryItemSkeleton key={`history-skeleton-${index}`} />
@@ -109,7 +109,7 @@ export function HistoryList({
       {itemColumns.map((column, columnIndex) => (
         <div
           key={`history-column-${columnIndex}`}
-          className="grid gap-4"
+          className="grid self-start content-start gap-4"
         >
           {column.map((item) => (
             <HistoryItem

--- a/src/features/generation-history/ui/history-list.tsx
+++ b/src/features/generation-history/ui/history-list.tsx
@@ -3,7 +3,6 @@ import { useTranslations } from "next-intl";
 import { useMemo, useSyncExternalStore } from "react";
 import type { GenerationHistoryItem } from "@/entities/generation/model/types";
 import { HistoryItem, HistoryItemSkeleton } from "@/features/generation-history/ui/history-item";
-import { cn } from "@/shared/lib/utils";
 
 type HistoryListProps = {
   items: GenerationHistoryItem[];
@@ -53,14 +52,14 @@ export function HistoryList({
   const columnCount = isXlUp ? 4 : isMdUp ? 3 : 2;
 
   const skeletonColumns = useMemo(() => {
-    const columns = Array.from({ length: 4 }, () => [] as number[]);
+    const columns = Array.from({ length: columnCount }, () => [] as number[]);
 
     Array.from({ length: 9 }).forEach((_, index) => {
-      columns[index % 4].push(index);
+      columns[index % columnCount].push(index);
     });
 
     return columns;
-  }, []);
+  }, [columnCount]);
 
   const itemColumns = useMemo(() => {
     const columns = Array.from({ length: columnCount }, () => [] as GenerationHistoryItem[]);
@@ -78,11 +77,7 @@ export function HistoryList({
         {skeletonColumns.map((column, columnIndex) => (
           <div
             key={`history-skeleton-column-${columnIndex}`}
-            className={cn(
-              "grid gap-4",
-              columnIndex === 2 && "hidden md:grid",
-              columnIndex === 3 && "hidden xl:grid",
-            )}
+            className="grid gap-4"
           >
             {column.map((index) => (
               <HistoryItemSkeleton key={`history-skeleton-${index}`} />
@@ -114,10 +109,7 @@ export function HistoryList({
       {itemColumns.map((column, columnIndex) => (
         <div
           key={`history-column-${columnIndex}`}
-          className={cn(
-            "grid gap-4",
-            columnIndex === 3 && "hidden xl:grid",
-          )}
+          className="grid gap-4"
         >
           {column.map((item) => (
             <HistoryItem

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
@@ -15,6 +15,62 @@ describe("MonitoringRequestDetailDialog", () => {
     mockUseMonitoringRequestDetail.mockReset();
   });
 
+  it("seed와 fetched가 모두 없으면 loading 상태를 그대로 노출한다", () => {
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+
+    renderWithIntl(
+      <MonitoringRequestDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        request={{
+          id: "req-1",
+          type: "video" as never,
+          status: "processing",
+          model: "wan-2.2",
+          createdAt: "2026-01-10T10:00:00.000Z",
+          durationMs: null,
+          apiKeyLabel: "UI",
+        }}
+        timeZone="UTC"
+      />,
+    );
+
+    expect(screen.getByTestId("monitoring-detail-loading")).toBeInTheDocument();
+    expect(screen.queryByText("요청 상세를 불러오지 못했습니다.")).not.toBeInTheDocument();
+  });
+
+  it("seed와 fetched가 모두 없으면 fetch error를 그대로 노출한다", () => {
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error("boom"),
+    });
+
+    renderWithIntl(
+      <MonitoringRequestDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        request={{
+          id: "req-2",
+          type: "video" as never,
+          status: "failed",
+          model: "wan-2.2",
+          createdAt: "2026-01-10T10:00:00.000Z",
+          durationMs: null,
+          apiKeyLabel: "UI",
+        }}
+        timeZone="UTC"
+      />,
+    );
+
+    expect(screen.getByText("요청 상세를 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(screen.queryByTestId("monitoring-detail-loading")).not.toBeInTheDocument();
+  });
+
   it("partial seed가 있어도 상세 조회로 duration/progress/asset duration을 보강한다", () => {
     mockUseMonitoringRequestDetail.mockReturnValue({
       data: {

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx
@@ -1,19 +1,104 @@
 import "@testing-library/jest-dom/vitest";
 import { screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MonitoringRequestDetailDialog } from "@/features/monitoring-dashboard/ui/monitoring-request-detail-dialog";
 import { renderWithIntl } from "@/test-utils/intl";
 
+const mockUseMonitoringRequestDetail = vi.fn();
+
 vi.mock("@/features/monitoring-dashboard/hook/use-monitoring-dashboard", () => ({
-  useMonitoringRequestDetail: () => ({
-    data: null,
-    isLoading: false,
-    error: null,
-  }),
+  useMonitoringRequestDetail: (...args: unknown[]) => mockUseMonitoringRequestDetail(...args),
 }));
 
 describe("MonitoringRequestDetailDialog", () => {
+  beforeEach(() => {
+    mockUseMonitoringRequestDetail.mockReset();
+  });
+
+  it("partial seed가 있어도 상세 조회로 duration/progress/asset duration을 보강한다", () => {
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: {
+        id: "vid-1",
+        type: "video",
+        status: "processing",
+        model: "wan-2.2",
+        prompt: "full prompt",
+        createdAt: "2026-01-10T10:00:00.000Z",
+        updatedAt: "2026-01-10T10:00:03.000Z",
+        durationMs: 2500,
+        progress: 75,
+        errorMessage: null,
+        warningMessage: null,
+        inputImages: ["https://example.com/input.png"],
+        inputAudios: [],
+        referenceText: null,
+        assets: [
+          {
+            url: "https://example.com/video.mp4",
+            width: 1280,
+            height: 720,
+            durationSec: 4,
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithIntl(
+      <MonitoringRequestDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        request={{
+          id: "vid-1",
+          type: "video" as never,
+          status: "processing",
+          model: "wan-2.2",
+          createdAt: "2026-01-10T10:00:00.000Z",
+          durationMs: null,
+          apiKeyLabel: "UI",
+        }}
+        timeZone="UTC"
+        detailOverride={{
+          id: "vid-1",
+          type: "video" as never,
+          status: "processing",
+          model: "wan-2.2",
+          prompt: "seed prompt",
+          createdAt: "2026-01-10T10:00:00.000Z",
+          updatedAt: "2026-01-10T10:00:00.000Z",
+          durationMs: null,
+          progress: null,
+          errorMessage: null,
+          warningMessage: null,
+          inputImages: [],
+          inputAudios: [],
+          referenceText: null,
+          assets: [
+            {
+              url: "https://example.com/video.mp4",
+              width: null,
+              height: null,
+              durationSec: null,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(mockUseMonitoringRequestDetail).toHaveBeenCalledWith("video", "vid-1", true);
+    expect(screen.getByText("2.5s")).toBeInTheDocument();
+    expect(screen.getByText("75%")).toBeInTheDocument();
+    expect(screen.getByText("4s")).toBeInTheDocument();
+  });
+
   it("audio 상세는 오디오 플레이어를 렌더링한다", () => {
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+
     renderWithIntl(
       <MonitoringRequestDetailDialog
         open
@@ -62,6 +147,12 @@ describe("MonitoringRequestDetailDialog", () => {
   });
 
   it("completed 요청의 안내 메시지는 오류가 아니라 경고로 렌더링한다", () => {
+    mockUseMonitoringRequestDetail.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+
     renderWithIntl(
       <MonitoringRequestDetailDialog
         open

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
@@ -59,6 +59,72 @@ function resolveInputLabels(
   };
 }
 
+function mergeAssets(
+  fetchedAssets: MonitoringRequestDetail["assets"] | undefined,
+  seedAssets: MonitoringRequestDetail["assets"] | undefined,
+) {
+  const resolvedFetchedAssets = fetchedAssets ?? [];
+  const resolvedSeedAssets = seedAssets ?? [];
+  const assetCount = Math.max(resolvedFetchedAssets.length, resolvedSeedAssets.length);
+
+  return Array.from({ length: assetCount }, (_, index) => {
+    const fetchedAsset = resolvedFetchedAssets[index];
+    const seedAsset = resolvedSeedAssets[index];
+    const url = fetchedAsset?.url ?? seedAsset?.url;
+
+    if (!url) return null;
+
+    return {
+      url,
+      width: fetchedAsset?.width ?? seedAsset?.width ?? null,
+      height: fetchedAsset?.height ?? seedAsset?.height ?? null,
+      durationSec: fetchedAsset?.durationSec ?? seedAsset?.durationSec ?? null,
+    };
+  }).filter((asset): asset is NonNullable<typeof asset> => asset !== null);
+}
+
+function mergeMonitoringDetail({
+  request,
+  seed,
+  fetched,
+}: {
+  request: MonitoringRequestItem | null;
+  seed: MonitoringRequestDetail | null;
+  fetched: MonitoringRequestDetail | null;
+}): MonitoringRequestDetail | null {
+  const type = fetched?.type ?? seed?.type ?? request?.type ?? null;
+  const id = fetched?.id ?? seed?.id ?? request?.id ?? null;
+  const status = fetched?.status ?? seed?.status ?? request?.status ?? null;
+  const createdAt = fetched?.createdAt ?? seed?.createdAt ?? request?.createdAt ?? null;
+
+  if (!type || !id || !status || !createdAt) {
+    return null;
+  }
+
+  const fetchedInputImages = fetched?.inputImages ?? [];
+  const seedInputImages = seed?.inputImages ?? [];
+  const fetchedInputAudios = fetched?.inputAudios ?? [];
+  const seedInputAudios = seed?.inputAudios ?? [];
+
+  return {
+    id,
+    type,
+    status,
+    model: fetched?.model ?? seed?.model ?? request?.model ?? null,
+    prompt: fetched?.prompt ?? seed?.prompt ?? "",
+    createdAt,
+    updatedAt: fetched?.updatedAt ?? seed?.updatedAt ?? createdAt,
+    durationMs: fetched?.durationMs ?? seed?.durationMs ?? request?.durationMs ?? null,
+    progress: fetched?.progress ?? seed?.progress ?? null,
+    errorMessage: fetched?.errorMessage ?? seed?.errorMessage ?? null,
+    warningMessage: fetched?.warningMessage ?? seed?.warningMessage ?? null,
+    inputImages: fetchedInputImages.length > 0 ? fetchedInputImages : seedInputImages,
+    inputAudios: fetchedInputAudios.length > 0 ? fetchedInputAudios : seedInputAudios,
+    referenceText: fetched?.referenceText ?? seed?.referenceText ?? null,
+    assets: mergeAssets(fetched?.assets, seed?.assets),
+  };
+}
+
 export function MonitoringRequestDetailDialog({
   open,
   onOpenChange,
@@ -75,7 +141,7 @@ export function MonitoringRequestDetailDialog({
     failed: t("statuses.failed"),
   };
 
-  const shouldFetchDetail = !detailOverride;
+  const shouldFetchDetail = Boolean(request);
   const detailQuery = useMonitoringRequestDetail(
     request?.type ?? null,
     request?.id ?? null,
@@ -96,7 +162,15 @@ export function MonitoringRequestDetailDialog({
     return formatter.format(parsed);
   };
 
-  const detail = detailOverride ?? detailQuery.data ?? null;
+  const detail = useMemo(
+    () =>
+      mergeMonitoringDetail({
+        request,
+        seed: detailOverride,
+        fetched: detailQuery.data ?? null,
+      }),
+    [detailOverride, detailQuery.data, request],
+  );
   const isFinished = detail ? FINISHED_STATUSES.has(detail.status) : false;
   const status = detail
     ? resolveMonitoringStatus(detail.status, statusLabels)
@@ -116,9 +190,9 @@ export function MonitoringRequestDetailDialog({
           </DialogTitle>
         </DialogHeader>
 
-        {shouldFetchDetail && detailQuery.isLoading ? (
+        {shouldFetchDetail && detailQuery.isLoading && !detail ? (
           <div className="mt-6 h-48 rounded-xl border border-white/10 bg-background-dark/50" />
-        ) : shouldFetchDetail && detailQuery.error ? (
+        ) : shouldFetchDetail && detailQuery.error && !detail ? (
           <div className="mt-6 rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
             {t("requests.detailFetchError")}
           </div>

--- a/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
+++ b/src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.tsx
@@ -92,6 +92,10 @@ function mergeMonitoringDetail({
   seed: MonitoringRequestDetail | null;
   fetched: MonitoringRequestDetail | null;
 }): MonitoringRequestDetail | null {
+  if (!seed && !fetched) {
+    return null;
+  }
+
   const type = fetched?.type ?? seed?.type ?? request?.type ?? null;
   const id = fetched?.id ?? seed?.id ?? request?.id ?? null;
   const status = fetched?.status ?? seed?.status ?? request?.status ?? null;
@@ -110,7 +114,7 @@ function mergeMonitoringDetail({
     id,
     type,
     status,
-    model: fetched?.model ?? seed?.model ?? request?.model ?? null,
+    model: fetched?.model ?? seed?.model ?? null,
     prompt: fetched?.prompt ?? seed?.prompt ?? "",
     createdAt,
     updatedAt: fetched?.updatedAt ?? seed?.updatedAt ?? createdAt,
@@ -191,7 +195,10 @@ export function MonitoringRequestDetailDialog({
         </DialogHeader>
 
         {shouldFetchDetail && detailQuery.isLoading && !detail ? (
-          <div className="mt-6 h-48 rounded-xl border border-white/10 bg-background-dark/50" />
+          <div
+            data-testid="monitoring-detail-loading"
+            className="mt-6 h-48 rounded-xl border border-white/10 bg-background-dark/50"
+          />
         ) : shouldFetchDetail && detailQuery.error && !detail ? (
           <div className="mt-6 rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
             {t("requests.detailFetchError")}

--- a/src/screens/generation-history/ui/generation-history-screen.test.tsx
+++ b/src/screens/generation-history/ui/generation-history-screen.test.tsx
@@ -1,0 +1,42 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GenerationHistoryScreen } from "@/screens/generation-history/ui/generation-history-screen";
+import { renderWithIntl } from "@/test-utils/intl";
+
+const useGenerationHistoryListMock = vi.fn();
+
+vi.mock("@/features/generation-history/hook/use-generation-history-list", () => ({
+  useGenerationHistoryList: (...args: unknown[]) => useGenerationHistoryListMock(...args),
+}));
+
+vi.mock("@/features/generation-history/ui/history-list", () => ({
+  HistoryList: () => <div data-testid="history-list" />,
+}));
+
+describe("GenerationHistoryScreen", () => {
+  it("renders the infinite loading sentinel without decorative pill styles", () => {
+    useGenerationHistoryListMock.mockReturnValue({
+      items: [
+        {
+          id: "history-1",
+          type: "image",
+          status: "completed",
+          prompt: "prompt",
+          createdAt: "2026-03-10T00:00:00.000Z",
+        },
+      ],
+      total: 2,
+      isLoading: true,
+      error: null,
+      sentinelRef: { current: null },
+      removeItem: vi.fn(),
+    });
+
+    renderWithIntl(<GenerationHistoryScreen />);
+
+    const sentinel = screen.getByTestId("history-infinite-sentinel");
+    expect(sentinel).not.toHaveClass("rounded-full");
+    expect(sentinel).not.toHaveClass("border");
+    expect(sentinel).not.toHaveClass("bg-surface-dark/60");
+  });
+});

--- a/src/screens/generation-history/ui/generation-history-screen.test.tsx
+++ b/src/screens/generation-history/ui/generation-history-screen.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { GenerationHistoryScreen } from "@/screens/generation-history/ui/generation-history-screen";
 import { renderWithIntl } from "@/test-utils/intl";
@@ -14,6 +14,39 @@ vi.mock("@/features/generation-history/ui/history-list", () => ({
 }));
 
 describe("GenerationHistoryScreen", () => {
+  it("shows an audio filter and requests audio history when selected", () => {
+    useGenerationHistoryListMock.mockReturnValue({
+      items: [],
+      total: 0,
+      isLoading: false,
+      error: null,
+      sentinelRef: { current: null },
+      removeItem: vi.fn(),
+    });
+
+    renderWithIntl(<GenerationHistoryScreen />);
+
+    const audioFilter = screen.getByRole("button", { name: "오디오" });
+    expect(audioFilter).toBeInTheDocument();
+    expect(useGenerationHistoryListMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "all",
+        sort: "date_desc",
+        query: "",
+      }),
+    );
+
+    fireEvent.click(audioFilter);
+
+    expect(useGenerationHistoryListMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "audio",
+        sort: "date_desc",
+        query: "",
+      }),
+    );
+  });
+
   it("renders the infinite loading sentinel without decorative pill styles", () => {
     useGenerationHistoryListMock.mockReturnValue({
       items: [

--- a/src/screens/generation-history/ui/generation-history-screen.tsx
+++ b/src/screens/generation-history/ui/generation-history-screen.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import {
+  AudioLines,
   Grid2X2,
   Image as ImageIcon,
   SlidersHorizontal,
@@ -85,6 +86,14 @@ export function GenerationHistoryScreen() {
             icon={<Video className="h-4 w-4" />}
           >
             {tCommonLabels("videos")}
+          </DashboardFilterToggle>
+          <DashboardFilterToggle
+            onClick={() => setType("audio")}
+            aria-pressed={type === "audio"}
+            active={type === "audio"}
+            icon={<AudioLines className="h-4 w-4" />}
+          >
+            {tCommonLabels("audios")}
           </DashboardFilterToggle>
           <DashboardFilterDivider />
           <Button

--- a/src/screens/generation-history/ui/generation-history-screen.tsx
+++ b/src/screens/generation-history/ui/generation-history-screen.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { Grid2X2, Image as ImageIcon, SlidersHorizontal, Video } from "lucide-react";
+import {
+  Grid2X2,
+  Image as ImageIcon,
+  SlidersHorizontal,
+  Video,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
 import type {
   GenerationHistorySort,
@@ -9,10 +14,7 @@ import type {
 } from "@/entities/generation/model/types";
 import { HistoryList } from "@/features/generation-history/ui/history-list";
 import { useGenerationHistoryList } from "@/features/generation-history/hook/use-generation-history-list";
-import {
-  PageHeader,
-  PageHeaderSearchInput,
-} from "@/shared/ui/page-header";
+import { PageHeader, PageHeaderSearchInput } from "@/shared/ui/page-header";
 import { Button } from "@/shared/ui/button";
 import { useDebouncedValue } from "@/shared/lib/hooks/use-debounced-value";
 import {
@@ -38,9 +40,7 @@ export function GenerationHistoryScreen() {
     });
 
   const renderSortLabel =
-    sort === "date_desc"
-      ? tCommonLabels("dateDesc")
-      : tCommonLabels("dateAsc");
+    sort === "date_desc" ? tCommonLabels("dateDesc") : tCommonLabels("dateAsc");
 
   return (
     <div className="flex flex-col gap-8 pb-20 overflow-x-hidden">
@@ -125,7 +125,9 @@ export function GenerationHistoryScreen() {
           <div className="mt-6 flex flex-col items-center gap-3">
             <div
               ref={sentinelRef}
-              className="h-8 w-full max-w-xs rounded-full border border-white/10 bg-surface-dark/60"
+              data-testid="history-infinite-sentinel"
+              aria-hidden="true"
+              className="h-8 w-full max-w-xs"
             />
             {isLoading && (
               <span className="text-xs font-mono uppercase tracking-widest text-gray-500">

--- a/src/widgets/header/ui/header.test.tsx
+++ b/src/widgets/header/ui/header.test.tsx
@@ -1,6 +1,5 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { within } from "@testing-library/react";
 import { describe, it, vi } from "vitest";
 import { Header } from "@/widgets/header/ui/header";
 import { renderWithIntl } from "@/test-utils/intl";

--- a/src/widgets/header/ui/header.test.tsx
+++ b/src/widgets/header/ui/header.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { within } from "@testing-library/react";
 import { describe, it, vi } from "vitest";
 import { Header } from "@/widgets/header/ui/header";
 import { renderWithIntl } from "@/test-utils/intl";
@@ -30,6 +31,19 @@ describe("Header", () => {
     expect(container.querySelectorAll('a[href="/audio"]').length).toBeGreaterThan(0);
   });
 
+  it("desktop nav 링크는 xl 미만 숨김용 라벨 wrapper와 접근성 이름을 가진다", () => {
+    renderWithIntl(<Header isAuthenticated userEmail="admin@example.com" />);
+
+    const desktopNav = screen.getByRole("navigation");
+    const audioLink = within(desktopNav).getByRole("link", { name: "오디오" });
+    const label = within(audioLink).getByText("오디오");
+
+    expect(audioLink).toHaveAttribute("aria-label", "오디오");
+    expect(label.tagName).toBe("SPAN");
+    expect(label).toHaveClass("hidden");
+    expect(label).toHaveClass("xl:inline");
+  });
+
   it("모바일 메뉴를 열면 Audio 링크가 보인다", async () => {
     const user = userEvent.setup();
     const { container } = renderWithIntl(
@@ -39,6 +53,11 @@ describe("Header", () => {
     expect(container.querySelectorAll('a[href="/audio"]').length).toBe(1);
     await user.click(screen.getByRole("button", { name: /메뉴/i }));
 
-    expect(container.ownerDocument.querySelectorAll('a[href="/audio"]').length).toBeGreaterThan(1);
+    const audioLinks = container.ownerDocument.querySelectorAll('a[href="/audio"]');
+    expect(audioLinks.length).toBeGreaterThan(1);
+
+    const dropdownAudioLink = audioLinks[audioLinks.length - 1];
+    expect(dropdownAudioLink).toHaveTextContent("오디오");
+    expect(dropdownAudioLink.querySelector("span")).toBeNull();
   });
 });

--- a/src/widgets/header/ui/header.tsx
+++ b/src/widgets/header/ui/header.tsx
@@ -95,10 +95,11 @@ export function Header({
             <Link
               key={item.href}
               href={item.href}
-              className="flex items-center gap-2 rounded-full px-4 py-2 text-xs font-medium text-gray-400 transition-all hover:bg-white/5 hover:text-white"
+              aria-label={tNav(item.key)}
+              className="flex items-center gap-2 rounded-full px-3 py-2 text-xs font-medium text-gray-400 transition-all hover:bg-white/5 hover:text-white xl:px-4"
             >
               <Icon className="h-4 w-4" />
-              {tNav(item.key)}
+              <span className="hidden xl:inline">{tNav(item.key)}</span>
             </Link>
           );
         })}


### PR DESCRIPTION
## 개요
- `audio` 메뉴 추가 이후 생긴 헤더/히스토리 반응형 회귀와 상세 메타데이터 누락을 정리합니다.
- history 화면에 audio 필터를 추가하고, video 카드를 카드 안에서 바로 재생할 수 있게 만듭니다.

## 변경 사항
- 헤더 desktop nav를 `xl` 미만에서 아이콘 전용으로 조정했습니다.
- history skeleton 컬럼 수를 viewport 컬럼 수와 동기화하고, infinite loading sentinel의 시각 노출을 제거했습니다.
- history detail modal이 fetched detail을 seed data 위에 병합해 duration/progress/asset duration 누락을 복구했습니다.
- generation history screen에 audio 타입 필터를 추가했습니다.
- history video 카드에 native player controls를 추가하고 컬럼 정렬을 조정했습니다.

## 테스트
- `pnpm vitest run src/widgets/header/ui/header.test.tsx src/features/generation-history/ui/history-list.test.tsx src/screens/generation-history/ui/generation-history-screen.test.tsx src/features/generation-history/ui/history-item.test.tsx src/features/monitoring-dashboard/ui/monitoring-request-detail-dialog.test.tsx`
- `pnpm vitest run src/features/generation-history/ui/history-item.test.tsx src/features/generation-history/ui/history-list.test.tsx`
- pre-push hook: `pnpm test && pnpm typecheck && pnpm build`

## 관련 문서
- Spec: `docs/features/F043-history-responsive-audio-detail-fixes/spec.md`
- Tasks: `docs/features/F043-history-responsive-audio-detail-fixes/tasks.md`
- Decisions: `docs/features/F043-history-responsive-audio-detail-fixes/decisions.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 세대 기록 화면에 오디오 필터 버튼 추가

* **개선 사항**
  * 비디오 미리보기에 기본 재생 컨트롤 추가
  * 헤더 네비게이션의 반응형 동작 개선(작은 화면에서 아이콘 중심 표시)
  * 무한 로드 표시기 구조 및 스타일 정리
  * 상세 모달에서 지속시간·진행률·자산 지속시간 표시 개선

* **테스트**
  * 테스트 커버리지 확대 및 모킹/테스트 안정성 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->