### PR TITLE
feat(#89): codex-image-bridge-provider (F046-codex-image-bridge-provider 구현)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,3 +104,5 @@ CODEX_IMAGE_BRIDGE_URL=
 
 # Codex image bridge bearer token
 CODEX_IMAGE_BRIDGE_TOKEN=
+
+# Bridge 호출 timeout은 모델 카탈로그 provider_config.timeout_ms에서 관리합니다.

--- a/.env.example
+++ b/.env.example
@@ -99,7 +99,7 @@ HF_TOKEN=
 # CODEX_IMAGE_BRIDGE_TOKEN은 bridge 서비스의 CODEX_BRIDGE_TOKEN과 같은 값이어야 합니다.
 # ------------------------------------------------------------------------------
 
-# Codex image bridge base URL (예: http://codex-image-bridge-xxxxx:18080)
+# Codex image bridge origin/root URL, path 제외 (예: http://codex-image-bridge-xxxxx:18080)
 CODEX_IMAGE_BRIDGE_URL=
 
 # Codex image bridge bearer token

--- a/.env.example
+++ b/.env.example
@@ -92,3 +92,15 @@ HF_TOKEN=
 
 # Codex CLI 인증 홈 (선택)
 # CODEX_HOME=
+
+# ------------------------------------------------------------------------------
+# Codex Image Bridge 이미지 생성 (GPT Image 2)
+# 메인 앱 컨테이너에 Codex CLI/OAuth를 넣지 않고 별도 codex-image-bridge 서비스로 위임할 때 사용합니다.
+# CODEX_IMAGE_BRIDGE_TOKEN은 bridge 서비스의 CODEX_BRIDGE_TOKEN과 같은 값이어야 합니다.
+# ------------------------------------------------------------------------------
+
+# Codex image bridge base URL (예: http://codex-image-bridge-xxxxx:18080)
+CODEX_IMAGE_BRIDGE_URL=
+
+# Codex image bridge bearer token
+CODEX_IMAGE_BRIDGE_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,7 @@ HF_TOKEN=
 # Codex Image Bridge 이미지 생성 (GPT Image 2)
 # 메인 앱 컨테이너에 Codex CLI/OAuth를 넣지 않고 별도 codex-image-bridge 서비스로 위임할 때 사용합니다.
 # CODEX_IMAGE_BRIDGE_TOKEN은 bridge 서비스의 CODEX_BRIDGE_TOKEN과 같은 값이어야 합니다.
+# public proxy timeout을 피하기 위해 앱은 bridge async job API를 polling합니다.
 # ------------------------------------------------------------------------------
 
 # Codex image bridge origin/root URL, path 제외 (예: http://codex-image-bridge-xxxxx:18080)

--- a/MODEL_CATALOG.md
+++ b/MODEL_CATALOG.md
@@ -64,7 +64,7 @@
 }
 ```
 
-`base_url_env`와 `token_env`는 env 이름만 저장합니다. 실제 token 값은 모델 카탈로그/DB에 저장하지 않습니다. `codex_bridge` providerConfig는 위 필드 외의 추가 값을 거부합니다. 호출 timeout은 `timeout_ms`로 모델 카탈로그에서 관리하며, Bridge 서비스는 `POST /v1/images/generate`를 제공하고 data URL 이미지를 반환해야 합니다.
+`base_url_env`와 `token_env`는 env 이름만 저장합니다. 실제 token 값은 모델 카탈로그/DB에 저장하지 않습니다. `codex_bridge` providerConfig는 위 필드 외의 추가 값을 거부합니다. 호출 timeout은 `timeout_ms`로 모델 카탈로그에서 관리하며, `CODEX_IMAGE_BRIDGE_URL`은 path 없는 `http(s)` origin/root URL이어야 합니다. Bridge 서비스는 `POST /v1/images/generate`를 제공하고 data URL 이미지를 반환해야 합니다.
 
 ## 스키마 확장 가이드
 

--- a/MODEL_CATALOG.md
+++ b/MODEL_CATALOG.md
@@ -64,7 +64,7 @@
 }
 ```
 
-`base_url_env`와 `token_env`는 env 이름만 저장합니다. 실제 token 값은 모델 카탈로그/DB에 저장하지 않습니다. `codex_bridge` providerConfig는 위 필드 외의 추가 값을 거부합니다. 호출 timeout은 `timeout_ms`로 모델 카탈로그에서 관리하며, `CODEX_IMAGE_BRIDGE_URL`은 path 없는 `http(s)` origin/root URL이어야 합니다. Bridge 서비스는 `POST /v1/images/generate`를 제공하고 data URL 이미지를 반환해야 합니다.
+`base_url_env`와 `token_env`는 env 이름만 저장합니다. 실제 token 값은 모델 카탈로그/DB에 저장하지 않습니다. `codex_bridge` providerConfig는 위 필드 외의 추가 값을 거부합니다. 호출 timeout은 `timeout_ms`로 모델 카탈로그에서 관리하며, `CODEX_IMAGE_BRIDGE_URL`은 path 없는 `http(s)` origin/root URL이어야 합니다. Bridge 서비스는 `POST /v1/images/jobs`와 `GET /v1/images/jobs/{jobId}`를 제공하고, completed job에서 data URL 이미지를 반환해야 합니다.
 
 ## 스키마 확장 가이드
 

--- a/MODEL_CATALOG.md
+++ b/MODEL_CATALOG.md
@@ -7,7 +7,10 @@
 
 - **type**: `image` | `video`
 - **key / label / vendor / provider**
-- **providerConfig**: `hf_space` 설정 (예: `space_id`, `api_name`, `timeout_ms`)
+- **providerConfig**: provider별 설정
+  - `hf_space`: `space_id`, `api_name`, `timeout_ms`
+  - `codex_cli`: `command`, `model_id`, `agent_model`, `timeout_ms`
+  - `codex_bridge`: `base_url_env`, `token_env`, `model_id`, `agent_model`, `timeout_ms`
 - **parameters**: UI 및 검증 파라미터 정의
 - **meta**: 기본값/제약/모달리티 정보
 
@@ -44,6 +47,24 @@
 
 - **이미지**: `max_input_images > 0` 이면 `I2I` 추가, 기본은 `T2I`
 - **비디오**: `supports_init_image` 또는 `i2v_model_id`가 있으면 `I2V`, `t2v_model_id`가 있으면 `T2V`
+
+## Codex bridge provider
+
+`codex_bridge`는 메인 앱 컨테이너에서 Codex CLI를 직접 실행하지 않고 별도 `codex-image-bridge` HTTP 서비스에 이미지 생성을 위임하는 image-only provider입니다.
+
+예시 providerConfig:
+
+```json
+{
+  "base_url_env": "CODEX_IMAGE_BRIDGE_URL",
+  "token_env": "CODEX_IMAGE_BRIDGE_TOKEN",
+  "model_id": "gpt-image-2",
+  "agent_model": "gpt-5.5",
+  "timeout_ms": 300000
+}
+```
+
+`base_url_env`와 `token_env`는 env 이름만 저장합니다. 실제 token 값은 모델 카탈로그/DB에 저장하지 않습니다. Bridge 서비스는 `POST /v1/images/generate`를 제공하고 data URL 이미지를 반환해야 합니다.
 
 ## 스키마 확장 가이드
 

--- a/MODEL_CATALOG.md
+++ b/MODEL_CATALOG.md
@@ -64,7 +64,7 @@
 }
 ```
 
-`base_url_env`와 `token_env`는 env 이름만 저장합니다. 실제 token 값은 모델 카탈로그/DB에 저장하지 않습니다. Bridge 서비스는 `POST /v1/images/generate`를 제공하고 data URL 이미지를 반환해야 합니다.
+`base_url_env`와 `token_env`는 env 이름만 저장합니다. 실제 token 값은 모델 카탈로그/DB에 저장하지 않습니다. `codex_bridge` providerConfig는 위 필드 외의 추가 값을 거부합니다. 호출 timeout은 `timeout_ms`로 모델 카탈로그에서 관리하며, Bridge 서비스는 `POST /v1/images/generate`를 제공하고 data URL 이미지를 반환해야 합니다.
 
 ## 스키마 확장 가이드
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ pnpm dev
 4. 모델 카탈로그(DB) 갱신
 5. 필요 시 `.env.example`에 새 제공자 설정 추가
 
-`codex_bridge` provider는 별도 `codex-image-bridge` 서비스가 Codex CLI/OAuth를 소유하는 운영 구성을 위한 provider입니다. leesfield 앱에는 `CODEX_IMAGE_BRIDGE_URL`과 `CODEX_IMAGE_BRIDGE_TOKEN`만 설정하면 되고, 메인 앱 컨테이너에 `codex` CLI를 설치할 필요가 없습니다.
+`codex_bridge` provider는 별도 `codex-image-bridge` 서비스가 Codex CLI/OAuth를 소유하는 운영 구성을 위한 provider입니다. leesfield 앱에는 `CODEX_IMAGE_BRIDGE_URL`과 `CODEX_IMAGE_BRIDGE_TOKEN`만 설정하면 되고, 메인 앱 컨테이너에 `codex` CLI를 설치할 필요가 없습니다. `CODEX_IMAGE_BRIDGE_URL`은 path 없는 `http(s)` origin/root URL이어야 하며, 앱이 `/v1/images/generate`를 붙여 호출합니다.
 
 #### 2) 저장소 어댑터 (이미지/비디오/오디오 업로드)
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ pnpm dev
 4. 모델 카탈로그(DB) 갱신
 5. 필요 시 `.env.example`에 새 제공자 설정 추가
 
-`codex_bridge` provider는 별도 `codex-image-bridge` 서비스가 Codex CLI/OAuth를 소유하는 운영 구성을 위한 provider입니다. leesfield 앱에는 `CODEX_IMAGE_BRIDGE_URL`과 `CODEX_IMAGE_BRIDGE_TOKEN`만 설정하면 되고, 메인 앱 컨테이너에 `codex` CLI를 설치할 필요가 없습니다. `CODEX_IMAGE_BRIDGE_URL`은 path 없는 `http(s)` origin/root URL이어야 하며, 앱이 `/v1/images/generate`를 붙여 호출합니다.
+`codex_bridge` provider는 별도 `codex-image-bridge` 서비스가 Codex CLI/OAuth를 소유하는 운영 구성을 위한 provider입니다. leesfield 앱에는 `CODEX_IMAGE_BRIDGE_URL`과 `CODEX_IMAGE_BRIDGE_TOKEN`만 설정하면 되고, 메인 앱 컨테이너에 `codex` CLI를 설치할 필요가 없습니다. `CODEX_IMAGE_BRIDGE_URL`은 path 없는 `http(s)` origin/root URL이어야 하며, 앱은 `/v1/images/jobs`로 job을 만든 뒤 `/v1/images/jobs/{jobId}`를 polling합니다.
 
 #### 2) 저장소 어댑터 (이미지/비디오/오디오 업로드)
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ pnpm dev
 
 현재 구현된 provider:
 
-- 이미지: `hf_space`
+- 이미지: `hf_space`, `codex_cli`, `codex_bridge`
 - 비디오: `hf_space`
 
 설정/선택:
@@ -166,6 +166,8 @@ pnpm dev
 3. `image-generation.ts` / `video-generation.ts`에서 제공자 분기 추가
 4. 모델 카탈로그(DB) 갱신
 5. 필요 시 `.env.example`에 새 제공자 설정 추가
+
+`codex_bridge` provider는 별도 `codex-image-bridge` 서비스가 Codex CLI/OAuth를 소유하는 운영 구성을 위한 provider입니다. leesfield 앱에는 `CODEX_IMAGE_BRIDGE_URL`과 `CODEX_IMAGE_BRIDGE_TOKEN`만 설정하면 되고, 메인 앱 컨테이너에 `codex` CLI를 설치할 필요가 없습니다.
 
 #### 2) 저장소 어댑터 (이미지/비디오/오디오 업로드)
 
@@ -220,8 +222,7 @@ pnpm dev
 ### 외부 API 사용
 
 모델별 `provider` 값에 따라 API 호출 어댑터가 선택됩니다.
-현재 구현된 호출 어댑터는 `hf_space`이며, Space ID/엔드포인트는
-모델 카탈로그(DB)에서 관리합니다.
+현재 이미지 호출 어댑터는 `hf_space`, `codex_cli`, `codex_bridge`이며, provider별 설정은 모델 카탈로그(DB)에서 관리합니다. `codex_bridge` token 값은 DB가 아니라 env로만 읽습니다.
 
 외부 API 엔드포인트:
 

--- a/configs/image-models.json
+++ b/configs/image-models.json
@@ -184,6 +184,63 @@
       "default_steps": 1,
       "concurrent_limit": 1,
       "max_input_images": 1
+    },
+    {
+      "key": "gpt-image-2-bridge",
+      "label": "GPT Image 2 Bridge",
+      "vendor": "OPENAI",
+      "provider": "codex_bridge",
+      "pipeline": "image_generation",
+      "model_id": "gpt-image-2",
+      "provider_config": {
+        "base_url_env": "CODEX_IMAGE_BRIDGE_URL",
+        "token_env": "CODEX_IMAGE_BRIDGE_TOKEN",
+        "model_id": "gpt-image-2",
+        "agent_model": "gpt-5.5",
+        "timeout_ms": 300000
+      },
+      "parameters": {
+        "prompt": {
+          "ui": "textarea",
+          "required": true
+        },
+        "width": {
+          "ui": "hidden",
+          "min": 1024,
+          "max": 1024,
+          "step": 1,
+          "default": 1024
+        },
+        "height": {
+          "ui": "hidden",
+          "min": 1024,
+          "max": 1024,
+          "step": 1,
+          "default": 1024
+        },
+        "steps": {
+          "ui": "hidden",
+          "min": 1,
+          "max": 1,
+          "step": 1,
+          "default": 1
+        },
+        "seed": {
+          "ui": "hidden",
+          "default": ""
+        },
+        "imageCount": {
+          "ui": "hidden",
+          "min": 1,
+          "max": 1,
+          "default": 1
+        }
+      },
+      "default_width": 1024,
+      "default_height": 1024,
+      "default_steps": 1,
+      "concurrent_limit": 1,
+      "max_input_images": 1
     }
   ]
 }

--- a/src/features/image-generation/model/image-generation-schema.test.ts
+++ b/src/features/image-generation/model/image-generation-schema.test.ts
@@ -80,14 +80,20 @@ describe("image-generation-schema", () => {
     const gptImageModel = imageModels.find(
       (model) => model.key === "gpt-image-2-codex",
     );
+    const bridgeImageModel = imageModels.find(
+      (model) => model.key === "gpt-image-2-bridge",
+    );
     expect(gptImageModel).toBeDefined();
-    if (!gptImageModel) return;
+    expect(bridgeImageModel).toBeDefined();
+    if (!gptImageModel || !bridgeImageModel) return;
 
-    expect(gptImageModel.parameters.width.ui).toBe("hidden");
-    expect(gptImageModel.parameters.height.ui).toBe("hidden");
-    expect(gptImageModel.parameters.steps.ui).toBe("hidden");
-    expect(gptImageModel.parameters.seed?.ui).toBe("hidden");
-    expect(modelImageLimits["gpt-image-2-codex"]?.maxInputImages).toBe(1);
+    for (const model of [gptImageModel, bridgeImageModel]) {
+      expect(model.parameters.width.ui).toBe("hidden");
+      expect(model.parameters.height.ui).toBe("hidden");
+      expect(model.parameters.steps.ui).toBe("hidden");
+      expect(model.parameters.seed?.ui).toBe("hidden");
+      expect(modelImageLimits[model.key]?.maxInputImages).toBe(1);
+    }
 
     const schema = createImageGenerationSchema(t);
     const inputImage =
@@ -97,7 +103,7 @@ describe("image-generation-schema", () => {
       width: 1024,
       height: 1024,
       initImages: [inputImage],
-      model: "gpt-image-2-codex",
+      model: "gpt-image-2-bridge",
       imageCount: 1,
       steps: 1,
       seed: "",
@@ -107,7 +113,7 @@ describe("image-generation-schema", () => {
       width: 1024,
       height: 1024,
       initImages: [inputImage, inputImage],
-      model: "gpt-image-2-codex",
+      model: "gpt-image-2-bridge",
       imageCount: 1,
       steps: 1,
       seed: "",

--- a/src/features/image-generation/ui/image-generation-form.test.tsx
+++ b/src/features/image-generation/ui/image-generation-form.test.tsx
@@ -202,16 +202,18 @@ describe("ImageGenerationForm", () => {
     const user = userEvent.setup();
     renderWithIntl(<ImageGenerationForm isAuthenticated />);
 
-    const gptButton = await screen.findByRole("button", {
-      name: /GPT Image 2 Bridge/i,
-    });
-    await user.click(gptButton);
+    for (const label of ["GPT Image 2", "GPT Image 2 Bridge"]) {
+      const modelLabel = await screen.findByText(label);
+      const gptButton = modelLabel.closest("button");
+      expect(gptButton).not.toBeNull();
+      await user.click(gptButton as HTMLButtonElement);
 
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("heading", { name: "설정" }),
-      ).not.toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("heading", { name: "설정" }),
+        ).not.toBeInTheDocument();
+      });
+    }
   });
 
   it("모델 카드에 모달리티 배지를 표시한다", async () => {

--- a/src/features/image-generation/ui/image-generation-form.test.tsx
+++ b/src/features/image-generation/ui/image-generation-form.test.tsx
@@ -192,7 +192,7 @@ describe("ImageGenerationForm", () => {
     expect(await screen.findByText("프롬프트 업샘플링")).toBeInTheDocument();
   });
 
-  it("GPT Image 2 모델에서는 설정 패널을 노출하지 않는다", async () => {
+  it("GPT Image 2 모델들에서는 설정 패널을 노출하지 않는다", async () => {
     mockUseImageGeneration.mockReturnValue({
       state: { status: "idle", progress: 0 },
       startGeneration: vi.fn(),
@@ -203,7 +203,7 @@ describe("ImageGenerationForm", () => {
     renderWithIntl(<ImageGenerationForm isAuthenticated />);
 
     const gptButton = await screen.findByRole("button", {
-      name: /GPT Image 2/i,
+      name: /GPT Image 2 Bridge/i,
     });
     await user.click(gptButton);
 

--- a/src/server/image-generation/adapters/codex-bridge-adapter.test.ts
+++ b/src/server/image-generation/adapters/codex-bridge-adapter.test.ts
@@ -86,7 +86,10 @@ describe("codexBridgeImageAdapter", () => {
   it("bridge에 생성 요청을 보내고 data URL 이미지를 반환한다", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValue(response({ images: [pngDataUrl] }));
+      .mockResolvedValueOnce(response({ jobId: "job-1", status: "queued" }, { status: 202 }))
+      .mockResolvedValueOnce(
+        response({ jobId: "job-1", status: "completed", images: [pngDataUrl] }),
+      );
     vi.stubGlobal("fetch", fetchMock);
 
     const { codexBridgeImageAdapter } = await import(
@@ -98,7 +101,7 @@ describe("codexBridgeImageAdapter", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://codex-bridge.internal:18080/v1/images/generate",
+      "http://codex-bridge.internal:18080/v1/images/jobs",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -117,12 +120,24 @@ describe("codexBridgeImageAdapter", () => {
       height: 1024,
       initImages: [],
     });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://codex-bridge.internal:18080/v1/images/jobs/job-1",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          authorization: "Bearer secret-token",
+        }),
+      }),
+    );
   });
 
   it("init image를 resolver로 검증한 뒤 data URL로 bridge에 전달한다", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValue(response({ images: [pngDataUrl] }));
+      .mockResolvedValueOnce(response({ jobId: "job-1", status: "queued" }, { status: 202 }))
+      .mockResolvedValueOnce(
+        response({ jobId: "job-1", status: "completed", images: [pngDataUrl] }),
+      );
     vi.stubGlobal("fetch", fetchMock);
 
     const { codexBridgeImageAdapter } = await import(
@@ -139,7 +154,10 @@ describe("codexBridgeImageAdapter", () => {
     mockCatalog({ agent_model: undefined });
     const fetchMock = vi
       .fn()
-      .mockResolvedValue(response({ images: [pngDataUrl] }));
+      .mockResolvedValueOnce(response({ jobId: "job-1", status: "queued" }, { status: 202 }))
+      .mockResolvedValueOnce(
+        response({ jobId: "job-1", status: "completed", images: [pngDataUrl] }),
+      );
     vi.stubGlobal("fetch", fetchMock);
 
     const { codexBridgeImageAdapter } = await import(
@@ -150,6 +168,31 @@ describe("codexBridgeImageAdapter", () => {
 
     const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string);
     expect(body.agentModel).toBe("gpt-5.5");
+  });
+
+  it("processing job은 완료될 때까지 polling한다", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response({ jobId: "job-1", status: "queued" }, { status: 202 }))
+      .mockResolvedValueOnce(response({ jobId: "job-1", status: "processing" }))
+      .mockResolvedValueOnce(
+        response({ jobId: "job-1", status: "completed", images: [pngDataUrl] }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { codexBridgeImageAdapter } = await import(
+      "@/server/image-generation/adapters/codex-bridge-adapter"
+    );
+
+    const generation = codexBridgeImageAdapter.generate(payload());
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(generation).resolves.toEqual({ images: [pngDataUrl] });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("bridge URL 또는 token env가 없으면 사용자 메시지로 매핑한다", async () => {
@@ -232,9 +275,18 @@ describe("codexBridgeImageAdapter", () => {
   it("bridge 비정상 응답과 빈 이미지 결과를 구분해 매핑한다", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(new Response("not json", { status: 200 }))
-      .mockResolvedValueOnce(response({ images: [] }))
-      .mockResolvedValueOnce(response({ error: { code: "CODEX_IMAGE_GENERATION_FAILED" } }, { status: 502 }));
+      .mockResolvedValueOnce(new Response("not json", { status: 202 }))
+      .mockResolvedValueOnce(response({ jobId: "job-2", status: "queued" }, { status: 202 }))
+      .mockResolvedValueOnce(response({ jobId: "job-2", status: "completed", images: [] }))
+      .mockResolvedValueOnce(response({ error: { code: "CODEX_IMAGE_GENERATION_FAILED" } }, { status: 502 }))
+      .mockResolvedValueOnce(response({ jobId: "job-3", status: "queued" }, { status: 202 }))
+      .mockResolvedValueOnce(
+        response({
+          jobId: "job-3",
+          status: "failed",
+          error: { code: "CODEX_OAUTH_REQUIRED", status: 503 },
+        }),
+      );
     vi.stubGlobal("fetch", fetchMock);
 
     const { codexBridgeImageAdapter } = await import(
@@ -250,9 +302,17 @@ describe("codexBridgeImageAdapter", () => {
     await expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
       "CODEX_BRIDGE_BAD_STATUS",
     );
+    await expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
+      "CODEX_BRIDGE_OAUTH_REQUIRED",
+    );
     expect(
       codexBridgeImageAdapter.mapError?.(new Error("CODEX_BRIDGE_BAD_STATUS")),
     ).toBe("Codex bridge 호출에 실패했습니다. bridge 서비스 상태를 확인해주세요.");
+    expect(
+      codexBridgeImageAdapter.mapError?.(new Error("CODEX_BRIDGE_OAUTH_REQUIRED")),
+    ).toBe(
+      "Codex bridge의 Codex OAuth 로그인이 필요합니다. bridge 컨테이너에서 codex login 상태를 확인해주세요.",
+    );
   });
 
   it("bridge response body 파싱 중에도 timeout을 적용한다", async () => {
@@ -260,7 +320,7 @@ describe("codexBridgeImageAdapter", () => {
     mockCatalog({ timeout_ms: 10 });
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      status: 200,
+      status: 202,
       json: vi.fn(() => new Promise(() => undefined)),
     });
     vi.stubGlobal("fetch", fetchMock);

--- a/src/server/image-generation/adapters/codex-bridge-adapter.test.ts
+++ b/src/server/image-generation/adapters/codex-bridge-adapter.test.ts
@@ -9,7 +9,7 @@ vi.mock("@/server/model-catalog/catalog-service", () => ({
 const pngDataUrl =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
-function mockCatalog() {
+function mockCatalog(providerConfigOverrides: Record<string, unknown> = {}) {
   mockGetModelCatalog.mockResolvedValue([
     {
       id: "image-model-bridge",
@@ -24,6 +24,7 @@ function mockCatalog() {
         model_id: "gpt-image-2",
         agent_model: "gpt-5.5",
         timeout_ms: 300000,
+        ...providerConfigOverrides,
       },
       parameters: {
         prompt: { ui: "textarea", required: true },
@@ -69,6 +70,7 @@ describe("codexBridgeImageAdapter", () => {
     vi.resetModules();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
     vi.stubEnv("CODEX_IMAGE_BRIDGE_URL", "http://codex-bridge.internal:18080");
     vi.stubEnv("CODEX_IMAGE_BRIDGE_TOKEN", "secret-token");
     mockCatalog();
@@ -124,6 +126,23 @@ describe("codexBridgeImageAdapter", () => {
 
     const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string);
     expect(body.initImages).toEqual([pngDataUrl]);
+  });
+
+  it("agent_model이 생략되면 gpt-5.5를 기본 agentModel로 전달한다", async () => {
+    mockCatalog({ agent_model: undefined });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(response({ images: [pngDataUrl] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { codexBridgeImageAdapter } = await import(
+      "@/server/image-generation/adapters/codex-bridge-adapter"
+    );
+
+    await codexBridgeImageAdapter.generate(payload());
+
+    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string);
+    expect(body.agentModel).toBe("gpt-5.5");
   });
 
   it("bridge URL 또는 token env가 없으면 사용자 메시지로 매핑한다", async () => {
@@ -197,7 +216,32 @@ describe("codexBridgeImageAdapter", () => {
       "CODEX_BRIDGE_OUTPUT_NOT_FOUND",
     );
     await expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
-      "CODEX_BRIDGE_GENERATION_FAILED",
+      "CODEX_BRIDGE_BAD_STATUS",
     );
+    expect(
+      codexBridgeImageAdapter.mapError?.(new Error("CODEX_BRIDGE_BAD_STATUS")),
+    ).toBe("Codex bridge 호출에 실패했습니다. bridge 서비스 상태를 확인해주세요.");
+  });
+
+  it("bridge response body 파싱 중에도 timeout을 적용한다", async () => {
+    vi.useFakeTimers();
+    mockCatalog({ timeout_ms: 10 });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn(() => new Promise(() => undefined)),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { codexBridgeImageAdapter } = await import(
+      "@/server/image-generation/adapters/codex-bridge-adapter"
+    );
+
+    const generation = expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
+      "CODEX_BRIDGE_TIMEOUT",
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(10);
+    await generation;
   });
 });

--- a/src/server/image-generation/adapters/codex-bridge-adapter.test.ts
+++ b/src/server/image-generation/adapters/codex-bridge-adapter.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetModelCatalog = vi.hoisted(() => vi.fn());
+
+vi.mock("@/server/model-catalog/catalog-service", () => ({
+  getModelCatalog: mockGetModelCatalog,
+}));
+
+const pngDataUrl =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+function mockCatalog() {
+  mockGetModelCatalog.mockResolvedValue([
+    {
+      id: "image-model-bridge",
+      type: "image",
+      key: "gpt-image-2-bridge",
+      label: "GPT Image 2 Bridge",
+      vendor: "OPENAI",
+      provider: "codex_bridge",
+      providerConfig: {
+        base_url_env: "CODEX_IMAGE_BRIDGE_URL",
+        token_env: "CODEX_IMAGE_BRIDGE_TOKEN",
+        model_id: "gpt-image-2",
+        agent_model: "gpt-5.5",
+        timeout_ms: 300000,
+      },
+      parameters: {
+        prompt: { ui: "textarea", required: true },
+      },
+      meta: {
+        pipeline: "image_generation",
+        model_id: "gpt-image-2",
+        default_width: 1024,
+        default_height: 1024,
+        default_steps: 1,
+        max_input_images: 1,
+      },
+      isActive: true,
+      isDefault: false,
+    },
+  ]);
+}
+
+function payload(overrides = {}) {
+  return {
+    prompt: "a small red house",
+    model: "gpt-image-2-bridge",
+    width: 1024,
+    height: 1024,
+    imageCount: 1,
+    steps: 1,
+    seed: "",
+    initImages: [],
+    ...overrides,
+  };
+}
+
+function response(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+describe("codexBridgeImageAdapter", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.stubEnv("CODEX_IMAGE_BRIDGE_URL", "http://codex-bridge.internal:18080");
+    vi.stubEnv("CODEX_IMAGE_BRIDGE_TOKEN", "secret-token");
+    mockCatalog();
+  });
+
+  it("bridge에 생성 요청을 보내고 data URL 이미지를 반환한다", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(response({ images: [pngDataUrl] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { codexBridgeImageAdapter } = await import(
+      "@/server/image-generation/adapters/codex-bridge-adapter"
+    );
+
+    await expect(codexBridgeImageAdapter.generate(payload())).resolves.toEqual({
+      images: [pngDataUrl],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://codex-bridge.internal:18080/v1/images/generate",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          authorization: "Bearer secret-token",
+          "content-type": "application/json",
+        }),
+        body: expect.any(String),
+      }),
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string);
+    expect(body).toEqual({
+      prompt: "a small red house",
+      modelId: "gpt-image-2",
+      agentModel: "gpt-5.5",
+      width: 1024,
+      height: 1024,
+      initImages: [],
+    });
+  });
+
+  it("init image를 resolver로 검증한 뒤 data URL로 bridge에 전달한다", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(response({ images: [pngDataUrl] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { codexBridgeImageAdapter } = await import(
+      "@/server/image-generation/adapters/codex-bridge-adapter"
+    );
+
+    await codexBridgeImageAdapter.generate(payload({ initImages: [pngDataUrl] }));
+
+    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string);
+    expect(body.initImages).toEqual([pngDataUrl]);
+  });
+
+  it("bridge URL 또는 token env가 없으면 사용자 메시지로 매핑한다", async () => {
+    vi.stubEnv("CODEX_IMAGE_BRIDGE_URL", "");
+    const { codexBridgeImageAdapter } = await import(
+      "@/server/image-generation/adapters/codex-bridge-adapter"
+    );
+
+    await expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
+      "CODEX_BRIDGE_URL_REQUIRED",
+    );
+    expect(
+      codexBridgeImageAdapter.mapError?.(new Error("CODEX_BRIDGE_URL_REQUIRED")),
+    ).toBe("Codex bridge URL이 설정되어 있지 않습니다.");
+
+    vi.resetModules();
+    vi.stubEnv("CODEX_IMAGE_BRIDGE_URL", "http://codex-bridge.internal:18080");
+    vi.stubEnv("CODEX_IMAGE_BRIDGE_TOKEN", "");
+    const { codexBridgeImageAdapter: reloadedAdapter } = await import(
+      "@/server/image-generation/adapters/codex-bridge-adapter"
+    );
+    await expect(reloadedAdapter.generate(payload())).rejects.toThrow(
+      "CODEX_BRIDGE_TOKEN_REQUIRED",
+    );
+    expect(
+      reloadedAdapter.mapError?.(new Error("CODEX_BRIDGE_TOKEN_REQUIRED")),
+    ).toBe("Codex bridge token이 설정되어 있지 않습니다.");
+  });
+
+  it("bridge 인증 실패와 timeout을 구분해 매핑한다", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response({ error: { code: "UNAUTHORIZED" } }, { status: 401 }))
+      .mockRejectedValueOnce(Object.assign(new Error("aborted"), { name: "AbortError" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { codexBridgeImageAdapter } = await import(
+      "@/server/image-generation/adapters/codex-bridge-adapter"
+    );
+
+    await expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
+      "CODEX_BRIDGE_AUTH_FAILED",
+    );
+    await expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
+      "CODEX_BRIDGE_TIMEOUT",
+    );
+    expect(
+      codexBridgeImageAdapter.mapError?.(new Error("CODEX_BRIDGE_AUTH_FAILED")),
+    ).toBe("Codex bridge 인증에 실패했습니다. bridge token 설정을 확인해주세요.");
+    expect(
+      codexBridgeImageAdapter.mapError?.(new Error("CODEX_BRIDGE_TIMEOUT")),
+    ).toBe("Codex bridge 이미지 생성 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.");
+  });
+
+  it("bridge 비정상 응답과 빈 이미지 결과를 구분해 매핑한다", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("not json", { status: 200 }))
+      .mockResolvedValueOnce(response({ images: [] }))
+      .mockResolvedValueOnce(response({ error: { code: "CODEX_IMAGE_GENERATION_FAILED" } }, { status: 502 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { codexBridgeImageAdapter } = await import(
+      "@/server/image-generation/adapters/codex-bridge-adapter"
+    );
+
+    await expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
+      "CODEX_BRIDGE_BAD_RESPONSE",
+    );
+    await expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
+      "CODEX_BRIDGE_OUTPUT_NOT_FOUND",
+    );
+    await expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
+      "CODEX_BRIDGE_GENERATION_FAILED",
+    );
+  });
+});

--- a/src/server/image-generation/adapters/codex-bridge-adapter.test.ts
+++ b/src/server/image-generation/adapters/codex-bridge-adapter.test.ts
@@ -272,6 +272,19 @@ describe("codexBridgeImageAdapter", () => {
     ).toBe("Codex bridge 이미지 생성 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.");
   });
 
+  it("bridge 연결 실패는 생성 실패가 아니라 호출 실패로 매핑한다", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { codexBridgeImageAdapter } = await import(
+      "@/server/image-generation/adapters/codex-bridge-adapter"
+    );
+
+    await expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
+      "CODEX_BRIDGE_BAD_STATUS",
+    );
+  });
+
   it("bridge 비정상 응답과 빈 이미지 결과를 구분해 매핑한다", async () => {
     const fetchMock = vi
       .fn()

--- a/src/server/image-generation/adapters/codex-bridge-adapter.test.ts
+++ b/src/server/image-generation/adapters/codex-bridge-adapter.test.ts
@@ -58,10 +58,17 @@ function payload(overrides = {}) {
 }
 
 function response(body: unknown, init?: ResponseInit) {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (init?.headers) {
+    new Headers(init.headers).forEach((value, key) => {
+      headers.set(key, value);
+    });
+  }
+
   return new Response(JSON.stringify(body), {
     status: 200,
-    headers: { "content-type": "application/json" },
     ...init,
+    headers,
   });
 }
 
@@ -170,6 +177,31 @@ describe("codexBridgeImageAdapter", () => {
     expect(
       reloadedAdapter.mapError?.(new Error("CODEX_BRIDGE_TOKEN_REQUIRED")),
     ).toBe("Codex bridge token이 설정되어 있지 않습니다.");
+  });
+
+  it("bridge URL 형식 오류를 누락과 구분해 매핑한다", async () => {
+    const { codexBridgeImageAdapter } = await import(
+      "@/server/image-generation/adapters/codex-bridge-adapter"
+    );
+
+    for (const invalidUrl of [
+      "not-a-url",
+      "ftp://codex-bridge.internal",
+      "http://codex-bridge.internal:18080/api",
+    ]) {
+      vi.stubEnv("CODEX_IMAGE_BRIDGE_URL", invalidUrl);
+      await expect(codexBridgeImageAdapter.generate(payload())).rejects.toThrow(
+        "CODEX_BRIDGE_URL_INVALID",
+      );
+    }
+
+    expect(
+      codexBridgeImageAdapter.mapError?.(
+        new Error("CODEX_BRIDGE_URL_INVALID"),
+      ),
+    ).toBe(
+      "Codex bridge URL 형식이 올바르지 않습니다. http(s) origin만 입력해주세요.",
+    );
   });
 
   it("bridge 인증 실패와 timeout을 구분해 매핑한다", async () => {

--- a/src/server/image-generation/adapters/codex-bridge-adapter.ts
+++ b/src/server/image-generation/adapters/codex-bridge-adapter.ts
@@ -1,0 +1,234 @@
+import { z } from "zod";
+import type { ImageGenerationFormValues } from "@/features/image-generation/model/image-generation-schema";
+import type { ImageGenerationAdapter } from "@/server/image-generation/adapters/types";
+import {
+  resolveInputImageBuffer,
+  type ResolvedInputImageBuffer,
+} from "@/server/shared/input-image-resolver";
+import { getModelCatalog } from "@/server/model-catalog/catalog-service";
+import type { ImageModelCatalogItem } from "@/server/model-catalog/catalog-schema";
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const INPUT_IMAGE_FETCH_TIMEOUT_MS = 20_000;
+const BRIDGE_GENERATE_PATH = "/v1/images/generate";
+
+const codexBridgeConfigSchema = z
+  .object({
+    base_url_env: z.string().min(1),
+    token_env: z.string().min(1),
+    model_id: z.string().min(1),
+    agent_model: z.string().min(1).optional(),
+    timeout_ms: z.number().int().positive().optional(),
+  })
+  .passthrough();
+
+type CodexBridgeConfig = {
+  baseUrl: string;
+  token: string;
+  modelId: string;
+  agentModel?: string;
+  timeoutMs: number;
+};
+
+function getEnvValue(envName: string) {
+  return process.env[envName]?.trim() ?? "";
+}
+
+function normalizeBridgeBaseUrl(rawUrl: string) {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error("CODEX_BRIDGE_URL_REQUIRED");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("CODEX_BRIDGE_URL_REQUIRED");
+  }
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}
+
+function buildGenerateUrl(baseUrl: string) {
+  return `${baseUrl}${BRIDGE_GENERATE_PATH}`;
+}
+
+async function getCatalogImageModel(modelKey: string) {
+  const catalog = await getModelCatalog({ includeInactive: true });
+  const model = catalog.find(
+    (item): item is ImageModelCatalogItem =>
+      item.type === "image" && item.key === modelKey,
+  );
+  if (!model) {
+    throw new Error(`IMAGE_MODEL_NOT_FOUND:${modelKey}`);
+  }
+  return model;
+}
+
+async function getBridgeConfig(modelKey: ImageGenerationFormValues["model"]) {
+  const model = await getCatalogImageModel(modelKey);
+  if (model.provider !== "codex_bridge") {
+    throw new Error("IMAGE_PROVIDER_NOT_SUPPORTED");
+  }
+  const parsedConfig = codexBridgeConfigSchema.safeParse(model.providerConfig);
+  if (!parsedConfig.success) {
+    throw new Error("CODEX_BRIDGE_CONFIG_INVALID");
+  }
+
+  const providerConfig = parsedConfig.data;
+  const rawBaseUrl = getEnvValue(providerConfig.base_url_env);
+  if (!rawBaseUrl) {
+    throw new Error("CODEX_BRIDGE_URL_REQUIRED");
+  }
+  const token = getEnvValue(providerConfig.token_env);
+  if (!token) {
+    throw new Error("CODEX_BRIDGE_TOKEN_REQUIRED");
+  }
+
+  const timeoutRaw = Number(providerConfig.timeout_ms ?? DEFAULT_TIMEOUT_MS);
+  return {
+    baseUrl: normalizeBridgeBaseUrl(rawBaseUrl),
+    token,
+    modelId: providerConfig.model_id.trim(),
+    agentModel: providerConfig.agent_model?.trim() || undefined,
+    timeoutMs:
+      Number.isFinite(timeoutRaw) && timeoutRaw > 0
+        ? timeoutRaw
+        : DEFAULT_TIMEOUT_MS,
+  } satisfies CodexBridgeConfig;
+}
+
+function toDataUrl({ buffer, mime }: ResolvedInputImageBuffer) {
+  return `data:${mime};base64,${buffer.toString("base64")}`;
+}
+
+async function resolveBridgeInitImages(images: string[] | undefined) {
+  const inputImages = images ?? [];
+  if (inputImages.length === 0) {
+    return [];
+  }
+
+  return Promise.all(
+    inputImages.map(async (source) => {
+      const resolved = await resolveInputImageBuffer(source, {
+        invalidErrorCode: "CODEX_BRIDGE_INPUT_INVALID",
+        fetchErrorCode: "CODEX_BRIDGE_INPUT_INVALID",
+        notBase64ErrorCode: "CODEX_BRIDGE_INPUT_INVALID",
+        timeoutMs: INPUT_IMAGE_FETCH_TIMEOUT_MS,
+      });
+      if (!resolved.mime.startsWith("image/")) {
+        throw new Error("CODEX_BRIDGE_INPUT_INVALID");
+      }
+      return toDataUrl(resolved);
+    }),
+  );
+}
+
+function isDataUrlImage(value: unknown): value is string {
+  return typeof value === "string" && /^data:image\/[^;]+;base64,/i.test(value);
+}
+
+async function readBridgeJson(response: Response) {
+  try {
+    return (await response.json()) as unknown;
+  } catch {
+    throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
+  }
+}
+
+async function requestBridgeImage(
+  config: CodexBridgeConfig,
+  payload: ImageGenerationFormValues,
+) {
+  const initImages = await resolveBridgeInitImages(payload.initImages);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), config.timeoutMs);
+  let response: Response;
+
+  try {
+    response = await fetch(buildGenerateUrl(config.baseUrl), {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${config.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        prompt: payload.prompt.trim(),
+        modelId: config.modelId,
+        agentModel: config.agentModel,
+        width: payload.width,
+        height: payload.height,
+        initImages,
+      }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("CODEX_BRIDGE_TIMEOUT");
+    }
+    throw new Error("CODEX_BRIDGE_GENERATION_FAILED");
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Error("CODEX_BRIDGE_AUTH_FAILED");
+  }
+  if (!response.ok) {
+    throw new Error("CODEX_BRIDGE_GENERATION_FAILED");
+  }
+
+  const parsed = await readBridgeJson(response);
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
+  }
+  const images = (parsed as { images?: unknown }).images;
+  if (!Array.isArray(images) || images.length === 0) {
+    throw new Error("CODEX_BRIDGE_OUTPUT_NOT_FOUND");
+  }
+  if (!images.every(isDataUrlImage)) {
+    throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
+  }
+  return images;
+}
+
+export const codexBridgeImageAdapter: ImageGenerationAdapter = {
+  mapError(error: unknown) {
+    if (!(error instanceof Error)) {
+      return "Codex bridge 이미지 생성에 실패했습니다.";
+    }
+    if (error.message.startsWith("IMAGE_MODEL_NOT_FOUND")) {
+      return "요청한 이미지 모델을 찾을 수 없습니다.";
+    }
+    if (error.message.startsWith("IMAGE_PROVIDER_NOT_SUPPORTED")) {
+      return "요청한 이미지 제공자가 지원되지 않습니다.";
+    }
+    switch (error.message) {
+      case "CODEX_BRIDGE_URL_REQUIRED":
+        return "Codex bridge URL이 설정되어 있지 않습니다.";
+      case "CODEX_BRIDGE_TOKEN_REQUIRED":
+        return "Codex bridge token이 설정되어 있지 않습니다.";
+      case "CODEX_BRIDGE_AUTH_FAILED":
+        return "Codex bridge 인증에 실패했습니다. bridge token 설정을 확인해주세요.";
+      case "CODEX_BRIDGE_TIMEOUT":
+        return "Codex bridge 이미지 생성 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.";
+      case "CODEX_BRIDGE_BAD_RESPONSE":
+        return "Codex bridge 응답 형식이 올바르지 않습니다.";
+      case "CODEX_BRIDGE_OUTPUT_NOT_FOUND":
+        return "Codex bridge가 생성한 이미지 결과를 찾을 수 없습니다.";
+      case "CODEX_BRIDGE_INPUT_INVALID":
+        return "입력 이미지 형식이 올바르지 않습니다. 다른 이미지를 사용해주세요.";
+      case "CODEX_BRIDGE_CONFIG_INVALID":
+        return "Codex bridge 이미지 모델 설정이 올바르지 않습니다.";
+      case "CODEX_BRIDGE_GENERATION_FAILED":
+        return "Codex bridge 이미지 생성에 실패했습니다. 잠시 후 다시 시도해주세요.";
+      default:
+        return "Codex bridge 이미지 생성에 실패했습니다.";
+    }
+  },
+  async generate(payload: ImageGenerationFormValues) {
+    const config = await getBridgeConfig(payload.model);
+    const images = await requestBridgeImage(config, payload);
+    return { images };
+  },
+};

--- a/src/server/image-generation/adapters/codex-bridge-adapter.ts
+++ b/src/server/image-generation/adapters/codex-bridge-adapter.ts
@@ -13,7 +13,8 @@ import {
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_AGENT_MODEL = "gpt-5.5";
 const INPUT_IMAGE_FETCH_TIMEOUT_MS = 20_000;
-const BRIDGE_GENERATE_PATH = "/v1/images/generate";
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const BRIDGE_JOBS_PATH = "/v1/images/jobs";
 
 type CodexBridgeConfig = {
   baseUrl: string;
@@ -43,8 +44,15 @@ function normalizeBridgeBaseUrl(rawUrl: string) {
   return url.origin;
 }
 
-function buildGenerateUrl(baseUrl: string) {
-  return new URL(BRIDGE_GENERATE_PATH, `${baseUrl}/`).toString();
+function buildJobsUrl(baseUrl: string) {
+  return new URL(BRIDGE_JOBS_PATH, `${baseUrl}/`).toString();
+}
+
+function buildJobUrl(baseUrl: string, jobId: string) {
+  return new URL(
+    `${BRIDGE_JOBS_PATH}/${encodeURIComponent(jobId)}`,
+    `${baseUrl}/`,
+  ).toString();
 }
 
 async function getCatalogImageModel(modelKey: string) {
@@ -129,6 +137,78 @@ async function readBridgeJson(response: Response) {
   }
 }
 
+function isBridgeObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function getBridgeErrorCode(parsed: unknown) {
+  if (!isBridgeObject(parsed) || !isBridgeObject(parsed.error)) {
+    return undefined;
+  }
+  const code = parsed.error.code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function mapBridgeErrorCode(code: unknown, fallback: string) {
+  switch (code) {
+    case "UNAUTHORIZED":
+      return "CODEX_BRIDGE_AUTH_FAILED";
+    case "CODEX_OAUTH_REQUIRED":
+      return "CODEX_BRIDGE_OAUTH_REQUIRED";
+    case "CODEX_CLI_NOT_FOUND":
+      return "CODEX_BRIDGE_CLI_NOT_FOUND";
+    case "CODEX_IMAGE_TIMEOUT":
+      return "CODEX_BRIDGE_TIMEOUT";
+    case "CODEX_IMAGE_OUTPUT_NOT_FOUND":
+      return "CODEX_BRIDGE_OUTPUT_NOT_FOUND";
+    case "CODEX_IMAGE_OUTPUT_INVALID":
+      return "CODEX_BRIDGE_BAD_RESPONSE";
+    case "CODEX_BRIDGE_INPUT_INVALID":
+      return "CODEX_BRIDGE_INPUT_INVALID";
+    case "CODEX_IMAGE_GENERATION_FAILED":
+      return "CODEX_BRIDGE_GENERATION_FAILED";
+    default:
+      return fallback;
+  }
+}
+
+function mapBridgeHttpErrorCode(code: unknown) {
+  switch (code) {
+    case "UNAUTHORIZED":
+      return "CODEX_BRIDGE_AUTH_FAILED";
+    case "CODEX_OAUTH_REQUIRED":
+      return "CODEX_BRIDGE_OAUTH_REQUIRED";
+    case "CODEX_CLI_NOT_FOUND":
+      return "CODEX_BRIDGE_CLI_NOT_FOUND";
+    case "CODEX_IMAGE_TIMEOUT":
+      return "CODEX_BRIDGE_TIMEOUT";
+    case "CODEX_BRIDGE_INPUT_INVALID":
+      return "CODEX_BRIDGE_INPUT_INVALID";
+    default:
+      return "CODEX_BRIDGE_BAD_STATUS";
+  }
+}
+
+async function throwForBridgeHttpError(response: Response) {
+  if (response.status === 401 || response.status === 403) {
+    throw new Error("CODEX_BRIDGE_AUTH_FAILED");
+  }
+  if (response.ok) {
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await readBridgeJson(response);
+  } catch (error) {
+    if (error instanceof Error && error.message === "CODEX_BRIDGE_TIMEOUT") {
+      throw error;
+    }
+    throw new Error("CODEX_BRIDGE_BAD_STATUS");
+  }
+  throw new Error(mapBridgeHttpErrorCode(getBridgeErrorCode(parsed)));
+}
+
 async function withBridgeTimeout<T>(
   timeoutMs: number,
   task: (signal: AbortSignal) => Promise<T>,
@@ -156,6 +236,143 @@ async function withBridgeTimeout<T>(
   }
 }
 
+function makeAbortError() {
+  return Object.assign(new Error("aborted"), { name: "AbortError" });
+}
+
+function waitForNextPoll(signal: AbortSignal) {
+  if (signal.aborted) {
+    throw makeAbortError();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      signal.removeEventListener("abort", onAbort);
+      reject(makeAbortError());
+    };
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, DEFAULT_POLL_INTERVAL_MS);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function fetchBridge(
+  url: string,
+  init: RequestInit,
+  signal: AbortSignal,
+) {
+  try {
+    return await fetch(url, { ...init, signal });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("CODEX_BRIDGE_TIMEOUT");
+    }
+    throw new Error("CODEX_BRIDGE_GENERATION_FAILED");
+  }
+}
+
+function assertBridgeJobId(parsed: unknown) {
+  if (!isBridgeObject(parsed)) {
+    throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
+  }
+  const jobId = parsed.jobId;
+  const status = parsed.status;
+  if (
+    typeof jobId !== "string" ||
+    !jobId ||
+    (status !== "queued" && status !== "processing" && status !== "completed")
+  ) {
+    throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
+  }
+  return jobId;
+}
+
+function assertCompletedImages(parsed: Record<string, unknown>) {
+  const images = parsed.images;
+  if (!Array.isArray(images) || images.length === 0) {
+    throw new Error("CODEX_BRIDGE_OUTPUT_NOT_FOUND");
+  }
+  if (!images.every(isDataUrlImage)) {
+    throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
+  }
+  return images;
+}
+
+async function createBridgeJob(
+  config: CodexBridgeConfig,
+  payload: ImageGenerationFormValues,
+  initImages: string[],
+  signal: AbortSignal,
+) {
+  const response = await fetchBridge(
+    buildJobsUrl(config.baseUrl),
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${config.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        prompt: payload.prompt.trim(),
+        modelId: config.modelId,
+        agentModel: config.agentModel,
+        width: payload.width,
+        height: payload.height,
+        initImages,
+      }),
+    },
+    signal,
+  );
+  await throwForBridgeHttpError(response);
+  return assertBridgeJobId(await readBridgeJson(response));
+}
+
+async function pollBridgeJob(
+  config: CodexBridgeConfig,
+  jobId: string,
+  signal: AbortSignal,
+) {
+  while (true) {
+    const response = await fetchBridge(
+      buildJobUrl(config.baseUrl, jobId),
+      {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${config.token}`,
+        },
+      },
+      signal,
+    );
+    await throwForBridgeHttpError(response);
+
+    const parsed = await readBridgeJson(response);
+    if (!isBridgeObject(parsed)) {
+      throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
+    }
+
+    switch (parsed.status) {
+      case "queued":
+      case "processing":
+        await waitForNextPoll(signal);
+        break;
+      case "completed":
+        return assertCompletedImages(parsed);
+      case "failed":
+        throw new Error(
+          mapBridgeErrorCode(
+            getBridgeErrorCode(parsed),
+            "CODEX_BRIDGE_GENERATION_FAILED",
+          ),
+        );
+      default:
+        throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
+    }
+  }
+}
+
 async function requestBridgeImage(
   config: CodexBridgeConfig,
   payload: ImageGenerationFormValues,
@@ -163,51 +380,8 @@ async function requestBridgeImage(
   const initImages = await resolveBridgeInitImages(payload.initImages);
 
   return withBridgeTimeout(config.timeoutMs, async (signal) => {
-    let response: Response;
-
-    try {
-      response = await fetch(buildGenerateUrl(config.baseUrl), {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${config.token}`,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          prompt: payload.prompt.trim(),
-          modelId: config.modelId,
-          agentModel: config.agentModel,
-          width: payload.width,
-          height: payload.height,
-          initImages,
-        }),
-        signal,
-      });
-    } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") {
-        throw new Error("CODEX_BRIDGE_TIMEOUT");
-      }
-      throw new Error("CODEX_BRIDGE_GENERATION_FAILED");
-    }
-
-    if (response.status === 401 || response.status === 403) {
-      throw new Error("CODEX_BRIDGE_AUTH_FAILED");
-    }
-    if (!response.ok) {
-      throw new Error("CODEX_BRIDGE_BAD_STATUS");
-    }
-
-    const parsed = await readBridgeJson(response);
-    if (!parsed || typeof parsed !== "object") {
-      throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
-    }
-    const images = (parsed as { images?: unknown }).images;
-    if (!Array.isArray(images) || images.length === 0) {
-      throw new Error("CODEX_BRIDGE_OUTPUT_NOT_FOUND");
-    }
-    if (!images.every(isDataUrlImage)) {
-      throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
-    }
-    return images;
+    const jobId = await createBridgeJob(config, payload, initImages, signal);
+    return pollBridgeJob(config, jobId, signal);
   });
 }
 
@@ -231,6 +405,10 @@ export const codexBridgeImageAdapter: ImageGenerationAdapter = {
         return "Codex bridge token이 설정되어 있지 않습니다.";
       case "CODEX_BRIDGE_AUTH_FAILED":
         return "Codex bridge 인증에 실패했습니다. bridge token 설정을 확인해주세요.";
+      case "CODEX_BRIDGE_OAUTH_REQUIRED":
+        return "Codex bridge의 Codex OAuth 로그인이 필요합니다. bridge 컨테이너에서 codex login 상태를 확인해주세요.";
+      case "CODEX_BRIDGE_CLI_NOT_FOUND":
+        return "Codex bridge 컨테이너에서 Codex CLI를 찾을 수 없습니다.";
       case "CODEX_BRIDGE_TIMEOUT":
         return "Codex bridge 이미지 생성 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.";
       case "CODEX_BRIDGE_BAD_RESPONSE":

--- a/src/server/image-generation/adapters/codex-bridge-adapter.ts
+++ b/src/server/image-generation/adapters/codex-bridge-adapter.ts
@@ -9,6 +9,7 @@ import { getModelCatalog } from "@/server/model-catalog/catalog-service";
 import type { ImageModelCatalogItem } from "@/server/model-catalog/catalog-schema";
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_AGENT_MODEL = "gpt-5.5";
 const INPUT_IMAGE_FETCH_TIMEOUT_MS = 20_000;
 const BRIDGE_GENERATE_PATH = "/v1/images/generate";
 
@@ -20,13 +21,13 @@ const codexBridgeConfigSchema = z
     agent_model: z.string().min(1).optional(),
     timeout_ms: z.number().int().positive().optional(),
   })
-  .passthrough();
+  .strict();
 
 type CodexBridgeConfig = {
   baseUrl: string;
   token: string;
   modelId: string;
-  agentModel?: string;
+  agentModel: string;
   timeoutMs: number;
 };
 
@@ -90,7 +91,7 @@ async function getBridgeConfig(modelKey: ImageGenerationFormValues["model"]) {
     baseUrl: normalizeBridgeBaseUrl(rawBaseUrl),
     token,
     modelId: providerConfig.model_id.trim(),
-    agentModel: providerConfig.agent_model?.trim() || undefined,
+    agentModel: providerConfig.agent_model?.trim() || DEFAULT_AGENT_MODEL,
     timeoutMs:
       Number.isFinite(timeoutRaw) && timeoutRaw > 0
         ? timeoutRaw
@@ -131,8 +132,38 @@ function isDataUrlImage(value: unknown): value is string {
 async function readBridgeJson(response: Response) {
   try {
     return (await response.json()) as unknown;
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("CODEX_BRIDGE_TIMEOUT");
+    }
     throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
+  }
+}
+
+async function withBridgeTimeout<T>(
+  timeoutMs: number,
+  task: (signal: AbortSignal) => Promise<T>,
+) {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+      reject(new Error("CODEX_BRIDGE_TIMEOUT"));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([task(controller.signal), timeoutPromise]);
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("CODEX_BRIDGE_TIMEOUT");
+    }
+    throw error;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
   }
 }
 
@@ -141,55 +172,54 @@ async function requestBridgeImage(
   payload: ImageGenerationFormValues,
 ) {
   const initImages = await resolveBridgeInitImages(payload.initImages);
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), config.timeoutMs);
-  let response: Response;
 
-  try {
-    response = await fetch(buildGenerateUrl(config.baseUrl), {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${config.token}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        prompt: payload.prompt.trim(),
-        modelId: config.modelId,
-        agentModel: config.agentModel,
-        width: payload.width,
-        height: payload.height,
-        initImages,
-      }),
-      signal: controller.signal,
-    });
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      throw new Error("CODEX_BRIDGE_TIMEOUT");
+  return withBridgeTimeout(config.timeoutMs, async (signal) => {
+    let response: Response;
+
+    try {
+      response = await fetch(buildGenerateUrl(config.baseUrl), {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${config.token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          prompt: payload.prompt.trim(),
+          modelId: config.modelId,
+          agentModel: config.agentModel,
+          width: payload.width,
+          height: payload.height,
+          initImages,
+        }),
+        signal,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error("CODEX_BRIDGE_TIMEOUT");
+      }
+      throw new Error("CODEX_BRIDGE_GENERATION_FAILED");
     }
-    throw new Error("CODEX_BRIDGE_GENERATION_FAILED");
-  } finally {
-    clearTimeout(timeoutId);
-  }
 
-  if (response.status === 401 || response.status === 403) {
-    throw new Error("CODEX_BRIDGE_AUTH_FAILED");
-  }
-  if (!response.ok) {
-    throw new Error("CODEX_BRIDGE_GENERATION_FAILED");
-  }
+    if (response.status === 401 || response.status === 403) {
+      throw new Error("CODEX_BRIDGE_AUTH_FAILED");
+    }
+    if (!response.ok) {
+      throw new Error("CODEX_BRIDGE_BAD_STATUS");
+    }
 
-  const parsed = await readBridgeJson(response);
-  if (!parsed || typeof parsed !== "object") {
-    throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
-  }
-  const images = (parsed as { images?: unknown }).images;
-  if (!Array.isArray(images) || images.length === 0) {
-    throw new Error("CODEX_BRIDGE_OUTPUT_NOT_FOUND");
-  }
-  if (!images.every(isDataUrlImage)) {
-    throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
-  }
-  return images;
+    const parsed = await readBridgeJson(response);
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
+    }
+    const images = (parsed as { images?: unknown }).images;
+    if (!Array.isArray(images) || images.length === 0) {
+      throw new Error("CODEX_BRIDGE_OUTPUT_NOT_FOUND");
+    }
+    if (!images.every(isDataUrlImage)) {
+      throw new Error("CODEX_BRIDGE_BAD_RESPONSE");
+    }
+    return images;
+  });
 }
 
 export const codexBridgeImageAdapter: ImageGenerationAdapter = {
@@ -216,6 +246,8 @@ export const codexBridgeImageAdapter: ImageGenerationAdapter = {
         return "Codex bridge 응답 형식이 올바르지 않습니다.";
       case "CODEX_BRIDGE_OUTPUT_NOT_FOUND":
         return "Codex bridge가 생성한 이미지 결과를 찾을 수 없습니다.";
+      case "CODEX_BRIDGE_BAD_STATUS":
+        return "Codex bridge 호출에 실패했습니다. bridge 서비스 상태를 확인해주세요.";
       case "CODEX_BRIDGE_INPUT_INVALID":
         return "입력 이미지 형식이 올바르지 않습니다. 다른 이미지를 사용해주세요.";
       case "CODEX_BRIDGE_CONFIG_INVALID":

--- a/src/server/image-generation/adapters/codex-bridge-adapter.ts
+++ b/src/server/image-generation/adapters/codex-bridge-adapter.ts
@@ -270,7 +270,7 @@ async function fetchBridge(
     if (error instanceof Error && error.name === "AbortError") {
       throw new Error("CODEX_BRIDGE_TIMEOUT");
     }
-    throw new Error("CODEX_BRIDGE_GENERATION_FAILED");
+    throw new Error("CODEX_BRIDGE_BAD_STATUS");
   }
 }
 

--- a/src/server/image-generation/adapters/codex-bridge-adapter.ts
+++ b/src/server/image-generation/adapters/codex-bridge-adapter.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 import type { ImageGenerationFormValues } from "@/features/image-generation/model/image-generation-schema";
 import type { ImageGenerationAdapter } from "@/server/image-generation/adapters/types";
 import {
@@ -6,22 +5,15 @@ import {
   type ResolvedInputImageBuffer,
 } from "@/server/shared/input-image-resolver";
 import { getModelCatalog } from "@/server/model-catalog/catalog-service";
-import type { ImageModelCatalogItem } from "@/server/model-catalog/catalog-schema";
+import {
+  codexBridgeConfigSchema,
+  type ImageModelCatalogItem,
+} from "@/server/model-catalog/catalog-schema";
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_AGENT_MODEL = "gpt-5.5";
 const INPUT_IMAGE_FETCH_TIMEOUT_MS = 20_000;
 const BRIDGE_GENERATE_PATH = "/v1/images/generate";
-
-const codexBridgeConfigSchema = z
-  .object({
-    base_url_env: z.string().min(1),
-    token_env: z.string().min(1),
-    model_id: z.string().min(1),
-    agent_model: z.string().min(1).optional(),
-    timeout_ms: z.number().int().positive().optional(),
-  })
-  .strict();
 
 type CodexBridgeConfig = {
   baseUrl: string;
@@ -40,18 +32,19 @@ function normalizeBridgeBaseUrl(rawUrl: string) {
   try {
     url = new URL(rawUrl);
   } catch {
-    throw new Error("CODEX_BRIDGE_URL_REQUIRED");
+    throw new Error("CODEX_BRIDGE_URL_INVALID");
   }
   if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new Error("CODEX_BRIDGE_URL_REQUIRED");
+    throw new Error("CODEX_BRIDGE_URL_INVALID");
   }
-  url.search = "";
-  url.hash = "";
-  return url.toString().replace(/\/$/, "");
+  if (url.pathname !== "/" && url.pathname !== "") {
+    throw new Error("CODEX_BRIDGE_URL_INVALID");
+  }
+  return url.origin;
 }
 
 function buildGenerateUrl(baseUrl: string) {
-  return `${baseUrl}${BRIDGE_GENERATE_PATH}`;
+  return new URL(BRIDGE_GENERATE_PATH, `${baseUrl}/`).toString();
 }
 
 async function getCatalogImageModel(modelKey: string) {
@@ -86,16 +79,12 @@ async function getBridgeConfig(modelKey: ImageGenerationFormValues["model"]) {
     throw new Error("CODEX_BRIDGE_TOKEN_REQUIRED");
   }
 
-  const timeoutRaw = Number(providerConfig.timeout_ms ?? DEFAULT_TIMEOUT_MS);
   return {
     baseUrl: normalizeBridgeBaseUrl(rawBaseUrl),
     token,
     modelId: providerConfig.model_id.trim(),
     agentModel: providerConfig.agent_model?.trim() || DEFAULT_AGENT_MODEL,
-    timeoutMs:
-      Number.isFinite(timeoutRaw) && timeoutRaw > 0
-        ? timeoutRaw
-        : DEFAULT_TIMEOUT_MS,
+    timeoutMs: providerConfig.timeout_ms ?? DEFAULT_TIMEOUT_MS,
   } satisfies CodexBridgeConfig;
 }
 
@@ -236,6 +225,8 @@ export const codexBridgeImageAdapter: ImageGenerationAdapter = {
     switch (error.message) {
       case "CODEX_BRIDGE_URL_REQUIRED":
         return "Codex bridge URL이 설정되어 있지 않습니다.";
+      case "CODEX_BRIDGE_URL_INVALID":
+        return "Codex bridge URL 형식이 올바르지 않습니다. http(s) origin만 입력해주세요.";
       case "CODEX_BRIDGE_TOKEN_REQUIRED":
         return "Codex bridge token이 설정되어 있지 않습니다.";
       case "CODEX_BRIDGE_AUTH_FAILED":

--- a/src/server/image-generation/image-generation.test.ts
+++ b/src/server/image-generation/image-generation.test.ts
@@ -5,6 +5,8 @@ const mockHfGenerate = vi.hoisted(() => vi.fn());
 const mockHfMapError = vi.hoisted(() => vi.fn(() => "HF mapped error"));
 const mockCodexGenerate = vi.hoisted(() => vi.fn());
 const mockCodexMapError = vi.hoisted(() => vi.fn(() => "Codex mapped error"));
+const mockBridgeGenerate = vi.hoisted(() => vi.fn());
+const mockBridgeMapError = vi.hoisted(() => vi.fn(() => "Bridge mapped error"));
 const mockResolveImageStorageProvider = vi.hoisted(() => vi.fn());
 const mockLeemageUploadImages = vi.hoisted(() => vi.fn());
 
@@ -26,6 +28,13 @@ vi.mock("@/server/image-generation/adapters/codex-cli-adapter", () => ({
   },
 }));
 
+vi.mock("@/server/image-generation/adapters/codex-bridge-adapter", () => ({
+  codexBridgeImageAdapter: {
+    generate: mockBridgeGenerate,
+    mapError: mockBridgeMapError,
+  },
+}));
+
 vi.mock("@/server/image-generation/storage/storage-selector", () => ({
   resolveImageStorageProvider: mockResolveImageStorageProvider,
 }));
@@ -36,13 +45,16 @@ vi.mock("@/server/image-generation/storage/adapters/leemage-storage-adapter", ()
   },
 }));
 
-function catalogModel(key: string, provider: "hf_space" | "codex_cli") {
+function catalogModel(
+  key: string,
+  provider: "hf_space" | "codex_cli" | "codex_bridge",
+) {
   return {
     id: `image-${key}`,
     type: "image",
     key,
     label: key,
-    vendor: provider === "codex_cli" ? "OPENAI" : "HF",
+    vendor: provider === "hf_space" ? "HF" : "OPENAI",
     provider,
     providerConfig:
       provider === "codex_cli"
@@ -51,6 +63,14 @@ function catalogModel(key: string, provider: "hf_space" | "codex_cli") {
             model_id: "gpt-image-2",
             timeout_ms: 300000,
           }
+        : provider === "codex_bridge"
+          ? {
+              base_url_env: "CODEX_IMAGE_BRIDGE_URL",
+              token_env: "CODEX_IMAGE_BRIDGE_TOKEN",
+              model_id: "gpt-image-2",
+              agent_model: "gpt-5.5",
+              timeout_ms: 300000,
+            }
         : {
             space_id: "demo/space",
             api_name: "/generate_image",
@@ -91,6 +111,9 @@ describe("resolveImageGenerationResult provider dispatch", () => {
     mockCodexGenerate.mockResolvedValue({
       images: ["data:image/png;base64,Y29kZXg="],
     });
+    mockBridgeGenerate.mockResolvedValue({
+      images: ["data:image/png;base64,YnJpZGdl"],
+    });
   });
 
   afterEach(() => {
@@ -112,6 +135,7 @@ describe("resolveImageGenerationResult provider dispatch", () => {
       expect.objectContaining({ model: "z-image-turbo" }),
     );
     expect(mockCodexGenerate).not.toHaveBeenCalled();
+    expect(mockBridgeGenerate).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       status: "completed",
       skipDbSave: true,
@@ -144,6 +168,7 @@ describe("resolveImageGenerationResult provider dispatch", () => {
       expect.objectContaining({ model: "gpt-image-2-codex" }),
     );
     expect(mockHfGenerate).not.toHaveBeenCalled();
+    expect(mockBridgeGenerate).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       status: "completed",
       skipDbSave: true,
@@ -151,6 +176,39 @@ describe("resolveImageGenerationResult provider dispatch", () => {
         images: [
           {
             url: "data:image/png;base64,Y29kZXg=",
+            width: 1024,
+            height: 1024,
+          },
+        ],
+      },
+    });
+  });
+
+  it("codex_bridge 이미지 모델은 Codex bridge adapter로 라우팅한다", async () => {
+    mockGetModelCatalog.mockResolvedValue([
+      catalogModel("gpt-image-2-bridge", "codex_bridge"),
+    ]);
+
+    const { resolveImageGenerationResult } = await import(
+      "@/server/image-generation/image-generation"
+    );
+    const result = await resolveImageGenerationResult(
+      payload("gpt-image-2-bridge"),
+      "req-bridge",
+    );
+
+    expect(mockBridgeGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gpt-image-2-bridge" }),
+    );
+    expect(mockHfGenerate).not.toHaveBeenCalled();
+    expect(mockCodexGenerate).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      status: "completed",
+      skipDbSave: true,
+      result: {
+        images: [
+          {
+            url: "data:image/png;base64,YnJpZGdl",
             width: 1024,
             height: 1024,
           },
@@ -172,6 +230,7 @@ describe("resolveImageGenerationResult provider dispatch", () => {
 
     expect(mockHfGenerate).not.toHaveBeenCalled();
     expect(mockCodexGenerate).not.toHaveBeenCalled();
+    expect(mockBridgeGenerate).not.toHaveBeenCalled();
     expect(result).toEqual({
       status: "failed",
       errorMessage: "선택한 이미지 모델을 찾을 수 없습니다.",
@@ -196,6 +255,7 @@ describe("resolveImageGenerationResult provider dispatch", () => {
 
     expect(mockHfGenerate).not.toHaveBeenCalled();
     expect(mockCodexGenerate).not.toHaveBeenCalled();
+    expect(mockBridgeGenerate).not.toHaveBeenCalled();
     expect(result).toEqual({
       status: "failed",
       errorMessage: "지원하지 않는 이미지 provider입니다.",

--- a/src/server/image-generation/image-generation.ts
+++ b/src/server/image-generation/image-generation.ts
@@ -1,5 +1,6 @@
 import type { ImageGenerationFormValues } from "@/features/image-generation/model/image-generation-schema";
 import type { ImageGenerationResponse } from "@/features/image-generation/model/image-generation-types";
+import { codexBridgeImageAdapter } from "@/server/image-generation/adapters/codex-bridge-adapter";
 import { codexCliImageAdapter } from "@/server/image-generation/adapters/codex-cli-adapter";
 import { hfSpaceImageAdapter } from "@/server/image-generation/adapters/hf-space-adapter";
 import type { ImageGenerationAdapter } from "@/server/image-generation/adapters/types";
@@ -9,7 +10,7 @@ import { resolveImageStorageProvider } from "@/server/image-generation/storage/s
 import { getModelCatalog } from "@/server/model-catalog/catalog-service";
 import type { ImageModelCatalogItem } from "@/server/model-catalog/catalog-schema";
 
-type ImageProvider = "hf_space" | "codex_cli";
+type ImageProvider = "hf_space" | "codex_cli" | "codex_bridge";
 
 async function resolveCatalogImageModel(
   modelKey: ImageGenerationFormValues["model"]
@@ -38,6 +39,7 @@ async function getAdapter(
   const provider = await resolveImageProvider(modelKey);
   if (provider === "hf_space") return hfSpaceImageAdapter;
   if (provider === "codex_cli") return codexCliImageAdapter;
+  if (provider === "codex_bridge") return codexBridgeImageAdapter;
   throw new Error(`IMAGE_PROVIDER_NOT_SUPPORTED:${provider}`);
 }
 

--- a/src/server/model-catalog/catalog-schema.test.ts
+++ b/src/server/model-catalog/catalog-schema.test.ts
@@ -82,6 +82,45 @@ describe("model-catalog option normalization", () => {
     expect(parsed.data.providerConfig.token_env).toBe("CODEX_IMAGE_BRIDGE_TOKEN");
   });
 
+  it("codex_bridge provider config는 알 수 없는 필드를 거부한다", () => {
+    const parsed = modelCatalogInputSchema.safeParse({
+      type: "image",
+      key: "gpt-image-2-bridge",
+      label: "GPT Image 2 Bridge",
+      vendor: "OPENAI",
+      provider: "codex_bridge",
+      providerConfig: {
+        base_url_env: "CODEX_IMAGE_BRIDGE_URL",
+        token_env: "CODEX_IMAGE_BRIDGE_TOKEN",
+        model_id: "gpt-image-2",
+        agent_model: "gpt-5.5",
+        timeout_ms: 300000,
+        token: "must-not-be-persisted",
+      },
+      parameters: {
+        prompt: { ui: "textarea", required: true },
+        width: { ui: "hidden", min: 1024, max: 1024, step: 1, default: 1024 },
+        height: { ui: "hidden", min: 1024, max: 1024, step: 1, default: 1024 },
+        steps: { ui: "hidden", min: 1, max: 1, step: 1, default: 1 },
+        seed: { ui: "hidden", default: "" },
+        imageCount: { ui: "hidden", min: 1, max: 1, step: 1, default: 1 },
+      },
+      meta: {
+        pipeline: "image_generation",
+        model_id: "gpt-image-2",
+        default_width: 1024,
+        default_height: 1024,
+        default_steps: 1,
+        concurrent_limit: 1,
+        max_input_images: 1,
+      },
+      isActive: true,
+      isDefault: false,
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
   it("image 모델은 provider와 providerConfig가 일치해야 한다", () => {
     const base = {
       type: "image",

--- a/src/server/model-catalog/catalog-schema.test.ts
+++ b/src/server/model-catalog/catalog-schema.test.ts
@@ -41,6 +41,47 @@ describe("model-catalog option normalization", () => {
     expect(parsed.data.providerConfig.model_id).toBe("gpt-image-2");
   });
 
+  it("image 모델은 codex_bridge provider config를 허용한다", () => {
+    const parsed = modelCatalogInputSchema.safeParse({
+      type: "image",
+      key: "gpt-image-2-bridge",
+      label: "GPT Image 2 Bridge",
+      vendor: "OPENAI",
+      provider: "codex_bridge",
+      providerConfig: {
+        base_url_env: "CODEX_IMAGE_BRIDGE_URL",
+        token_env: "CODEX_IMAGE_BRIDGE_TOKEN",
+        model_id: "gpt-image-2",
+        agent_model: "gpt-5.5",
+        timeout_ms: 300000,
+      },
+      parameters: {
+        prompt: { ui: "textarea", required: true },
+        width: { ui: "hidden", min: 1024, max: 1024, step: 1, default: 1024 },
+        height: { ui: "hidden", min: 1024, max: 1024, step: 1, default: 1024 },
+        steps: { ui: "hidden", min: 1, max: 1, step: 1, default: 1 },
+        seed: { ui: "hidden", default: "" },
+        imageCount: { ui: "hidden", min: 1, max: 1, step: 1, default: 1 },
+      },
+      meta: {
+        pipeline: "image_generation",
+        model_id: "gpt-image-2",
+        default_width: 1024,
+        default_height: 1024,
+        default_steps: 1,
+        concurrent_limit: 1,
+        max_input_images: 1,
+      },
+      isActive: true,
+      isDefault: false,
+    });
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.provider).toBe("codex_bridge");
+    expect(parsed.data.providerConfig.token_env).toBe("CODEX_IMAGE_BRIDGE_TOKEN");
+  });
+
   it("image 모델은 provider와 providerConfig가 일치해야 한다", () => {
     const base = {
       type: "image",
@@ -84,12 +125,22 @@ describe("model-catalog option normalization", () => {
         agent_model: "gpt-5.5",
       },
     });
+    const bridgeWithCodexConfig = modelCatalogInputSchema.safeParse({
+      ...base,
+      provider: "codex_bridge",
+      providerConfig: {
+        command: "codex",
+        model_id: "gpt-image-2",
+        agent_model: "gpt-5.5",
+      },
+    });
 
     expect(codexWithHfConfig.success).toBe(false);
     expect(hfWithCodexConfig.success).toBe(false);
+    expect(bridgeWithCodexConfig.success).toBe(false);
   });
 
-  it("video와 audio 모델은 codex_cli provider를 거부한다", () => {
+  it("video와 audio 모델은 codex_cli와 codex_bridge provider를 거부한다", () => {
     const videoParsed = modelCatalogInputSchema.safeParse({
       type: "video",
       key: "video-codex",
@@ -137,9 +188,58 @@ describe("model-catalog option normalization", () => {
         default_speed: 1,
       },
     });
+    const videoBridgeParsed = modelCatalogInputSchema.safeParse({
+      type: "video",
+      key: "video-bridge",
+      label: "Video Bridge",
+      vendor: "OPENAI",
+      provider: "codex_bridge",
+      providerConfig: {
+        base_url_env: "CODEX_IMAGE_BRIDGE_URL",
+        token_env: "CODEX_IMAGE_BRIDGE_TOKEN",
+        model_id: "gpt-image-2",
+      },
+      parameters: {
+        prompt: { ui: "textarea", required: true },
+        durationSec: { ui: "range", min: 1, max: 5, step: 1, default: 3 },
+        steps: { ui: "range", min: 1, max: 10, step: 1, default: 5 },
+        guidanceScale: { ui: "range", min: 0, max: 10, step: 1, default: 1 },
+      },
+      meta: {
+        supports_init_image: false,
+        t2v_model_id: "video-bridge",
+        default_width: 1280,
+        default_height: 720,
+        default_duration_sec: 3,
+        default_fps: 24,
+        default_steps: 5,
+        default_guidance_scale: 1,
+      },
+    });
+    const audioBridgeParsed = modelCatalogInputSchema.safeParse({
+      type: "audio",
+      key: "audio-bridge",
+      label: "Audio Bridge",
+      vendor: "OPENAI",
+      provider: "codex_bridge",
+      providerConfig: {
+        base_url_env: "CODEX_IMAGE_BRIDGE_URL",
+        token_env: "CODEX_IMAGE_BRIDGE_TOKEN",
+        model_id: "gpt-image-2",
+      },
+      parameters: {
+        prompt: { ui: "textarea", required: true },
+      },
+      meta: {
+        model_id: "audio-bridge",
+        default_speed: 1,
+      },
+    });
 
     expect(videoParsed.success).toBe(false);
     expect(audioParsed.success).toBe(false);
+    expect(videoBridgeParsed.success).toBe(false);
+    expect(audioBridgeParsed.success).toBe(false);
   });
 
   it("등록 payload의 flat/tuple options를 canonical option object로 정규화한다", () => {

--- a/src/server/model-catalog/catalog-schema.ts
+++ b/src/server/model-catalog/catalog-schema.ts
@@ -122,7 +122,7 @@ const codexBridgeConfigSchema = z
     agent_model: z.string().min(1).optional(),
     timeout_ms: z.number().int().positive().optional(),
   })
-  .passthrough();
+  .strict();
 
 const imageMetaSchema = z.object({
   pipeline: z.string().min(1),

--- a/src/server/model-catalog/catalog-schema.ts
+++ b/src/server/model-catalog/catalog-schema.ts
@@ -114,6 +114,16 @@ const codexCliConfigSchema = z
   })
   .passthrough();
 
+const codexBridgeConfigSchema = z
+  .object({
+    base_url_env: z.string().min(1),
+    token_env: z.string().min(1),
+    model_id: z.string().min(1),
+    agent_model: z.string().min(1).optional(),
+    timeout_ms: z.number().int().positive().optional(),
+  })
+  .passthrough();
+
 const imageMetaSchema = z.object({
   pipeline: z.string().min(1),
   model_id: z.string().min(1),
@@ -150,8 +160,12 @@ const baseModelSchema = z.object({
   key: z.string().min(1),
   label: z.string().min(1),
   vendor: z.string().min(1),
-  provider: z.enum(["hf_space", "codex_cli"]),
-  providerConfig: z.union([hfSpaceConfigSchema, codexCliConfigSchema]),
+  provider: z.enum(["hf_space", "codex_cli", "codex_bridge"]),
+  providerConfig: z.union([
+    hfSpaceConfigSchema,
+    codexCliConfigSchema,
+    codexBridgeConfigSchema,
+  ]),
   parameters: z.unknown(),
   meta: z.unknown(),
   isActive: z.boolean(),
@@ -176,9 +190,15 @@ const imageCodexCliModelSchema = imageModelSchema.extend({
   providerConfig: codexCliConfigSchema,
 });
 
+const imageCodexBridgeModelSchema = imageModelSchema.extend({
+  provider: z.literal("codex_bridge"),
+  providerConfig: codexBridgeConfigSchema,
+});
+
 const imageModelProviderSchema = z.union([
   imageHfSpaceModelSchema,
   imageCodexCliModelSchema,
+  imageCodexBridgeModelSchema,
 ]);
 
 const videoModelSchema = baseModelSchema.extend({
@@ -202,8 +222,12 @@ const baseModelInputSchema = z.object({
   key: z.string().min(1),
   label: z.string().min(1),
   vendor: z.string().min(1),
-  provider: z.enum(["hf_space", "codex_cli"]),
-  providerConfig: z.union([hfSpaceConfigSchema, codexCliConfigSchema]),
+  provider: z.enum(["hf_space", "codex_cli", "codex_bridge"]),
+  providerConfig: z.union([
+    hfSpaceConfigSchema,
+    codexCliConfigSchema,
+    codexBridgeConfigSchema,
+  ]),
   parameters: z.unknown(),
   meta: z.unknown(),
   isActive: z.boolean().optional(),
@@ -226,9 +250,15 @@ const imageCodexCliModelInputSchema = imageModelInputSchema.extend({
   providerConfig: codexCliConfigSchema,
 });
 
+const imageCodexBridgeModelInputSchema = imageModelInputSchema.extend({
+  provider: z.literal("codex_bridge"),
+  providerConfig: codexBridgeConfigSchema,
+});
+
 const imageModelProviderInputSchema = z.union([
   imageHfSpaceModelInputSchema,
   imageCodexCliModelInputSchema,
+  imageCodexBridgeModelInputSchema,
 ]);
 
 const videoModelInputSchema = baseModelInputSchema.extend({

--- a/src/server/model-catalog/catalog-schema.ts
+++ b/src/server/model-catalog/catalog-schema.ts
@@ -114,7 +114,7 @@ const codexCliConfigSchema = z
   })
   .passthrough();
 
-const codexBridgeConfigSchema = z
+export const codexBridgeConfigSchema = z
   .object({
     base_url_env: z.string().min(1),
     token_env: z.string().min(1),
@@ -293,6 +293,9 @@ export type VideoModelCatalogItem = z.infer<typeof videoModelSchema>;
 export type AudioModelCatalogItem = z.infer<typeof audioModelSchema>;
 export type ModelCatalogType = ModelCatalogItem["type"];
 export type ModelCatalogInput = z.infer<typeof modelCatalogInputSchema>;
+export type CodexBridgeProviderConfig = z.infer<
+  typeof codexBridgeConfigSchema
+>;
 
 export type ModelCatalogParams = {
   includeInactive?: boolean;

--- a/src/server/model-catalog/handlers/update-model-catalog.test.ts
+++ b/src/server/model-catalog/handlers/update-model-catalog.test.ts
@@ -144,6 +144,42 @@ describe("updateModelCatalogHandler provider validation", () => {
     expect(mockInvalidateModelCatalogCache).toHaveBeenCalled();
   });
 
+  it("image 모델은 codex_bridge provider 업데이트를 허용한다", async () => {
+    mockGetModelCatalogRecordByKey.mockResolvedValue(imageRecord());
+    const { updateModelCatalogHandler } = await import(
+      "@/server/model-catalog/handlers/update-model-catalog"
+    );
+
+    await expect(
+      updateModelCatalogHandler({
+        key: "gpt-image-2-codex",
+        payload: {
+          provider: "codex_bridge",
+          providerConfig: {
+            base_url_env: "CODEX_IMAGE_BRIDGE_URL",
+            token_env: "CODEX_IMAGE_BRIDGE_TOKEN",
+            model_id: "gpt-image-2",
+            agent_model: "gpt-5.5",
+            timeout_ms: 300000,
+          },
+        },
+      }),
+    ).resolves.toEqual({ key: "gpt-image-2-codex" });
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          provider: "codex_bridge",
+          providerConfig: expect.objectContaining({
+            base_url_env: "CODEX_IMAGE_BRIDGE_URL",
+            token_env: "CODEX_IMAGE_BRIDGE_TOKEN",
+          }),
+        }),
+      }),
+    );
+    expect(mockInvalidateModelCatalogCache).toHaveBeenCalled();
+  });
+
   it("video 모델은 codex_cli provider 업데이트를 거부한다", async () => {
     mockGetModelCatalogRecordByKey.mockResolvedValue(videoRecord());
     const { updateModelCatalogHandler } = await import(
@@ -166,6 +202,28 @@ describe("updateModelCatalogHandler provider validation", () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
+  it("video 모델은 codex_bridge provider 업데이트를 거부한다", async () => {
+    mockGetModelCatalogRecordByKey.mockResolvedValue(videoRecord());
+    const { updateModelCatalogHandler } = await import(
+      "@/server/model-catalog/handlers/update-model-catalog"
+    );
+
+    await expect(
+      updateModelCatalogHandler({
+        key: "video-model",
+        payload: {
+          provider: "codex_bridge",
+          providerConfig: {
+            base_url_env: "CODEX_IMAGE_BRIDGE_URL",
+            token_env: "CODEX_IMAGE_BRIDGE_TOKEN",
+            model_id: "gpt-image-2",
+          },
+        },
+      }),
+    ).rejects.toThrow("INVALID_PAYLOAD");
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("image 모델도 provider만 codex_cli로 바꾸고 HF config를 남기면 거부한다", async () => {
     mockGetModelCatalogRecordByKey.mockResolvedValue(imageRecord());
     const { updateModelCatalogHandler } = await import(
@@ -177,6 +235,23 @@ describe("updateModelCatalogHandler provider validation", () => {
         key: "gpt-image-2-codex",
         payload: {
           provider: "codex_cli",
+        },
+      }),
+    ).rejects.toThrow("INVALID_PAYLOAD");
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("image 모델도 provider만 codex_bridge로 바꾸고 HF config를 남기면 거부한다", async () => {
+    mockGetModelCatalogRecordByKey.mockResolvedValue(imageRecord());
+    const { updateModelCatalogHandler } = await import(
+      "@/server/model-catalog/handlers/update-model-catalog"
+    );
+
+    await expect(
+      updateModelCatalogHandler({
+        key: "gpt-image-2-codex",
+        payload: {
+          provider: "codex_bridge",
         },
       }),
     ).rejects.toThrow("INVALID_PAYLOAD");

--- a/src/server/model-catalog/handlers/update-model-catalog.test.ts
+++ b/src/server/model-catalog/handlers/update-model-catalog.test.ts
@@ -180,6 +180,31 @@ describe("updateModelCatalogHandler provider validation", () => {
     expect(mockInvalidateModelCatalogCache).toHaveBeenCalled();
   });
 
+  it("codex_bridge provider 업데이트는 알 수 없는 config 필드를 거부한다", async () => {
+    mockGetModelCatalogRecordByKey.mockResolvedValue(imageRecord());
+    const { updateModelCatalogHandler } = await import(
+      "@/server/model-catalog/handlers/update-model-catalog"
+    );
+
+    await expect(
+      updateModelCatalogHandler({
+        key: "gpt-image-2-codex",
+        payload: {
+          provider: "codex_bridge",
+          providerConfig: {
+            base_url_env: "CODEX_IMAGE_BRIDGE_URL",
+            token_env: "CODEX_IMAGE_BRIDGE_TOKEN",
+            model_id: "gpt-image-2",
+            agent_model: "gpt-5.5",
+            timeout_ms: 300000,
+            token: "must-not-be-persisted",
+          },
+        },
+      }),
+    ).rejects.toThrow("INVALID_PAYLOAD");
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("video 모델은 codex_cli provider 업데이트를 거부한다", async () => {
     mockGetModelCatalogRecordByKey.mockResolvedValue(videoRecord());
     const { updateModelCatalogHandler } = await import(

--- a/src/server/model-catalog/handlers/update-model-catalog.ts
+++ b/src/server/model-catalog/handlers/update-model-catalog.ts
@@ -15,7 +15,7 @@ const updatePayloadSchema = z.object({
   key: z.string().min(1).optional(),
   label: z.string().min(1).optional(),
   vendor: z.string().min(1).optional(),
-  provider: z.enum(["hf_space", "codex_cli"]).optional(),
+  provider: z.enum(["hf_space", "codex_cli", "codex_bridge"]).optional(),
   providerConfig: z.record(z.string(), z.unknown()).optional(),
   parameters: z.record(z.string(), z.unknown()).optional(),
   meta: z.record(z.string(), z.unknown()).optional(),


### PR DESCRIPTION
# PR Draft: codex-image-bridge-provider

## 개요

- 변경 목적: Codex CLI/OAuth를 메인 앱 컨테이너에 설치하지 않고, 별도 `codex-image-bridge` HTTP 서비스에 위임해 GPT Image 2 이미지 생성을 수행할 수 있도록 image provider, adapter, model catalog, 운영 문서를 추가한다.
- 사용자 영향: 운영 환경의 leesfield는 bridge URL/token만 설정해 GPT Image 2 bridge 모델을 사용할 수 있으며, 기존 `hf_space` 및 `codex_cli` 이미지 provider 흐름은 유지된다.

## 변경 사항

- [x] image model catalog/admin update schema에 image-only `codex_bridge` provider와 `gpt-image-2-bridge` seed 모델 추가
- [x] `POST /v1/images/generate`를 호출하는 Codex bridge image adapter 추가
- [x] T2I/I2I 단일 입력 이미지 data URL 전달, timeout, auth, malformed/empty/non-2xx 오류 매핑 구현
- [x] image generation dispatch와 image UI/model metadata 테스트에 bridge 모델 경로 추가
- [x] Pre-PR review에서 지적된 providerConfig secret persistence, body parse timeout, default agent model, non-2xx mapping 문제 수정
- [x] `.env.example`, `MODEL_CATALOG.md`, `README.md`에 bridge 운영 전제와 env 설정 문서화

## 테스트

- [x] `pnpm vitest src/server/model-catalog/catalog-schema.test.ts src/server/model-catalog/handlers/update-model-catalog.test.ts` — PASS (14 tests)
- [x] `pnpm vitest src/server/image-generation/adapters/codex-bridge-adapter.test.ts` — PASS (7 tests)
- [x] `pnpm vitest src/server/image-generation/image-generation.test.ts src/features/image-generation/model/image-generation-schema.test.ts src/features/image-generation/ui/image-generation-form.test.tsx` — PASS (18 tests)
- [x] `pnpm vitest src/server/model-catalog/catalog-schema.test.ts src/server/model-catalog/handlers/update-model-catalog.test.ts src/server/image-generation/adapters/codex-bridge-adapter.test.ts src/server/image-generation/image-generation.test.ts src/features/image-generation/model/image-generation-schema.test.ts src/features/image-generation/ui/image-generation-form.test.tsx` — PASS (39 tests)
- [x] `pnpm db:generate` — PASS
- [x] `pnpm db:seed:model-catalog` — PASS (`created 0, updated 5`)
- [x] `pnpm typecheck` — PASS
- [x] `pnpm lint` — PASS (0 errors, 16 existing warnings)
- [x] `git diff --check` — PASS
- [x] Pre-PR review follow-up — approve, no remaining Critical/Important findings

## 아키텍처 다이어그램

```mermaid
sequenceDiagram
  participant User as Image UI
  participant App as leesfield image generation
  participant Catalog as Model catalog
  participant Bridge as codex-image-bridge
  participant Codex as Codex CLI/OAuth

  User->>App: Generate with gpt-image-2-bridge
  App->>Catalog: Resolve codex_bridge providerConfig
  Catalog-->>App: Env names, model_id, agent_model, timeout_ms
  App->>App: Resolve init image to data URL
  App->>Bridge: POST /v1/images/generate
  Bridge->>Codex: codex exec with OAuth session
  Codex-->>Bridge: Generated image artifact
  Bridge-->>App: data URL images
  App-->>User: Existing image result flow
```

## 관련 문서

- Spec: `docs/features/F046-codex-image-bridge-provider/spec.md`
- Plan: `docs/features/F046-codex-image-bridge-provider/plan.md`
- Tasks: `docs/features/F046-codex-image-bridge-provider/tasks.md`
- Decisions: `docs/features/F046-codex-image-bridge-provider/decisions.md`
- Issue: #89
- Closes #89


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * Codex Image Bridge 지원 추가: 외부 브리지 서비스로 이미지 생성 위임 및 새로운 모델 키(gpt-image-2-bridge) 추가
  * 새 환경 변수 추가: CODEX_IMAGE_BRIDGE_URL, CODEX_IMAGE_BRIDGE_TOKEN

* **Documentation**
  * 모델 카탈로그 및 README에 codex_bridge 설정, URL 형식·토큰 사용 방식, 타임아웃 및 잡 기반 API 계약 문서화

* **Tests**
  * codex_bridge용 단위·통합·스키마 테스트 추가로 동작·오류 처리 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->