### PR TITLE
feat(#85): audio-qwen-tts-bugfix (F044-audio-qwen-tts-bugfix 구현)

### DIFF
--- a/src/screens/model-management/ui/model-management-screen.test.tsx
+++ b/src/screens/model-management/ui/model-management-screen.test.tsx
@@ -207,7 +207,7 @@ describe("ModelManagementScreen", () => {
 
     await waitFor(() => {
       expect((typeSelect as HTMLSelectElement).value).toBe("audio");
-      expect(screen.getByDisplayValue(/generate_audio/)).toBeTruthy();
+      expect(screen.getByDisplayValue(/run_generation/)).toBeTruthy();
       expect(screen.getByDisplayValue(/default_speed/)).toBeTruthy();
       expect(screen.getByDisplayValue(/referenceText/)).toBeTruthy();
       expect(screen.getByDisplayValue(/inputAudio/)).toBeTruthy();

--- a/src/screens/model-management/ui/model-management-screen.tsx
+++ b/src/screens/model-management/ui/model-management-screen.tsx
@@ -113,7 +113,7 @@ const defaultVideoProviderConfig = {
 
 const defaultAudioProviderConfig = {
   space_id: "owner/space",
-  api_name: "/generate_audio",
+  api_name: "/run_generation",
   timeout_ms: 300000,
 };
 

--- a/src/server/audio-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.test.ts
@@ -124,9 +124,14 @@ describe("hfSpaceAudioAdapter", () => {
       seed: "42",
     });
 
+    const expectedToken =
+      process.env.HF_TOKEN?.trim() ||
+      process.env.HUGGINGFACEHUB_API_TOKEN?.trim() ||
+      undefined;
+
     expect(mockConnect).toHaveBeenCalledWith(
       "leey00nsu/qwen-3.5-tts-faster-gradio",
-      { token: undefined },
+      { token: expectedToken },
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,

--- a/src/server/audio-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.test.ts
@@ -627,6 +627,99 @@ describe("hfSpaceAudioAdapter", () => {
     });
   });
 
+  it("빈 dependency api_name은 output scoring에 반영하지 않고 명시된 audio endpoint를 우선 선택한다", async () => {
+    const predict = vi.fn().mockResolvedValue({
+      data: [
+        {
+          audio: {
+            path: "/file=/tmp/generated.wav",
+            duration_sec: 1.9,
+          },
+        },
+      ],
+    });
+
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts-missing-dependency-api-name",
+        label: "Qwen TTS Missing Dependency API Name",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/stale_endpoint",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: false,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    const viewApi = vi.fn().mockResolvedValue({
+      named_endpoints: {
+        "/generate_audio": {
+          parameters: [{ parameter_name: "text", label: "Text" }],
+        },
+        "/run_generation": {
+          parameters: [{ parameter_name: "text", label: "Text" }],
+        },
+      },
+    });
+
+    mockConnect.mockResolvedValue({
+      view_api: viewApi,
+      predict,
+      config: {
+        components: [{ id: 1, type: "audio" }],
+        dependencies: [
+          { api_name: "", outputs: [1] },
+          { api_name: "/run_generation", outputs: [1] },
+        ],
+      },
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "audio/wav" }),
+        arrayBuffer: async () => Uint8Array.from([82, 73, 70, 70]).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    const result = await hfSpaceAudioAdapter.generate({
+      prompt: "hello",
+      model: "qwen-tts-missing-dependency-api-name",
+      speed: 1,
+    });
+
+    expect(predict).toHaveBeenCalledTimes(1);
+    expect(predict).toHaveBeenNthCalledWith(1, "/run_generation", expect.any(Object));
+    expect(result).toEqual({
+      audios: ["data:audio/wav;base64,UklGRg=="],
+      meta: { duration_sec: 1.9 },
+    });
+  });
+
   it("Python positional argument TypeError도 retryable parameter 오류로 분류해 다음 endpoint로 fallback한다", async () => {
     const predict = vi
       .fn()
@@ -724,6 +817,88 @@ describe("hfSpaceAudioAdapter", () => {
       audios: ["data:audio/wav;base64,UklGRg=="],
       meta: { duration_sec: 2.7 },
     });
+  });
+
+  it("generic function 오류는 endpoint invalid로 오인하지 않고 원래 오류를 유지한다", async () => {
+    const predict = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("function execution failed during inference"))
+      .mockResolvedValueOnce({
+        data: [
+          {
+            audio: {
+              path: "/file=/tmp/generated.wav",
+              duration_sec: 2.2,
+            },
+          },
+        ],
+      });
+
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts-generic-function-error",
+        label: "Qwen TTS Generic Function Error",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/voice_clone",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: false,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/voice_clone": {
+            parameters: [{ parameter_name: "text", label: "Text" }],
+          },
+          "/predict": {
+            parameters: [{ parameter_name: "prompt", label: "Prompt" }],
+          },
+        },
+      }),
+      predict,
+      config: {
+        components: [{ id: 1, type: "audio" }],
+        dependencies: [{ api_name: "/predict", outputs: [1] }],
+      },
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ stage: "RUNNING" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    await expect(
+      hfSpaceAudioAdapter.generate({
+        prompt: "hello",
+        model: "qwen-tts-generic-function-error",
+        speed: 1,
+      }),
+    ).rejects.toThrow("function execution failed during inference");
+
+    expect(predict).toHaveBeenCalledTimes(1);
+    expect(predict).toHaveBeenNthCalledWith(1, "/voice_clone", expect.any(Object));
   });
 
   it("view_api 조회가 실패해도 저장된 api_name으로 기존 payload fallback을 유지한다", async () => {

--- a/src/server/audio-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.test.ts
@@ -51,29 +51,51 @@ describe("hfSpaceAudioAdapter", () => {
       },
     ]);
 
-    mockConnect.mockResolvedValue({
-      view_api: vi.fn().mockResolvedValue({
-        named_endpoints: {
-          "/generate_audio": {
-            parameters: [
-              { parameter_name: "prompt", label: "Prompt" },
-              { parameter_name: "voice", label: "Voice" },
-              { parameter_name: "speed", label: "Speed" },
-              { parameter_name: "seed", label: "Seed" },
-            ],
+    const predict = vi.fn().mockResolvedValue({
+      data: [
+        {
+          audio: {
+            path: "/file=/tmp/generated.wav",
+            duration_sec: 3.2,
           },
         },
-      }),
-      predict: vi.fn().mockResolvedValue({
-        data: [
-          {
-            audio: {
-              path: "/file=/tmp/generated.wav",
-              duration_sec: 3.2,
+      ],
+    });
+
+    const viewApi = vi.fn().mockResolvedValue({
+      named_endpoints: {
+        "/generate_audio": {
+          parameters: [
+            { parameter_name: "prompt", label: "Prompt" },
+            { parameter_name: "voice", label: "Voice" },
+            { parameter_name: "speed", label: "Speed" },
+            { parameter_name: "seed", label: "Seed" },
+            { parameter_name: "", label: "State" },
+            {
+              parameter_name: "internal_state",
+              label: "Internal State",
+              hidden: true,
+              component: "state",
             },
-          },
+          ],
+        },
+      },
+    });
+
+    mockConnect.mockResolvedValue({
+      view_api: viewApi,
+      predict,
+      config: {
+        components: [
+          { id: 1, type: "textbox" },
+          { id: 2, type: "audio" },
         ],
-      }),
+        dependencies: [
+          { api_name: "/toggle_mode", outputs: [] },
+          { api_name: "/voice_clone", outputs: [2] },
+          { api_name: "/predict", outputs: [] },
+        ],
+      },
     });
 
     const fetchMock = vi
@@ -116,6 +138,13 @@ describe("hfSpaceAudioAdapter", () => {
       "https://leey00nsu-qwen-3.5-tts-faster-gradio.hf.space/gradio_api/file=/tmp/generated.wav",
       expect.objectContaining({})
     );
+    expect(predict).toHaveBeenCalledWith("/generate_audio", {
+      prompt: "hello",
+      voice: "alloy",
+      speed: 1.25,
+      seed: 42,
+    });
+    expect(viewApi).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       audios: ["data:audio/wav;base64,UklGRg=="],
       meta: { duration_sec: 3.2 },
@@ -491,5 +520,258 @@ describe("hfSpaceAudioAdapter", () => {
       audios: ["data:audio/wav;base64,UklGRg=="],
       meta: { duration_sec: undefined },
     });
+  });
+
+  it("stale api_name을 retryable endpoint/parameter 오류를 거쳐 실제 생성 endpoint로 fallback한다", async () => {
+    const predict = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("api_name /toggle_mode not found"))
+      .mockRejectedValueOnce(
+        new Error("unexpected keyword argument 'ref_audio_path'"),
+      )
+      .mockResolvedValueOnce({
+        data: [
+          {
+            audio: {
+              path: "/file=/tmp/generated.wav",
+              duration_sec: 4.1,
+            },
+          },
+        ],
+      });
+
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts-stale",
+        label: "Qwen TTS Stale",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/toggle_mode",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: false,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    const viewApi = vi.fn().mockResolvedValue({
+      named_endpoints: {
+        "/toggle_mode": {
+          parameters: [{ parameter_name: "mode", label: "Mode" }],
+        },
+        "/voice_clone": {
+          parameters: [
+            { parameter_name: "text", label: "Text" },
+            { parameter_name: "ref_audio_path", label: "Reference Audio" },
+          ],
+        },
+        "/predict": {
+          parameters: [{ parameter_name: "prompt", label: "Prompt" }],
+        },
+      },
+    });
+
+    mockConnect.mockResolvedValue({
+      view_api: viewApi,
+      predict,
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "audio/wav" }),
+        arrayBuffer: async () => Uint8Array.from([82, 73, 70, 70]).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    const result = await hfSpaceAudioAdapter.generate({
+      prompt: "hello",
+      model: "qwen-tts-stale",
+      speed: 1,
+    });
+
+    expect(predict).toHaveBeenNthCalledWith(1, "/toggle_mode", expect.any(Object));
+    expect(predict).toHaveBeenNthCalledWith(2, "/voice_clone", expect.any(Object));
+    expect(predict).toHaveBeenNthCalledWith(3, "/predict", expect.any(Object));
+    expect(viewApi).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      audios: ["data:audio/wav;base64,UklGRg=="],
+      meta: { duration_sec: 4.1 },
+    });
+  });
+
+  it("view_api 조회가 실패해도 저장된 api_name으로 기존 payload fallback을 유지한다", async () => {
+    const predict = vi.fn().mockResolvedValue({
+      data: [
+        {
+          audio: {
+            path: "/file=/tmp/generated.wav",
+            duration_sec: 2.4,
+          },
+        },
+      ],
+    });
+
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts-view-api-down",
+        label: "Qwen TTS View API Down",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/generate_audio",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: false,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    const viewApi = vi.fn().mockRejectedValue(new Error("view_api unavailable"));
+
+    mockConnect.mockResolvedValue({
+      view_api: viewApi,
+      predict,
+      config: {
+        components: [],
+        dependencies: [],
+      },
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "audio/wav" }),
+        arrayBuffer: async () => Uint8Array.from([82, 73, 70, 70]).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    const result = await hfSpaceAudioAdapter.generate({
+      prompt: "hello",
+      model: "qwen-tts-view-api-down",
+      voice: "alloy",
+      speed: 1.25,
+      seed: "42",
+    });
+
+    expect(viewApi).toHaveBeenCalledTimes(1);
+    expect(predict).toHaveBeenCalledTimes(1);
+    expect(predict).toHaveBeenCalledWith("/generate_audio", {
+      prompt: "hello",
+      voice: "alloy",
+      speed: 1.25,
+      seed: 42,
+    });
+    expect(result).toEqual({
+      audios: ["data:audio/wav;base64,UklGRg=="],
+      meta: { duration_sec: 2.4 },
+    });
+  });
+
+  it("생성 응답에서 오디오를 찾지 못하면 HF_SPACE_RESPONSE_INVALID를 반환한다", async () => {
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts-response-mismatch",
+        label: "Qwen TTS Response Mismatch",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/run_generation",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: false,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/run_generation": {
+            parameters: [{ parameter_name: "text", label: "Text" }],
+          },
+        },
+      }),
+      predict: vi.fn().mockResolvedValue({
+        data: [
+          {
+            message: "ok",
+          },
+        ],
+      }),
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ stage: "RUNNING" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    await expect(
+      hfSpaceAudioAdapter.generate({
+        prompt: "hello",
+        model: "qwen-tts-response-mismatch",
+        speed: 1,
+      }),
+    ).rejects.toThrow("HF_SPACE_RESPONSE_INVALID");
   });
 });

--- a/src/server/audio-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.test.ts
@@ -720,6 +720,89 @@ describe("hfSpaceAudioAdapter", () => {
     });
   });
 
+  it("parameter_name이 비어 있어도 label이 있으면 payload key fallback으로 유지한다", async () => {
+    const predict = vi.fn().mockResolvedValue({
+      data: [
+        {
+          audio: {
+            path: "/file=/tmp/generated.wav",
+            duration_sec: 1.1,
+          },
+        },
+      ],
+    });
+
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts-label-fallback",
+        label: "Qwen TTS Label Fallback",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/run_generation",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: false,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/run_generation": {
+            parameters: [
+              { parameter_name: "", label: "Text" },
+              { parameter_name: "", label: "State", hidden: true, component: "state" },
+            ],
+          },
+        },
+      }),
+      predict,
+      config: {
+        components: [{ id: 1, type: "audio" }],
+        dependencies: [{ api_name: "/run_generation", outputs: [1] }],
+      },
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "audio/wav" }),
+        arrayBuffer: async () => Uint8Array.from([82, 73, 70, 70]).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    await hfSpaceAudioAdapter.generate({
+      prompt: "hello",
+      model: "qwen-tts-label-fallback",
+      speed: 1,
+    });
+
+    expect(predict).toHaveBeenCalledWith("/run_generation", { Text: "hello" });
+  });
+
   it("Python positional argument TypeError도 retryable parameter 오류로 분류해 다음 endpoint로 fallback한다", async () => {
     const predict = vi
       .fn()
@@ -817,6 +900,78 @@ describe("hfSpaceAudioAdapter", () => {
       audios: ["data:audio/wav;base64,UklGRg=="],
       meta: { duration_sec: 2.7 },
     });
+  });
+
+  it("마지막 후보가 response invalid여도 더 구체적인 retryable 오류를 우선 보존한다", async () => {
+    const predict = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("unexpected keyword argument 'voice'"))
+      .mockResolvedValueOnce({
+        data: [{ text: "no audio here" }],
+      });
+
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts-error-specificity",
+        label: "Qwen TTS Error Specificity",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/voice_clone",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: false,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/voice_clone": {
+            parameters: [{ parameter_name: "text", label: "Text" }],
+          },
+          "/predict": {
+            parameters: [{ parameter_name: "prompt", label: "Prompt" }],
+          },
+        },
+      }),
+      predict,
+      config: {
+        components: [{ id: 1, type: "audio" }],
+        dependencies: [{ api_name: "/predict", outputs: [1] }],
+      },
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ stage: "RUNNING" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    await expect(
+      hfSpaceAudioAdapter.generate({
+        prompt: "hello",
+        model: "qwen-tts-error-specificity",
+        speed: 1,
+      }),
+    ).rejects.toThrow("HF_SPACE_PARAMETER_INVALID");
   });
 
   it("generic function 오류는 endpoint invalid로 오인하지 않고 원래 오류를 유지한다", async () => {

--- a/src/server/audio-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.test.ts
@@ -622,6 +622,105 @@ describe("hfSpaceAudioAdapter", () => {
     });
   });
 
+  it("Python positional argument TypeError도 retryable parameter 오류로 분류해 다음 endpoint로 fallback한다", async () => {
+    const predict = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("TypeError: predict() takes 2 positional arguments but 3 were given"),
+      )
+      .mockResolvedValueOnce({
+        data: [
+          {
+            audio: {
+              path: "/file=/tmp/generated.wav",
+              duration_sec: 2.7,
+            },
+          },
+        ],
+      });
+
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-model-1",
+        type: "audio",
+        key: "qwen-tts-positional-error",
+        label: "Qwen TTS Positional Error",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          api_name: "/voice_clone",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+        },
+        meta: {
+          model_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: false,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    const viewApi = vi.fn().mockResolvedValue({
+      named_endpoints: {
+        "/voice_clone": {
+          parameters: [
+            { parameter_name: "text", label: "Text" },
+            { parameter_name: "ref_audio_path", label: "Reference Audio" },
+          ],
+        },
+        "/predict": {
+          parameters: [{ parameter_name: "prompt", label: "Prompt" }],
+        },
+      },
+    });
+
+    mockConnect.mockResolvedValue({
+      view_api: viewApi,
+      predict,
+      config: {
+        components: [],
+        dependencies: [{ api_name: "/predict", outputs: [1] }],
+      },
+    });
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "audio/wav" }),
+        arrayBuffer: async () => Uint8Array.from([82, 73, 70, 70]).buffer,
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    const result = await hfSpaceAudioAdapter.generate({
+      prompt: "hello",
+      model: "qwen-tts-positional-error",
+      speed: 1,
+    });
+
+    expect(predict).toHaveBeenNthCalledWith(1, "/voice_clone", expect.any(Object));
+    expect(predict).toHaveBeenNthCalledWith(2, "/predict", expect.any(Object));
+    expect(viewApi).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      audios: ["data:audio/wav;base64,UklGRg=="],
+      meta: { duration_sec: 2.7 },
+    });
+  });
+
   it("view_api 조회가 실패해도 저장된 api_name으로 기존 payload fallback을 유지한다", async () => {
     const predict = vi.fn().mockResolvedValue({
       data: [

--- a/src/server/audio-generation/adapters/hf-space-adapter.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.ts
@@ -399,6 +399,48 @@ function normalizeLookupKey(parameter: EndpointParameter) {
     .replace(/[_\-]+/g, " ");
 }
 
+function resolveRequestParameterKey(parameter: EndpointParameter) {
+  const parameterName =
+    typeof parameter.parameter_name === "string"
+      ? parameter.parameter_name.trim()
+      : "";
+  if (parameterName.length > 0) {
+    return parameterName;
+  }
+
+  return typeof parameter.label === "string" ? parameter.label.trim() : "";
+}
+
+function getRetryableErrorPriority(message: string) {
+  switch (message) {
+    case "HF_SPACE_PARAMETER_INVALID":
+      return 3;
+    case "HF_SPACE_ENDPOINT_INVALID":
+      return 2;
+    case "HF_SPACE_RESPONSE_INVALID":
+      return 1;
+    case "HF_SPACE_REQUEST_TIMEOUT":
+      return 0;
+    default:
+      return -1;
+  }
+}
+
+function keepMoreSpecificRetryableError(
+  current: Error | null,
+  nextMessage: string,
+) {
+  const next = new Error(nextMessage);
+  if (!current) {
+    return next;
+  }
+
+  return getRetryableErrorPriority(next.message) >
+      getRetryableErrorPriority(current.message)
+    ? next
+    : current;
+}
+
 function resolveParamValue(
   parameter: EndpointParameter,
   payload: AudioGenerationFormValues,
@@ -524,17 +566,14 @@ function buildRequestPayload(
   const parameters =
     endpoint?.parameters?.filter(
       (parameter) => {
-        const parameterName =
-          typeof parameter.parameter_name === "string"
-            ? parameter.parameter_name.trim()
-            : "";
         const component =
           typeof parameter.component === "string"
             ? parameter.component.trim().toLowerCase()
             : "";
+        const requestKey = resolveRequestParameterKey(parameter);
 
         return (
-          parameterName.length > 0 &&
+          requestKey.length > 0 &&
           parameter.hidden !== true &&
           component !== "state"
         );
@@ -606,7 +645,7 @@ function buildRequestPayload(
   const requestPayload: Record<string, unknown> = {};
 
   parameters.forEach((parameter) => {
-    const key = parameter.parameter_name!.trim();
+    const key = resolveRequestParameterKey(parameter);
 
     requestPayload[key] = resolveParamValue(
       parameter,
@@ -857,7 +896,10 @@ export const hfSpaceAudioAdapter: AudioGenerationAdapter = {
       } catch (error) {
         const classified = classifyPredictError(error);
         if (classified) {
-          lastRetryableError = new Error(classified);
+          lastRetryableError = keepMoreSpecificRetryableError(
+            lastRetryableError,
+            classified,
+          );
           continue;
         }
         throw error;
@@ -875,7 +917,10 @@ export const hfSpaceAudioAdapter: AudioGenerationAdapter = {
       });
 
       if (audioGroups.length === 0) {
-        lastRetryableError = new Error("HF_SPACE_RESPONSE_INVALID");
+        lastRetryableError = keepMoreSpecificRetryableError(
+          lastRetryableError,
+          "HF_SPACE_RESPONSE_INVALID",
+        );
         continue;
       }
 

--- a/src/server/audio-generation/adapters/hf-space-adapter.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.ts
@@ -6,6 +6,7 @@ import {
   resolveHfSpaceFileReferenceCandidates,
   resolveHfSpaceFileReference,
 } from "@/server/hf-space/file-reference-resolver";
+import { scoreEndpointCandidate } from "@/server/hf-space/endpoint-scoring";
 import { getModelCatalog } from "@/server/model-catalog/catalog-service";
 import type { AudioModelCatalogItem } from "@/server/model-catalog/catalog-schema";
 import {
@@ -291,25 +292,6 @@ function normalizeApiKey(apiName: string) {
   return normalizeApiName(apiName);
 }
 
-function hasAudioEndpointSignal(endpoint: EndpointInfo | undefined) {
-  const parameters = endpoint?.parameters ?? [];
-  return parameters.some((parameter) => {
-    const target = `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`.toLowerCase();
-    return (
-      target.includes("reference audio") ||
-      target.includes("ref audio") ||
-      target.includes("ref_audio") ||
-      target.includes("input audio") ||
-      target.includes("input_audio") ||
-      target.includes("voice") ||
-      target.includes("speaker") ||
-      target.includes("spk") ||
-      target.includes("speed") ||
-      target.includes("rate")
-    );
-  });
-}
-
 function buildOutputTypesByApiName(config: ClientConfigSnapshot | null | undefined) {
   const componentsById = new Map(
     (config?.components ?? []).map((component) => [component.id, component]),
@@ -326,52 +308,6 @@ function buildOutputTypesByApiName(config: ClientConfigSnapshot | null | undefin
   }
 
   return outputTypesByApiName;
-}
-
-function scoreEndpointCandidate(
-  apiName: string,
-  endpoint: EndpointInfo | undefined,
-  outputTypes: string[],
-) {
-  const normalizedName = apiName.toLowerCase();
-  const parameters = endpoint?.parameters ?? [];
-  let score = 0;
-
-  if (outputTypes.some((type) => type.includes("audio"))) {
-    score += 10;
-  }
-  if (hasAudioEndpointSignal(endpoint)) {
-    score += 10;
-  }
-  if (
-    normalizedName.includes("run") ||
-    normalizedName.includes("generate") ||
-    normalizedName.includes("predict") ||
-    normalizedName.includes("synth")
-  ) {
-    score += 10;
-  }
-  if (
-    normalizedName.includes("toggle") ||
-    normalizedName.includes("refresh") ||
-    normalizedName.includes("load")
-  ) {
-    score -= 10;
-  }
-
-  for (const parameter of parameters) {
-    const target = `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`.toLowerCase();
-    if (target.includes("prompt") || target.includes("text")) score += 2;
-    if (
-      target.includes("reference audio") ||
-      target.includes("ref audio") ||
-      target.includes("ref_audio")
-    ) {
-      score += 4;
-    }
-  }
-
-  return score;
 }
 
 function resolveApiCandidates(
@@ -423,11 +359,17 @@ function classifyPredictError(error: unknown) {
     "unknown argument",
     "missing required positional argument",
     "missing 1 required positional argument",
+    "positional argument",
     "got multiple values",
     "invalid parameter",
     "required argument",
   ];
-  if (parameterIndicators.some((indicator) => message.includes(indicator))) {
+  const positionalArgumentPattern =
+    /takes .* positional arguments?.* (was|were) given/;
+  if (
+    parameterIndicators.some((indicator) => message.includes(indicator)) ||
+    positionalArgumentPattern.test(message)
+  ) {
     return "HF_SPACE_PARAMETER_INVALID";
   }
 

--- a/src/server/audio-generation/adapters/hf-space-adapter.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.ts
@@ -299,7 +299,11 @@ function buildOutputTypesByApiName(config: ClientConfigSnapshot | null | undefin
   const outputTypesByApiName = new Map<string, string[]>();
 
   for (const dependency of config?.dependencies ?? []) {
-    const apiName = normalizeApiKey(dependency.api_name ?? "");
+    const rawApiName = dependency.api_name?.trim();
+    if (!rawApiName) {
+      continue;
+    }
+    const apiName = normalizeApiKey(rawApiName);
     const outputTypes = (dependency.outputs ?? [])
       .map((id) => componentsById.get(id))
       .map((component) => resolveComponentType(component))
@@ -373,8 +377,16 @@ function classifyPredictError(error: unknown) {
     return "HF_SPACE_PARAMETER_INVALID";
   }
 
-  const endpointIndicators = ["api_name", "endpoint", "function", "not found", "404"];
-  if (endpointIndicators.some((indicator) => message.includes(indicator))) {
+  const endpointPatterns = [
+    /\b404\b/,
+    /api_name .* not found/,
+    /unknown api[_ ]?name/,
+    /not a valid api[_ ]?name/,
+    /no endpoint named/,
+    /no function named/,
+    /endpoint .* not found/,
+  ];
+  if (endpointPatterns.some((pattern) => pattern.test(message))) {
     return "HF_SPACE_ENDPOINT_INVALID";
   }
 
@@ -900,6 +912,9 @@ export const hfSpaceAudioAdapter: AudioGenerationAdapter = {
       };
     }
 
-    throw lastRetryableError ?? new Error("HF_SPACE_API_NOT_FOUND");
+    if (lastRetryableError) {
+      throw lastRetryableError;
+    }
+    throw new Error("HF_SPACE_RESPONSE_INVALID");
   },
 };

--- a/src/server/audio-generation/adapters/hf-space-adapter.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.ts
@@ -41,6 +41,8 @@ type EndpointParameter = {
   parameter_name?: string;
   label?: string;
   parameter_default?: unknown;
+  hidden?: boolean;
+  component?: string;
 };
 
 type EndpointInfo = {
@@ -49,6 +51,21 @@ type EndpointInfo = {
 
 type ViewApiResponse = {
   named_endpoints?: Record<string, EndpointInfo>;
+};
+
+type ClientConfigComponent = {
+  id?: number;
+  type?: string;
+};
+
+type ClientConfigDependency = {
+  api_name?: string;
+  outputs?: number[];
+};
+
+type ClientConfigSnapshot = {
+  components?: ClientConfigComponent[];
+  dependencies?: ClientConfigDependency[];
 };
 
 const clientCache = new Map<string, Promise<Client>>();
@@ -253,16 +270,173 @@ function parseSeed(seed?: string) {
   return { seedValue: isValid ? parsed : 0, randomize: !isValid };
 }
 
-async function getEndpointInfo(client: Client, apiName: string) {
-  const apiInfo = (await client
-    .view_api()
-    .catch(() => null)) as ViewApiResponse | null;
+function getEndpointInfoFromSnapshot(
+  apiInfo: ViewApiResponse | null,
+  apiName: string,
+) {
   if (!apiInfo?.named_endpoints) return null;
   return (
     apiInfo.named_endpoints[apiName] ??
     apiInfo.named_endpoints[apiName.replace(/^\//, "")] ??
     null
   );
+}
+
+function resolveComponentType(component?: ClientConfigComponent | null) {
+  const raw = component?.type ?? "";
+  return typeof raw === "string" ? raw.toLowerCase() : "";
+}
+
+function normalizeApiKey(apiName: string) {
+  return normalizeApiName(apiName);
+}
+
+function hasAudioEndpointSignal(endpoint: EndpointInfo | undefined) {
+  const parameters = endpoint?.parameters ?? [];
+  return parameters.some((parameter) => {
+    const target = `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`.toLowerCase();
+    return (
+      target.includes("reference audio") ||
+      target.includes("ref audio") ||
+      target.includes("ref_audio") ||
+      target.includes("input audio") ||
+      target.includes("input_audio") ||
+      target.includes("voice") ||
+      target.includes("speaker") ||
+      target.includes("spk") ||
+      target.includes("speed") ||
+      target.includes("rate")
+    );
+  });
+}
+
+function buildOutputTypesByApiName(config: ClientConfigSnapshot | null | undefined) {
+  const componentsById = new Map(
+    (config?.components ?? []).map((component) => [component.id, component]),
+  );
+  const outputTypesByApiName = new Map<string, string[]>();
+
+  for (const dependency of config?.dependencies ?? []) {
+    const apiName = normalizeApiKey(dependency.api_name ?? "");
+    const outputTypes = (dependency.outputs ?? [])
+      .map((id) => componentsById.get(id))
+      .map((component) => resolveComponentType(component))
+      .filter(Boolean);
+    outputTypesByApiName.set(apiName, outputTypes);
+  }
+
+  return outputTypesByApiName;
+}
+
+function scoreEndpointCandidate(
+  apiName: string,
+  endpoint: EndpointInfo | undefined,
+  outputTypes: string[],
+) {
+  const normalizedName = apiName.toLowerCase();
+  const parameters = endpoint?.parameters ?? [];
+  let score = 0;
+
+  if (outputTypes.some((type) => type.includes("audio"))) {
+    score += 10;
+  }
+  if (hasAudioEndpointSignal(endpoint)) {
+    score += 10;
+  }
+  if (
+    normalizedName.includes("run") ||
+    normalizedName.includes("generate") ||
+    normalizedName.includes("predict") ||
+    normalizedName.includes("synth")
+  ) {
+    score += 10;
+  }
+  if (
+    normalizedName.includes("toggle") ||
+    normalizedName.includes("refresh") ||
+    normalizedName.includes("load")
+  ) {
+    score -= 10;
+  }
+
+  for (const parameter of parameters) {
+    const target = `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`.toLowerCase();
+    if (target.includes("prompt") || target.includes("text")) score += 2;
+    if (
+      target.includes("reference audio") ||
+      target.includes("ref audio") ||
+      target.includes("ref_audio")
+    ) {
+      score += 4;
+    }
+  }
+
+  return score;
+}
+
+function resolveApiCandidates(
+  apiInfo: ViewApiResponse | null,
+  requestedApiName: string,
+  outputTypesByApiName?: Map<string, string[]>,
+) {
+  const namedEndpoints = apiInfo?.named_endpoints ?? {};
+  const entries = Object.entries(namedEndpoints);
+  if (!entries.length) {
+    return [normalizeApiName(requestedApiName)];
+  }
+
+  const normalizedRequested = normalizeApiName(requestedApiName);
+  const scoredCandidates = entries
+    .map(([name, endpoint]) => ({
+      name,
+      score: scoreEndpointCandidate(
+        name,
+        endpoint,
+        outputTypesByApiName?.get(normalizeApiKey(name)) ?? [],
+      ),
+    }))
+    .sort((left, right) => right.score - left.score);
+
+  const ordered: string[] = [];
+  const requestedCandidate = scoredCandidates.find(
+    ({ name }) => normalizeApiName(name) === normalizedRequested,
+  );
+  if (requestedCandidate) {
+    ordered.push(requestedCandidate.name);
+  }
+
+  for (const candidate of scoredCandidates) {
+    if (!ordered.includes(candidate.name)) {
+      ordered.push(candidate.name);
+    }
+  }
+
+  return ordered;
+}
+
+function classifyPredictError(error: unknown) {
+  const message = extractErrorText(error).toLowerCase();
+  if (!message) return null;
+
+  const parameterIndicators = [
+    "unexpected keyword",
+    "unknown argument",
+    "missing required positional argument",
+    "missing 1 required positional argument",
+    "got multiple values",
+    "invalid parameter",
+    "required argument",
+  ];
+  if (parameterIndicators.some((indicator) => message.includes(indicator))) {
+    return "HF_SPACE_PARAMETER_INVALID";
+  }
+
+  const endpointIndicators = ["api_name", "endpoint", "function", "not found", "404"];
+  if (endpointIndicators.some((indicator) => message.includes(indicator))) {
+    return "HF_SPACE_ENDPOINT_INVALID";
+  }
+
+  return null;
 }
 
 function normalizeLookupKey(parameter: EndpointParameter) {
@@ -384,16 +558,34 @@ function resolveParamValue(
   return parameter.parameter_default;
 }
 
-async function buildRequestPayload(
-  client: Client,
+function buildRequestPayload(
+  apiInfo: ViewApiResponse | null,
   apiName: string,
   payload: AudioGenerationFormValues,
   defaults: ReturnType<typeof resolveRuntimeAudioDefaults>,
   speed: number,
   seed: { seedValue: number; randomize: boolean },
 ) {
-  const endpoint = await getEndpointInfo(client, apiName);
-  const parameters = endpoint?.parameters;
+  const endpoint = getEndpointInfoFromSnapshot(apiInfo, apiName);
+  const parameters =
+    endpoint?.parameters?.filter(
+      (parameter) => {
+        const parameterName =
+          typeof parameter.parameter_name === "string"
+            ? parameter.parameter_name.trim()
+            : "";
+        const component =
+          typeof parameter.component === "string"
+            ? parameter.component.trim().toLowerCase()
+            : "";
+
+        return (
+          parameterName.length > 0 &&
+          parameter.hidden !== true &&
+          component !== "state"
+        );
+      },
+    ) ?? [];
 
   if (!parameters?.length) {
     const fallbackPayload: Record<string, unknown> = {
@@ -459,11 +651,8 @@ async function buildRequestPayload(
 
   const requestPayload: Record<string, unknown> = {};
 
-  parameters.forEach((parameter, index) => {
-    const key =
-      typeof parameter.parameter_name === "string" && parameter.parameter_name.trim()
-        ? parameter.parameter_name
-        : `param_${index}`;
+  parameters.forEach((parameter) => {
+    const key = parameter.parameter_name!.trim();
 
     requestPayload[key] = resolveParamValue(
       parameter,
@@ -607,6 +796,12 @@ export const hfSpaceAudioAdapter: AudioGenerationAdapter = {
     if (lower === "hf_space_response_invalid") {
       return "HF Space 응답에서 오디오 결과를 찾지 못했습니다.";
     }
+    if (lower === "hf_space_endpoint_invalid") {
+      return "HF Space 생성 엔드포인트를 찾지 못했습니다. 모델 구성을 다시 가져오세요.";
+    }
+    if (lower === "hf_space_parameter_invalid") {
+      return "HF Space 입력 파라미터가 현재 엔드포인트와 맞지 않습니다. 모델 구성을 다시 가져오세요.";
+    }
     if (lower === "hf_space_config_invalid") {
       return "오디오 모델 설정이 올바르지 않습니다.";
     }
@@ -665,82 +860,104 @@ export const hfSpaceAudioAdapter: AudioGenerationAdapter = {
     const { config, model } = await getSpaceConfig(payload.model);
     await ensureSpaceRunning(config);
     const client = await getClient(config);
+    const apiInfo = (await client.view_api().catch(() => null)) as ViewApiResponse | null;
+    const outputTypesByApiName = buildOutputTypesByApiName(
+      (client as Client & { config?: ClientConfigSnapshot }).config,
+    );
 
     const defaults = resolveRuntimeAudioDefaults(model);
     const speedRange = getRuntimeAudioParamRange(model, "speed");
     const speed = clampNumber(payload.speed ?? defaults.speed, speedRange);
     const seed = parseSeed(payload.seed);
-    const apiName = normalizeApiName(config.apiName || "/generate_audio");
-
-    const requestPayload = await buildRequestPayload(
-      client,
-      apiName,
-      payload,
-      defaults,
-      speed,
-      seed,
+    const apiCandidates = resolveApiCandidates(
+      apiInfo,
+      config.apiName || "/generate_audio",
+      outputTypesByApiName,
     );
 
-    const predictPromise = client.predict(apiName, requestPayload);
+    let lastRetryableError: Error | null = null;
 
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(
-        () => reject(new Error("HF_SPACE_REQUEST_TIMEOUT")),
-        config.timeoutMs,
+    for (const apiName of apiCandidates) {
+      const requestPayload = buildRequestPayload(
+        apiInfo,
+        apiName,
+        payload,
+        defaults,
+        speed,
+        seed,
       );
-    });
 
-    let result: Awaited<typeof predictPromise>;
-    try {
-      result = await Promise.race([predictPromise, timeoutPromise]);
-    } finally {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    }
+      const predictPromise = client.predict(apiName, requestPayload);
 
-    const rawData = Array.isArray(result?.data) ? result.data : result;
-    const audioGroups = resolveHfSpaceFileReferenceCandidates(rawData, {
-      spaceUrl: config.spaceUrl,
-      matcher: looksLikeAudioPath,
-      maxDepth: 4,
-    });
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error("HF_SPACE_REQUEST_TIMEOUT")),
+          config.timeoutMs,
+        );
+      });
 
-    if (audioGroups.length === 0) {
-      throw new Error("HF_SPACE_RESPONSE_INVALID");
-    }
-
-    const dataUrls: string[] = [];
-    for (const group of audioGroups) {
-      let lastError: Error | null = null;
-      let resolvedDataUrl: string | null = null;
-
-      for (const candidate of group.candidates) {
-        try {
-          resolvedDataUrl = await fetchAudioDataUrl(
-            candidate,
-            config.spaceUrl,
-            Math.min(config.timeoutMs, FILE_FETCH_TIMEOUT_MS),
-          );
-          break;
-        } catch (error) {
-          lastError = error instanceof Error ? error : new Error(String(error));
+      let result: Awaited<typeof predictPromise>;
+      try {
+        result = await Promise.race([predictPromise, timeoutPromise]);
+      } catch (error) {
+        const classified = classifyPredictError(error);
+        if (classified) {
+          lastRetryableError = new Error(classified);
+          continue;
+        }
+        throw error;
+      } finally {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
         }
       }
 
-      if (!resolvedDataUrl) {
-        throw lastError ?? new Error("HF_SPACE_AUDIO_FETCH_FAILED");
+      const rawData = Array.isArray(result?.data) ? result.data : result;
+      const audioGroups = resolveHfSpaceFileReferenceCandidates(rawData, {
+        spaceUrl: config.spaceUrl,
+        matcher: looksLikeAudioPath,
+        maxDepth: 4,
+      });
+
+      if (audioGroups.length === 0) {
+        lastRetryableError = new Error("HF_SPACE_RESPONSE_INVALID");
+        continue;
       }
 
-      dataUrls.push(resolvedDataUrl);
+      const dataUrls: string[] = [];
+      for (const group of audioGroups) {
+        let lastError: Error | null = null;
+        let resolvedDataUrl: string | null = null;
+
+        for (const candidate of group.candidates) {
+          try {
+            resolvedDataUrl = await fetchAudioDataUrl(
+              candidate,
+              config.spaceUrl,
+              Math.min(config.timeoutMs, FILE_FETCH_TIMEOUT_MS),
+            );
+            break;
+          } catch (error) {
+            lastError = error instanceof Error ? error : new Error(String(error));
+          }
+        }
+
+        if (!resolvedDataUrl) {
+          throw lastError ?? new Error("HF_SPACE_AUDIO_FETCH_FAILED");
+        }
+
+        dataUrls.push(resolvedDataUrl);
+      }
+
+      return {
+        audios: dataUrls,
+        meta: {
+          duration_sec: extractDurationSec(rawData),
+        },
+      };
     }
 
-    return {
-      audios: dataUrls,
-      meta: {
-        duration_sec: extractDurationSec(rawData),
-      },
-    };
+    throw lastRetryableError ?? new Error("HF_SPACE_API_NOT_FOUND");
   },
 };

--- a/src/server/hf-space/endpoint-scoring.test.ts
+++ b/src/server/hf-space/endpoint-scoring.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { hasAudioEndpointSignal } from "@/server/hf-space/endpoint-scoring";
+
+describe("hasAudioEndpointSignal", () => {
+  it("learning_rate나 bitrate 같은 일반 rate 파라미터는 audio signal로 오인하지 않는다", () => {
+    expect(
+      hasAudioEndpointSignal({
+        parameters: [
+          { parameter_name: "learning_rate", label: "Learning Rate" },
+          { parameter_name: "bitrate", label: "Bitrate" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("voice/speed 같은 실제 오디오 제어 파라미터는 audio signal로 유지한다", () => {
+    expect(
+      hasAudioEndpointSignal({
+        parameters: [
+          { parameter_name: "speaker", label: "Speaker" },
+          { parameter_name: "generation_speed", label: "Generation Speed" },
+        ],
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/server/hf-space/endpoint-scoring.ts
+++ b/src/server/hf-space/endpoint-scoring.ts
@@ -1,0 +1,75 @@
+type EndpointScoringParameter = {
+  parameter_name?: string;
+  label?: string;
+};
+
+type EndpointScoringEndpoint = {
+  parameters?: EndpointScoringParameter[];
+};
+
+export function hasAudioEndpointSignal(
+  endpoint: EndpointScoringEndpoint | undefined,
+) {
+  const parameters = endpoint?.parameters ?? [];
+  return parameters.some((parameter) => {
+    const target = `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`.toLowerCase();
+    return (
+      target.includes("reference audio") ||
+      target.includes("ref audio") ||
+      target.includes("ref_audio") ||
+      target.includes("input audio") ||
+      target.includes("input_audio") ||
+      target.includes("voice") ||
+      target.includes("speaker") ||
+      target.includes("spk") ||
+      target.includes("speed") ||
+      target.includes("rate")
+    );
+  });
+}
+
+export function scoreEndpointCandidate(
+  apiName: string,
+  endpoint: EndpointScoringEndpoint | undefined,
+  outputTypes: string[],
+) {
+  const normalizedName = apiName.toLowerCase();
+  const parameters = endpoint?.parameters ?? [];
+  let score = 0;
+
+  if (outputTypes.some((type) => type.includes("audio"))) {
+    score += 10;
+  }
+  if (hasAudioEndpointSignal(endpoint)) {
+    score += 10;
+  }
+  if (
+    normalizedName.includes("run") ||
+    normalizedName.includes("generate") ||
+    normalizedName.includes("predict") ||
+    normalizedName.includes("synth")
+  ) {
+    score += 10;
+  }
+  if (
+    normalizedName.includes("toggle") ||
+    normalizedName.includes("refresh") ||
+    normalizedName.includes("load")
+  ) {
+    score -= 10;
+  }
+
+  for (const parameter of parameters) {
+    const target = `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`.toLowerCase();
+    if (target.includes("prompt") || target.includes("text")) score += 2;
+    if (
+      target.includes("reference audio") ||
+      target.includes("ref audio") ||
+      target.includes("ref_audio")
+    ) {
+      score += 4;
+    }
+  }
+
+  return score;
+}

--- a/src/server/hf-space/endpoint-scoring.ts
+++ b/src/server/hf-space/endpoint-scoring.ts
@@ -12,7 +12,19 @@ export function hasAudioEndpointSignal(
 ) {
   const parameters = endpoint?.parameters ?? [];
   return parameters.some((parameter) => {
-    const target = `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`.toLowerCase();
+    const rawTargets = [parameter.parameter_name ?? "", parameter.label ?? ""]
+      .map((value) => value.toLowerCase().trim())
+      .filter(Boolean);
+    const normalizedTargets = rawTargets.map((value) => value.replace(/[_-]+/g, " "));
+    const tokenLists = normalizedTargets.map((value) =>
+      value.split(/[^a-z0-9]+/).filter(Boolean),
+    );
+    const hasSpeedSignal = tokenLists.some((tokens) => tokens.includes("speed"));
+    const hasStandaloneRate = normalizedTargets.some((value) => value === "rate");
+    const hasExplicitAudioRate = normalizedTargets.some((value) =>
+      /\b(audio|speech|voice)\s+rate\b/.test(value),
+    );
+    const target = normalizedTargets.join(" ");
     return (
       target.includes("reference audio") ||
       target.includes("ref audio") ||
@@ -22,8 +34,9 @@ export function hasAudioEndpointSignal(
       target.includes("voice") ||
       target.includes("speaker") ||
       target.includes("spk") ||
-      target.includes("speed") ||
-      target.includes("rate")
+      hasSpeedSignal ||
+      hasStandaloneRate ||
+      hasExplicitAudioRate
     );
   });
 }

--- a/src/server/model-catalog/space-importer.test.ts
+++ b/src/server/model-catalog/space-importer.test.ts
@@ -339,4 +339,58 @@ describe("importModelDraftFromSpace", () => {
       default: 1.1,
     });
   });
+
+  it("명시한 apiName이 없으면 UNKNOWN_REQUESTED_API_NAME warning을 남기고 점수 기반 fallback을 사용한다", async () => {
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/toggle_mode": {
+            parameters: [{ parameter_name: "mode", label: "Generation Mode" }],
+          },
+          "/run_generation": {
+            parameters: [
+              { parameter_name: "text", label: "Text" },
+              { parameter_name: "ref_audio_path", label: "Reference Audio" },
+            ],
+          },
+        },
+      }),
+      config: {
+        space_id: "leey00nsu/qwen-3.5-tts-faster-gradio",
+        title: "Faster Qwen3 TTS",
+        components: [
+          { id: 1, type: "textbox", props: { label: "Text", lines: 4 } },
+          { id: 2, type: "audio", props: { label: "Reference Audio" } },
+          { id: 3, type: "audio", props: { label: "Generated Audio" } },
+        ],
+        dependencies: [
+          {
+            api_name: "/toggle_mode",
+            inputs: [1],
+            outputs: [],
+          },
+          {
+            api_name: "/run_generation",
+            inputs: [1, 2],
+            outputs: [3],
+          },
+        ],
+      },
+    });
+
+    const { importModelDraftFromSpace } = await import(
+      "@/server/model-catalog/space-importer"
+    );
+
+    const result = await importModelDraftFromSpace({
+      spaceUrl:
+        "https://huggingface.co/spaces/leey00nsu/qwen-3.5-tts-faster-gradio",
+      apiName: "/missing_endpoint",
+    });
+
+    expect(result.resolvedApiName).toBe("/run_generation");
+    expect(result.warnings).toContain(
+      "UNKNOWN_REQUESTED_API_NAME:/missing_endpoint",
+    );
+  });
 });

--- a/src/server/model-catalog/space-importer.ts
+++ b/src/server/model-catalog/space-importer.ts
@@ -1,5 +1,8 @@
 import { Client } from "@gradio/client";
 import {
+  scoreEndpointCandidate,
+} from "@/server/hf-space/endpoint-scoring";
+import {
   normalizeRuntimeParameterOptions,
   type RuntimeParameterOptionInput,
 } from "@/shared/model-catalog/parameter-options";
@@ -118,25 +121,6 @@ function normalizeApiName(name: string) {
 
 function normalizeKey(value: string) {
   return value.trim().toLowerCase().replace(/\s+/g, "");
-}
-
-function hasAudioEndpointSignal(endpoint: EndpointInfo | undefined) {
-  const parameters = endpoint?.parameters ?? [];
-  return parameters.some((parameter) => {
-    const target = `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`.toLowerCase();
-    return (
-      target.includes("reference audio") ||
-      target.includes("ref audio") ||
-      target.includes("ref_audio") ||
-      target.includes("input audio") ||
-      target.includes("input_audio") ||
-      target.includes("voice") ||
-      target.includes("speaker") ||
-      target.includes("spk") ||
-      target.includes("speed") ||
-      target.includes("rate")
-    );
-  });
 }
 
 function resolveParamKey(label?: string, paramName?: string, type?: string) {
@@ -352,48 +336,6 @@ function getDefaultFromParam(param?: ParameterConfig) {
   return param?.default;
 }
 
-function scoreEndpoint(
-  apiName: string,
-  endpoint: EndpointInfo | undefined,
-  outputTypes: string[],
-) {
-  const normalizedName = apiName.toLowerCase();
-  const parameters = endpoint?.parameters ?? [];
-  let score = 0;
-
-  if (outputTypes.some((type) => type.includes("audio"))) score += 10;
-  if (hasAudioEndpointSignal(endpoint)) score += 10;
-  if (
-    normalizedName.includes("run") ||
-    normalizedName.includes("generate") ||
-    normalizedName.includes("predict") ||
-    normalizedName.includes("synth")
-  ) {
-    score += 10;
-  }
-  if (
-    normalizedName.includes("toggle") ||
-    normalizedName.includes("refresh") ||
-    normalizedName.includes("load")
-  ) {
-    score -= 10;
-  }
-
-  for (const parameter of parameters) {
-    const target = `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`.toLowerCase();
-    if (target.includes("prompt") || target.includes("text")) score += 2;
-    if (
-      target.includes("reference audio") ||
-      target.includes("ref audio") ||
-      target.includes("ref_audio")
-    ) {
-      score += 4;
-    }
-  }
-
-  return score;
-}
-
 async function connectWithTimeout(
   spaceRef: string,
   clientOptions?: Parameters<typeof Client.connect>[1],
@@ -473,14 +415,14 @@ export async function importModelDraftFromSpace(
   const requested = payload.apiName ? normalizeApiName(payload.apiName) : "";
   const resolvedApiName =
     requested && apiNames.includes(requested)
-      ? requested
-      : [...apiNames].sort((left, right) => {
-          const leftScore = scoreEndpoint(
+        ? requested
+        : [...apiNames].sort((left, right) => {
+          const leftScore = scoreEndpointCandidate(
             left,
             named[left] ?? named[left.replace(/^\//, "")],
             outputTypesByApiName.get(left) ?? [],
           );
-          const rightScore = scoreEndpoint(
+          const rightScore = scoreEndpointCandidate(
             right,
             named[right] ?? named[right.replace(/^\//, "")],
             outputTypesByApiName.get(right) ?? [],

--- a/src/server/model-catalog/space-importer.ts
+++ b/src/server/model-catalog/space-importer.ts
@@ -412,7 +412,11 @@ export async function importModelDraftFromSpace(
     outputTypesByApiName.set(apiName, outputTypes);
   }
 
+  const warnings: string[] = [];
   const requested = payload.apiName ? normalizeApiName(payload.apiName) : "";
+  if (requested && !apiNames.includes(requested)) {
+    warnings.push(`UNKNOWN_REQUESTED_API_NAME:${requested}`);
+  }
   const resolvedApiName =
     requested && apiNames.includes(requested)
         ? requested
@@ -444,7 +448,6 @@ export async function importModelDraftFromSpace(
   const outputTypes = outputTypesByApiName.get(resolvedApiName) ?? [];
 
   const parameters: Record<string, ParameterConfig> = {};
-  const warnings: string[] = [];
   let hasVideoParam = false;
   let hasAudioParam = false;
   let hasImageInput = false;

--- a/src/server/model-catalog/space-importer.ts
+++ b/src/server/model-catalog/space-importer.ts
@@ -120,6 +120,25 @@ function normalizeKey(value: string) {
   return value.trim().toLowerCase().replace(/\s+/g, "");
 }
 
+function hasAudioEndpointSignal(endpoint: EndpointInfo | undefined) {
+  const parameters = endpoint?.parameters ?? [];
+  return parameters.some((parameter) => {
+    const target = `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`.toLowerCase();
+    return (
+      target.includes("reference audio") ||
+      target.includes("ref audio") ||
+      target.includes("ref_audio") ||
+      target.includes("input audio") ||
+      target.includes("input_audio") ||
+      target.includes("voice") ||
+      target.includes("speaker") ||
+      target.includes("spk") ||
+      target.includes("speed") ||
+      target.includes("rate")
+    );
+  });
+}
+
 function resolveParamKey(label?: string, paramName?: string, type?: string) {
   const target = `${label ?? ""} ${paramName ?? ""}`.toLowerCase();
   if (
@@ -343,6 +362,7 @@ function scoreEndpoint(
   let score = 0;
 
   if (outputTypes.some((type) => type.includes("audio"))) score += 10;
+  if (hasAudioEndpointSignal(endpoint)) score += 10;
   if (
     normalizedName.includes("run") ||
     normalizedName.includes("generate") ||


### PR DESCRIPTION
# PR Draft: audio-qwen-tts-bugfix

## 개요

- 변경 목적:
  - HF Space audio runtime이 stale `api_name`, hidden/internal parameter, endpoint scoring drift 때문에 실패하던 경로를 복구한다.
- 사용자 영향:
  - Qwen TTS HF Space 계열 모델 등록/생성 시 endpoint 선택과 payload 구성이 더 안정적으로 동작한다.

## 변경 사항

- [x] runtime fallback이 importer와 같은 audio-output-aware endpoint scoring을 사용하도록 정렬
- [x] `generate()` 요청 1회당 `view_api()` metadata를 한 번만 읽고 후보 선택과 payload 구성에서 재사용
- [x] model-management audio draft 기본 endpoint를 `/run_generation`으로 조정
- [x] stale `api_name`, hidden/internal parameter, response-shape mismatch 회귀 테스트 추가

## 테스트

- [x] `pnpm vitest run src/server/audio-generation/adapters/hf-space-adapter.test.ts src/server/model-catalog/space-importer.test.ts src/screens/model-management/ui/model-management-screen.test.tsx`

## 아키텍처 다이어그램

```mermaid
sequenceDiagram
  participant UI as Model Management UI
  participant API as App API
  participant Runtime as HF Space Runtime Adapter
  participant Space as Hugging Face Space
  UI->>API: 모델 저장/오디오 생성 요청
  API->>Runtime: endpoint metadata 조회
  Runtime->>Runtime: audio-output-aware scoring / payload 정규화
  Runtime->>Space: 선택된 생성 endpoint 호출
  Space-->>Runtime: audio response
  Runtime-->>API: normalized generation result
  API-->>UI: 생성 결과 반환
```

## 관련 문서

- Spec: `docs/.../spec.md`
- Tasks: `docs/.../tasks.md`
- Decisions: `docs/.../decisions.md`

Closes #85


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 기본 오디오 엔드포인트 값 변경 및 화면 기본값 동기화 ("/generate_audio" → "/run_generation")
  * 생성 실패 시 타 엔드포인트로의 재시도·폴백 동작 보강
  * 응답 유효성 검사 강화로 비오디오 응답 거부 처리

* **신규 기능**
  * 엔드포인트 우선순위(스코어링) 기반 선택 도입
  * 요청 파라미터 가시성 기준 필터링 적용
  * 오류 분류 및 사용자용 메시지 개선

* **테스트**
  * 엔드포인트 제어흐름·파라미터·기본값 관련 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->