### PR TITLE
feat(#95): hf-space-dynamic-parameter-contract (HF Space 파라미터를 손실 없이 자동 매핑하는 동적 계약 도입)

### DIFF
--- a/src/app/api/audio-generation/route.test.ts
+++ b/src/app/api/audio-generation/route.test.ts
@@ -182,4 +182,36 @@ describe("POST /api/audio-generation", () => {
       }),
     );
   });
+
+  it("multipart dynamicParams JSON을 object로 파싱한다", async () => {
+    mockGetSession.mockResolvedValue({
+      isLoggedIn: true,
+      adminEmail: "admin@example.com",
+    });
+    mockValidatePayload.mockResolvedValue({
+      success: false,
+      error: { flatten: () => ({}) },
+    });
+    const formData = new FormData();
+    formData.set("prompt", "hello");
+    formData.set("model", "qwen-dynamic");
+    formData.set(
+      "dynamicParams",
+      JSON.stringify({ "hf:model_size": "1.7B", "hf:use_xvector_only": false }),
+    );
+
+    await POST(new Request("http://localhost/api/audio-generation", {
+      method: "POST",
+      body: formData,
+    }));
+
+    expect(mockValidatePayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dynamicParams: {
+          "hf:model_size": "1.7B",
+          "hf:use_xvector_only": false,
+        },
+      }),
+    );
+  });
 });

--- a/src/app/api/audio-generation/route.ts
+++ b/src/app/api/audio-generation/route.ts
@@ -17,6 +17,19 @@ import { validateAudioGenerationPayload } from "@/server/model-catalog/generatio
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
+function getDynamicParams(formData: FormData) {
+  const value = getString(formData, "dynamicParams");
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function POST(request: Request) {
   const session = await getSession();
 
@@ -50,6 +63,7 @@ export async function POST(request: Request) {
           temperature: getNumber(formData, "temperature"),
           topK: getNumber(formData, "topK"),
           repetitionPenalty: getNumber(formData, "repetitionPenalty"),
+          dynamicParams: getDynamicParams(formData),
         }))
         .catch(() => null)
     : await request.json().catch(() => null);

--- a/src/features/audio-generation/api/audio-generation-api.test.ts
+++ b/src/features/audio-generation/api/audio-generation-api.test.ts
@@ -93,6 +93,32 @@ describe("requestAudioGeneration", () => {
     expect(body.get("repetitionPenalty")).toBe("1.1");
   });
 
+  it("dynamicParams를 JSON field로 직렬화한다", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ requestId: "req-dynamic", status: "pending", progress: 0 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await requestAudioGeneration({
+      prompt: "hello",
+      model: "qwen-dynamic",
+      dynamicParams: {
+        "hf:model_size": "1.7B",
+        "hf:use_xvector_only": false,
+      },
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = init.body as FormData;
+    expect(body.get("dynamicParams")).toBe(
+      JSON.stringify({
+        "hf:model_size": "1.7B",
+        "hf:use_xvector_only": false,
+      }),
+    );
+  });
+
   it("실패 응답이면 에러를 그대로 노출한다", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,

--- a/src/features/audio-generation/api/audio-generation-api.ts
+++ b/src/features/audio-generation/api/audio-generation-api.ts
@@ -37,6 +37,10 @@ export async function requestAudioGeneration(
 ): Promise<AudioGenerationResponse> {
   const formData = new FormData();
   Object.entries(payload).forEach(([key, value]) => {
+    if (key === "dynamicParams" && value && typeof value === "object") {
+      formData.append(key, JSON.stringify(value));
+      return;
+    }
     appendIfPresent(formData, key, value);
   });
 

--- a/src/features/audio-generation/model/audio-generation-schema.ts
+++ b/src/features/audio-generation/model/audio-generation-schema.ts
@@ -25,6 +25,9 @@ const audioGenerationBaseSchema = z.object({
   temperature: z.number().optional(),
   topK: z.number().optional(),
   repetitionPenalty: z.number().optional(),
+  dynamicParams: z
+    .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+    .optional(),
 });
 
 export const audioGenerationOpenApiSchema = audioGenerationBaseSchema;
@@ -96,4 +99,5 @@ export const audioGenerationDefaults: AudioGenerationFormValues = {
   temperature: undefined,
   topK: undefined,
   repetitionPenalty: undefined,
+  dynamicParams: {},
 };

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -148,6 +148,74 @@ const qwenModeModelFixture: RuntimeAudioModel = {
   isDefault: true,
 };
 
+const dynamicParameterModelFixture: RuntimeAudioModel = {
+  type: "audio",
+  key: "qwen-dynamic-clone",
+  label: "Qwen Dynamic Clone",
+  vendor: "HF Space",
+  provider: "huggingface-space",
+  providerConfig: {},
+  parameters: {
+    prompt: { ui: "textarea", required: true },
+    "hf:model_size": {
+      ui: "select",
+      label: "Model Size",
+      options: [
+        { label: "0.6B", value: "0.6B" },
+        { label: "1.7B", value: "1.7B" },
+      ],
+      default: "1.7B",
+      binding: {
+        source: "hf_space",
+        parameterName: "model_size",
+        valueType: "string",
+        order: 1,
+      },
+    },
+    "hf:use_xvector_only": {
+      ui: "toggle",
+      label: "Use x-vector only",
+      default: true,
+      binding: {
+        source: "hf_space",
+        parameterName: "use_xvector_only",
+        valueType: "boolean",
+        order: 2,
+      },
+    },
+    "hf:reference_sample": {
+      ui: "upload",
+      label: "Reference Sample",
+      required: true,
+      binding: {
+        source: "hf_space",
+        parameterName: "reference_sample",
+        valueType: "file",
+        order: 3,
+      },
+    },
+    "hf:temperature": {
+      ui: "range",
+      label: "Temperature",
+      min: 0.1,
+      max: 1,
+      step: 0.1,
+      default: 0.7,
+      binding: {
+        source: "hf_space",
+        parameterName: "temperature",
+        valueType: "number",
+        order: 4,
+      },
+    },
+  },
+  meta: {
+    supports_input_audio: true,
+  },
+  isActive: true,
+  isDefault: true,
+};
+
 async function waitForModels() {
   await screen.findByRole("button", { name: /Qwen 3\.5 TTS/i });
 }
@@ -616,4 +684,77 @@ describe("AudioGenerationForm", () => {
       );
     });
   }, 15_000);
+
+  it("HF binding 기반 동적 필드를 렌더링하고 dynamicParams로 제출한다", async () => {
+    const startGeneration = vi.fn();
+    mockUseAudioGeneration.mockReturnValue({
+      state: { status: "idle", progress: 0 },
+      startGeneration,
+      reset: vi.fn(),
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ items: [dynamicParameterModelFixture] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const fileReaderResult = "data:audio/wav;base64,ZHluYW1pYw==";
+    class MockFileReader {
+      result: string | ArrayBuffer | null = null;
+      onload: null | (() => void) = null;
+      readAsDataURL() {
+        this.result = fileReaderResult;
+        this.onload?.();
+      }
+    }
+    vi.stubGlobal("FileReader", MockFileReader as unknown as typeof FileReader);
+
+    const user = userEvent.setup();
+    renderWithIntl(<AudioGenerationForm isAuthenticated />);
+    await screen.findByRole("button", { name: /Qwen Dynamic Clone/i });
+
+    await user.type(
+      within(screen.getByRole("region", { name: "작업 입력" })).getByRole(
+        "textbox",
+      ),
+      "clone this voice",
+    );
+    await user.click(screen.getByRole("button", { name: /설정/i }));
+
+    expect(
+      screen.getByRole("combobox", { name: "Model Size" }),
+    ).toHaveTextContent("1.7B");
+    expect(
+      screen.getByRole("button", { name: "Use x-vector only" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("slider", { name: "Temperature" }),
+    ).toHaveValue("0.7");
+    await user.upload(
+      screen.getByLabelText("Reference Sample"),
+      new File([Uint8Array.from([82, 73, 70, 70])], "ref.wav", {
+        type: "audio/wav",
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "생성" }));
+
+    await waitFor(() => {
+      expect(startGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: "clone this voice",
+          dynamicParams: {
+            "hf:model_size": "1.7B",
+            "hf:use_xvector_only": true,
+            "hf:reference_sample": fileReaderResult,
+            "hf:temperature": 0.7,
+          },
+        }),
+      );
+    });
+  });
 });

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -172,6 +172,21 @@ const dynamicParameterModelFixture: RuntimeAudioModel = {
         order: 1,
       },
     },
+    "hf:quality_level": {
+      ui: "select",
+      label: "Quality Level",
+      options: [
+        { label: "Fast", value: 1 },
+        { label: "High", value: 2 },
+      ],
+      default: 2,
+      binding: {
+        source: "hf_space",
+        parameterName: "quality_level",
+        valueType: "number",
+        order: 2,
+      },
+    },
     "hf:use_xvector_only": {
       ui: "toggle",
       label: "Use x-vector only",
@@ -180,7 +195,7 @@ const dynamicParameterModelFixture: RuntimeAudioModel = {
         source: "hf_space",
         parameterName: "use_xvector_only",
         valueType: "boolean",
-        order: 2,
+        order: 3,
       },
     },
     "hf:reference_sample": {
@@ -191,7 +206,7 @@ const dynamicParameterModelFixture: RuntimeAudioModel = {
         source: "hf_space",
         parameterName: "reference_sample",
         valueType: "file",
-        order: 3,
+        order: 4,
       },
     },
     "hf:temperature": {
@@ -205,7 +220,7 @@ const dynamicParameterModelFixture: RuntimeAudioModel = {
         source: "hf_space",
         parameterName: "temperature",
         valueType: "number",
-        order: 4,
+        order: 5,
       },
     },
     "hf:style_prompt": {
@@ -216,7 +231,7 @@ const dynamicParameterModelFixture: RuntimeAudioModel = {
         source: "hf_space",
         parameterName: "style_prompt",
         valueType: "string",
-        order: 5,
+        order: 6,
       },
     },
   },
@@ -740,6 +755,9 @@ describe("AudioGenerationForm", () => {
     expect(
       screen.getByRole("combobox", { name: "Model Size" }),
     ).toHaveTextContent("1.7B");
+    Element.prototype.scrollIntoView = vi.fn();
+    screen.getByRole("combobox", { name: "Quality Level" }).focus();
+    await user.keyboard("{ArrowDown}{Home}{Enter}");
     expect(
       screen.getByRole("button", { name: "Use x-vector only" }),
     ).toHaveAttribute("aria-pressed", "true");
@@ -763,6 +781,7 @@ describe("AudioGenerationForm", () => {
           prompt: "clone this voice",
           dynamicParams: {
             "hf:model_size": "1.7B",
+            "hf:quality_level": 1,
             "hf:use_xvector_only": true,
             "hf:reference_sample": fileReaderResult,
             "hf:temperature": 0.7,

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -208,6 +208,17 @@ const dynamicParameterModelFixture: RuntimeAudioModel = {
         order: 4,
       },
     },
+    "hf:style_prompt": {
+      ui: "textarea",
+      label: "Style Prompt",
+      default: "Warm narration",
+      binding: {
+        source: "hf_space",
+        parameterName: "style_prompt",
+        valueType: "string",
+        order: 5,
+      },
+    },
   },
   meta: {
     supports_input_audio: true,
@@ -735,6 +746,9 @@ describe("AudioGenerationForm", () => {
     expect(
       screen.getByRole("slider", { name: "Temperature" }),
     ).toHaveValue("0.7");
+    expect(screen.getByRole("textbox", { name: "Style Prompt" }).tagName).toBe(
+      "TEXTAREA",
+    );
     await user.upload(
       screen.getByLabelText("Reference Sample"),
       new File([Uint8Array.from([82, 73, 70, 70])], "ref.wav", {
@@ -752,6 +766,7 @@ describe("AudioGenerationForm", () => {
             "hf:use_xvector_only": true,
             "hf:reference_sample": fileReaderResult,
             "hf:temperature": 0.7,
+            "hf:style_prompt": "Warm narration",
           },
         }),
       );

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -888,7 +888,13 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
               </AppFormLabel>
               <AppSelectRoot
                 value={field.value === undefined ? "" : String(field.value)}
-                onValueChange={field.onChange}
+                onValueChange={(nextValue) =>
+                  field.onChange(
+                    config.binding?.valueType === "number"
+                      ? Number(nextValue)
+                      : nextValue,
+                  )
+                }
               >
                 <AppFormControl>
                   <AppSelectTrigger surface="toolbar" aria-label={label}>

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -945,6 +945,32 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
       );
     }
 
+    if (config.ui === "textarea") {
+      return (
+        <AppFormControllerField
+          key={`${activeModel}-${key}`}
+          control={form.control}
+          name={fieldName}
+          render={({ field }) => (
+            <AppFormItem className="flex flex-col gap-2">
+              <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                {label}
+              </AppFormLabel>
+              <AppFormControl>
+                <AppTextarea
+                  value={typeof field.value === "string" ? field.value : ""}
+                  aria-label={label}
+                  onChange={field.onChange}
+                  className="min-h-[96px]"
+                />
+              </AppFormControl>
+              <AppFormMessage className="text-xs text-red-400" />
+            </AppFormItem>
+          )}
+        />
+      );
+    }
+
     return (
       <AppFormControllerField
         key={`${activeModel}-${key}`}

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/shared/model-catalog/parameter-options";
 import {
   getRuntimeAudioParamConfig,
+  getRuntimeAudioDynamicParameters,
   getRuntimeAudioParamRange,
   resolveRuntimeAudioDefaults,
   resolveRuntimeAudioSupportsInputAudio,
@@ -68,7 +69,10 @@ type AudioGenerationFormProps = {
   isAuthenticated: boolean;
 };
 
-type AudioFieldName = Exclude<keyof AudioGenerationFormValues, "prompt" | "model">;
+type AudioFieldName = Exclude<
+  keyof AudioGenerationFormValues,
+  "prompt" | "model" | "dynamicParams"
+>;
 
 const audioFieldOrder: Record<AudioFieldName, number> = {
   modeChoice: 10,
@@ -259,6 +263,10 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
   const primaryParameterKeys = parameterKeys.filter(
     (key) => !advancedAudioFields.has(key),
   );
+  const dynamicParameters = useMemo(
+    () => getRuntimeAudioDynamicParameters(activeRuntimeModel),
+    [activeRuntimeModel],
+  );
   const advancedParameterKeys = parameterKeys.filter((key) =>
     advancedAudioFields.has(key) && visibleAdvancedAudioFields.has(key),
   );
@@ -269,6 +277,13 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
       const config = getRuntimeAudioParamConfig(activeRuntimeModel, key);
       if (!config?.required) return false;
       const value = formValues?.[key];
+      if (typeof value === "string") return !value.trim();
+      if (typeof value === "number") return !Number.isFinite(value);
+      return value === undefined || value === null;
+    }) &&
+    !dynamicParameters.some(({ key, config }) => {
+      if (!config.required) return false;
+      const value = formValues?.dynamicParams?.[key];
       if (typeof value === "string") return !value.trim();
       if (typeof value === "number") return !Number.isFinite(value);
       return value === undefined || value === null;
@@ -287,6 +302,17 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
     const defaults = resolveRuntimeAudioDefaults(model);
     const currentValues = form.getValues();
     const supportsInputAudio = resolveRuntimeAudioSupportsInputAudio(model);
+    const dynamicParams: NonNullable<
+      AudioGenerationFormValues["dynamicParams"]
+    > = {};
+    for (const { key, config } of getRuntimeAudioDynamicParameters(model)) {
+      const currentValue = currentValues.dynamicParams?.[key];
+      if (currentValue !== undefined) {
+        dynamicParams[key] = currentValue;
+      } else if (config.default !== undefined) {
+        dynamicParams[key] = config.default;
+      }
+    }
 
     form.reset({
       ...audioGenerationDefaults,
@@ -312,6 +338,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
       temperature: defaults.temperature,
       topK: defaults.topK,
       repetitionPenalty: defaults.repetitionPenalty,
+      dynamicParams,
     });
 
     if (!supportsInputAudio) {
@@ -752,6 +779,208 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
     );
   };
 
+  const renderDynamicAudioField = (
+    key: string,
+    config: (typeof dynamicParameters)[number]["config"],
+  ) => {
+    const fieldName = `dynamicParams.${key}` as const;
+    const label =
+      typeof config.label === "string" && config.label.trim()
+        ? config.label
+        : key;
+
+    if (config.ui === "range") {
+      const min = typeof config.min === "number" ? config.min : 0;
+      const max = typeof config.max === "number" ? config.max : 100;
+      const step = typeof config.step === "number" ? config.step : 1;
+      return (
+        <AppFormControllerField
+          key={`${activeModel}-${key}`}
+          control={form.control}
+          name={fieldName}
+          render={({ field }) => {
+            const value =
+              typeof field.value === "number"
+                ? field.value
+                : typeof config.default === "number"
+                  ? config.default
+                  : min;
+            return (
+              <AppFormItem className="flex flex-col gap-3">
+                <div className="flex items-center justify-between">
+                  <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                    {label}
+                  </AppFormLabel>
+                  <span className="rounded border border-white/10 bg-surface-lighter px-2 py-0.5 text-xs font-bold text-white font-mono">
+                    {value}
+                  </span>
+                </div>
+                <AppFormControl>
+                  <input
+                    type="range"
+                    min={min}
+                    max={max}
+                    step={step}
+                    value={value}
+                    aria-label={label}
+                    onChange={(event) =>
+                      field.onChange(Number(event.target.value))
+                    }
+                    className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-surface-lighter"
+                  />
+                </AppFormControl>
+                <AppFormMessage className="text-xs text-red-400" />
+              </AppFormItem>
+            );
+          }}
+        />
+      );
+    }
+
+    if (config.ui === "upload") {
+      return (
+        <AppFormControllerField
+          key={`${activeModel}-${key}`}
+          control={form.control}
+          name={fieldName}
+          render={({ field }) => (
+            <AppFormItem className="flex flex-col gap-3">
+              <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                {label}
+              </AppFormLabel>
+              <AppFormControl>
+                <input
+                  type="file"
+                  accept="audio/*"
+                  aria-label={label}
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (!file) return;
+                    const reader = new FileReader();
+                    reader.onload = () => {
+                      if (typeof reader.result === "string") {
+                        field.onChange(reader.result);
+                      }
+                    };
+                    reader.readAsDataURL(file);
+                    event.target.value = "";
+                  }}
+                  className="block w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white file:mr-3 file:rounded-md file:border-0 file:bg-white/10 file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-white"
+                />
+              </AppFormControl>
+              <AppFormMessage className="text-xs text-red-400" />
+            </AppFormItem>
+          )}
+        />
+      );
+    }
+
+    if (config.ui === "select") {
+      return (
+        <AppFormControllerField
+          key={`${activeModel}-${key}`}
+          control={form.control}
+          name={fieldName}
+          render={({ field }) => (
+            <AppFormItem className="flex flex-col gap-2">
+              <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                {label}
+              </AppFormLabel>
+              <AppSelectRoot
+                value={field.value === undefined ? "" : String(field.value)}
+                onValueChange={field.onChange}
+              >
+                <AppFormControl>
+                  <AppSelectTrigger surface="toolbar" aria-label={label}>
+                    <AppSelectValue placeholder={label} />
+                  </AppSelectTrigger>
+                </AppFormControl>
+                <AppSelectContent>
+                  {(config.options ?? []).map((option) => (
+                    <AppSelectItem
+                      key={String(getRuntimeParameterOptionValue(option))}
+                      value={String(getRuntimeParameterOptionValue(option))}
+                    >
+                      {getRuntimeParameterOptionLabel(option)}
+                    </AppSelectItem>
+                  ))}
+                </AppSelectContent>
+              </AppSelectRoot>
+              <AppFormMessage className="text-xs text-red-400" />
+            </AppFormItem>
+          )}
+        />
+      );
+    }
+
+    if (config.ui === "toggle") {
+      return (
+        <AppFormControllerField
+          key={`${activeModel}-${key}`}
+          control={form.control}
+          name={fieldName}
+          render={({ field }) => {
+            const isEnabled = field.value === true;
+            return (
+              <AppFormItem className="flex items-center justify-between gap-4">
+                <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+                  {label}
+                </AppFormLabel>
+                <AppFormControl>
+                  <AppButton
+                    type="button"
+                    variant={isEnabled ? "primary" : "surface"}
+                    size="sm"
+                    aria-label={label}
+                    aria-pressed={isEnabled}
+                    onClick={() => field.onChange(!isEnabled)}
+                  >
+                    {isEnabled ? "On" : "Off"}
+                  </AppButton>
+                </AppFormControl>
+              </AppFormItem>
+            );
+          }}
+        />
+      );
+    }
+
+    return (
+      <AppFormControllerField
+        key={`${activeModel}-${key}`}
+        control={form.control}
+        name={fieldName}
+        render={({ field }) => (
+          <AppFormItem className="flex flex-col gap-2">
+            <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
+              {label}
+            </AppFormLabel>
+            <AppFormControl>
+              <AppInput
+                value={
+                  typeof field.value === "string" ||
+                  typeof field.value === "number"
+                    ? field.value
+                    : ""
+                }
+                type={config.binding?.valueType === "number" ? "number" : "text"}
+                aria-label={label}
+                onChange={(event) =>
+                  field.onChange(
+                    config.binding?.valueType === "number"
+                      ? Number(event.target.value)
+                      : event.target.value,
+                  )
+                }
+              />
+            </AppFormControl>
+            <AppFormMessage className="text-xs text-red-400" />
+          </AppFormItem>
+        )}
+      />
+    );
+  };
+
   return (
     <AppForm {...form}>
       <form
@@ -906,6 +1135,9 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
                       >
                         <div className="flex max-h-[70vh] flex-col gap-5 overflow-y-auto pr-1">
                           {primaryParameterKeys.map((key) => renderAudioField(key))}
+                          {dynamicParameters.map(({ key, config }) =>
+                            renderDynamicAudioField(key, config),
+                          )}
                           {advancedParameterKeys.length > 0 ? (
                             <>
                               <div className="h-px bg-white/5" />

--- a/src/server/audio-generation/adapters/hf-space-adapter.test.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.test.ts
@@ -156,6 +156,183 @@ describe("hfSpaceAudioAdapter", () => {
     });
   });
 
+  it("generic binding을 원래 parameter_name과 Gradio file 값으로 복원한다", async () => {
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-dynamic-1",
+        type: "audio",
+        key: "qwen-dynamic-clone",
+        label: "Qwen Dynamic Clone",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "Qwen/Qwen3-TTS-dynamic-test",
+          api_name: "/generate_voice_clone",
+          timeout_ms: 120000,
+        },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+          "hf:model_size": {
+            ui: "select",
+            binding: {
+              source: "hf_space",
+              parameterName: "model_size",
+              valueType: "string",
+              order: 1,
+            },
+          },
+          "hf:reference_sample": {
+            ui: "upload",
+            required: true,
+            binding: {
+              source: "hf_space",
+              parameterName: "reference_sample",
+              valueType: "file",
+              order: 2,
+            },
+          },
+        },
+        meta: {
+          model_id: "Qwen/Qwen3-TTS-dynamic-test",
+          default_speed: 1,
+          concurrent_limit: 1,
+          supports_input_audio: true,
+        },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+
+    const predict = vi.fn().mockResolvedValue({
+      data: [{ path: "/file=/tmp/generated.wav" }],
+    });
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/generate_voice_clone": {
+            parameters: [
+              { parameter_name: "target_text", label: "Target Text" },
+              { parameter_name: "model_size", label: "Model Size" },
+              {
+                parameter_name: "reference_sample",
+                label: "Reference Sample",
+              },
+            ],
+          },
+        },
+      }),
+      predict,
+      config: {
+        components: [{ id: 1, type: "audio" }],
+        dependencies: [
+          { api_name: "/generate_voice_clone", outputs: [1] },
+        ],
+      },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ stage: "RUNNING" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: new Headers({ "content-type": "audio/wav" }),
+          arrayBuffer: async () => Uint8Array.from([82, 73, 70, 70]).buffer,
+        }),
+    );
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    await hfSpaceAudioAdapter.generate({
+      prompt: "hello dynamic",
+      model: "qwen-dynamic-clone",
+      speed: 1,
+      dynamicParams: {
+        "hf:model_size": "1.7B",
+        "hf:reference_sample": "data:audio/wav;base64,UklGRg==",
+      },
+    });
+
+    expect(predict).toHaveBeenCalledWith("/generate_voice_clone", {
+      target_text: "hello dynamic",
+      model_size: "1.7B",
+      reference_sample: expect.objectContaining({ mockedFile: expect.any(Blob) }),
+    });
+  });
+
+  it("저장된 generic binding이 endpoint에서 사라지면 parameter drift로 진단한다", async () => {
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-drift-1",
+        type: "audio",
+        key: "qwen-dynamic-drift",
+        label: "Qwen Dynamic Drift",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: {
+          space_id: "Qwen/Qwen3-TTS-drift-test",
+          api_name: "/generate_voice_clone",
+        },
+        parameters: {
+          "hf:model_size": {
+            ui: "select",
+            binding: {
+              source: "hf_space",
+              parameterName: "model_size",
+              valueType: "string",
+              order: 1,
+            },
+          },
+        },
+        meta: { default_speed: 1 },
+        isActive: true,
+        isDefault: true,
+      },
+    ]);
+    const predict = vi.fn();
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/generate_voice_clone": {
+            parameters: [{ parameter_name: "target_text", label: "Text" }],
+          },
+        },
+      }),
+      predict,
+      config: {
+        components: [],
+        dependencies: [{ api_name: "/generate_voice_clone", outputs: [] }],
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ stage: "RUNNING" }),
+      }),
+    );
+
+    const { hfSpaceAudioAdapter } = await import(
+      "@/server/audio-generation/adapters/hf-space-adapter"
+    );
+
+    await expect(
+      hfSpaceAudioAdapter.generate({
+        prompt: "hello",
+        model: "qwen-dynamic-drift",
+        speed: 1,
+        dynamicParams: { "hf:model_size": "1.7B" },
+      }),
+    ).rejects.toThrow("HF_SPACE_PARAMETER_INVALID");
+    expect(predict).not.toHaveBeenCalled();
+  });
+
   it("quota/sleep 오류를 사용자 친화적으로 매핑한다", async () => {
     const { hfSpaceAudioAdapter } = await import(
       "@/server/audio-generation/adapters/hf-space-adapter"

--- a/src/server/audio-generation/adapters/hf-space-adapter.ts
+++ b/src/server/audio-generation/adapters/hf-space-adapter.ts
@@ -10,6 +10,7 @@ import { scoreEndpointCandidate } from "@/server/hf-space/endpoint-scoring";
 import { getModelCatalog } from "@/server/model-catalog/catalog-service";
 import type { AudioModelCatalogItem } from "@/server/model-catalog/catalog-schema";
 import {
+  getRuntimeAudioDynamicParameters,
   getRuntimeAudioParamRange,
   resolveRuntimeAudioDefaults,
   type RuntimeAudioModel,
@@ -554,14 +555,61 @@ function resolveParamValue(
   return parameter.parameter_default;
 }
 
+function resolveDynamicBindingValues(
+  model: RuntimeAudioModel,
+  payload: AudioGenerationFormValues,
+) {
+  const parameters = getRuntimeAudioDynamicParameters(model);
+  const parametersByKey = new Map(
+    parameters.map((parameter) => [parameter.key, parameter]),
+  );
+  const values = new Map<string, unknown>();
+
+  for (const [key, value] of Object.entries(payload.dynamicParams ?? {})) {
+    const parameter = parametersByKey.get(key);
+    if (!parameter) {
+      throw new Error("HF_SPACE_PARAMETER_INVALID");
+    }
+    const resolvedValue =
+      parameter.binding.valueType === "file"
+        ? typeof value === "string" && value
+          ? toGradioInputAudio(value)
+          : undefined
+        : value;
+    if (resolvedValue === undefined) {
+      throw new Error("HF_SPACE_PARAMETER_INVALID");
+    }
+    values.set(
+      parameter.binding.parameterName.trim().toLowerCase(),
+      resolvedValue,
+    );
+  }
+
+  for (const parameter of parameters) {
+    if (
+      parameter.config.required &&
+      !Object.prototype.hasOwnProperty.call(
+        payload.dynamicParams ?? {},
+        parameter.key,
+      )
+    ) {
+      throw new Error("HF_SPACE_PARAMETER_INVALID");
+    }
+  }
+
+  return values;
+}
+
 function buildRequestPayload(
   apiInfo: ViewApiResponse | null,
   apiName: string,
   payload: AudioGenerationFormValues,
+  model: RuntimeAudioModel,
   defaults: ReturnType<typeof resolveRuntimeAudioDefaults>,
   speed: number,
   seed: { seedValue: number; randomize: boolean },
 ) {
+  const dynamicBindingValues = resolveDynamicBindingValues(model, payload);
   const endpoint = getEndpointInfoFromSnapshot(apiInfo, apiName);
   const parameters =
     endpoint?.parameters?.filter(
@@ -638,22 +686,43 @@ function buildRequestPayload(
     if (!seed.randomize) {
       fallbackPayload.seed = seed.seedValue;
     }
+    for (const parameter of getRuntimeAudioDynamicParameters(model)) {
+      const value = dynamicBindingValues.get(
+        parameter.binding.parameterName.trim().toLowerCase(),
+      );
+      if (value !== undefined) {
+        fallbackPayload[parameter.binding.parameterName] = value;
+      }
+    }
 
     return fallbackPayload;
   }
 
   const requestPayload: Record<string, unknown> = {};
+  const endpointParameterNames = new Set(
+    parameters.map((parameter) =>
+      resolveRequestParameterKey(parameter).trim().toLowerCase(),
+    ),
+  );
+  for (const parameterName of dynamicBindingValues.keys()) {
+    if (!endpointParameterNames.has(parameterName)) {
+      throw new Error("HF_SPACE_PARAMETER_INVALID");
+    }
+  }
 
   parameters.forEach((parameter) => {
     const key = resolveRequestParameterKey(parameter);
+    const dynamicValue = dynamicBindingValues.get(key.trim().toLowerCase());
 
-    requestPayload[key] = resolveParamValue(
-      parameter,
-      payload,
-      defaults,
-      speed,
-      seed,
-    );
+    requestPayload[key] =
+      dynamicValue ??
+      resolveParamValue(
+        parameter,
+        payload,
+        defaults,
+        speed,
+        seed,
+      );
   });
 
   return requestPayload;
@@ -713,7 +782,7 @@ async function fetchAudioDataUrl(
       buffer,
     });
     return `data:${contentType};base64,${buffer.toString("base64")}`;
-  } catch (error) {
+  } catch {
     if (controller.signal.aborted) {
       throw new Error("HF_SPACE_AUDIO_FETCH_TIMEOUT");
     }
@@ -871,14 +940,30 @@ export const hfSpaceAudioAdapter: AudioGenerationAdapter = {
     let lastRetryableError: Error | null = null;
 
     for (const apiName of apiCandidates) {
-      const requestPayload = buildRequestPayload(
-        apiInfo,
-        apiName,
-        payload,
-        defaults,
-        speed,
-        seed,
-      );
+      let requestPayload: Record<string, unknown>;
+      try {
+        requestPayload = buildRequestPayload(
+          apiInfo,
+          apiName,
+          payload,
+          model,
+          defaults,
+          speed,
+          seed,
+        );
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message === "HF_SPACE_PARAMETER_INVALID"
+        ) {
+          lastRetryableError = keepMoreSpecificRetryableError(
+            lastRetryableError,
+            error.message,
+          );
+          continue;
+        }
+        throw error;
+      }
 
       const predictPromise = client.predict(apiName, requestPayload);
 

--- a/src/server/generation-worker/generation-worker.test.ts
+++ b/src/server/generation-worker/generation-worker.test.ts
@@ -146,6 +146,15 @@ describe("generation worker", () => {
           },
           customInstruction: { ui: "textarea" },
           voiceInstruction: { ui: "textarea" },
+          "hf:model_size": {
+            ui: "select",
+            binding: {
+              source: "hf_space",
+              parameterName: "model_size",
+              valueType: "string",
+              order: 20,
+            },
+          },
         },
         concurrentLimit: 1,
         supportsInputAudio: true,
@@ -321,6 +330,10 @@ describe("generation worker", () => {
         temperature: 0.9,
         topK: 50,
         repetitionPenalty: 1.05,
+        dynamicParams: {
+          "hf:model_size": "1.7B",
+          "hf:use_xvector_only": true,
+        },
       },
     };
 
@@ -353,6 +366,10 @@ describe("generation worker", () => {
         temperature: 0.9,
         topK: 50,
         repetitionPenalty: 1.05,
+        dynamicParams: {
+          "hf:model_size": "1.7B",
+          "hf:use_xvector_only": true,
+        },
       }),
       "aud-mode-request-id",
     );

--- a/src/server/generation-worker/generation-worker.test.ts
+++ b/src/server/generation-worker/generation-worker.test.ts
@@ -155,6 +155,15 @@ describe("generation worker", () => {
               order: 20,
             },
           },
+          "hf:use_xvector_only": {
+            ui: "toggle",
+            binding: {
+              source: "hf_space",
+              parameterName: "use_xvector_only",
+              valueType: "boolean",
+              order: 21,
+            },
+          },
         },
         concurrentLimit: 1,
         supportsInputAudio: true,

--- a/src/server/generation-worker/generation-worker.ts
+++ b/src/server/generation-worker/generation-worker.ts
@@ -269,6 +269,19 @@ function buildAudioPayload(
     typeof params.speaker === "string" &&
     Boolean(params.speaker.trim()) &&
     submittedVoice === defaults.voice;
+  const dynamicParams =
+    params.dynamicParams &&
+    typeof params.dynamicParams === "object" &&
+    !Array.isArray(params.dynamicParams)
+      ? Object.fromEntries(
+          Object.entries(params.dynamicParams).filter(
+            ([, value]) =>
+              typeof value === "string" ||
+              typeof value === "number" ||
+              typeof value === "boolean",
+          ),
+        )
+      : {};
 
   return {
     prompt: record.prompt,
@@ -337,6 +350,7 @@ function buildAudioPayload(
       typeof params.repetitionPenalty === "number"
         ? params.repetitionPenalty
         : undefined,
+    dynamicParams,
   };
 }
 

--- a/src/server/hf-space/parameter-contract.test.ts
+++ b/src/server/hf-space/parameter-contract.test.ts
@@ -114,6 +114,27 @@ describe("buildHfParameterDescriptors", () => {
     });
   });
 
+  it("Text로 시작하는 비표준 필드를 prompt로 오인하지 않는다", () => {
+    const result = buildHfParameterDescriptors([
+      {
+        parameter_name: "text_editor",
+        label: "Text Editor",
+        component: "Textbox",
+      },
+    ]);
+
+    expect(result.parameters.prompt).toBeUndefined();
+    expect(result.parameters["hf:text_editor"]).toMatchObject({
+      label: "Text Editor",
+      binding: {
+        parameterName: "text_editor",
+      },
+    });
+    expect(
+      result.parameters["hf:text_editor"].binding,
+    ).not.toHaveProperty("canonicalKey");
+  });
+
   it("hidden/state 파라미터는 노출하지 않는다", () => {
     const result = buildHfParameterDescriptors([
       {

--- a/src/server/hf-space/parameter-contract.test.ts
+++ b/src/server/hf-space/parameter-contract.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { buildHfParameterDescriptors } from "@/server/hf-space/parameter-contract";
+
+describe("buildHfParameterDescriptors", () => {
+  it("Qwen voice clone parameters를 canonical 또는 generic binding으로 보존한다", () => {
+    const result = buildHfParameterDescriptors([
+      {
+        parameter_name: "ref_audio",
+        label: "Reference Audio (Upload a voice sample to clone)",
+        component: "Audio",
+        parameter_has_default: false,
+      },
+      {
+        parameter_name: "ref_text",
+        label: "Reference Text (Transcript of the reference audio)",
+        component: "Textbox",
+        parameter_has_default: false,
+      },
+      {
+        parameter_name: "target_text",
+        label: "Target Text (Text to synthesize with cloned voice)",
+        component: "Textbox",
+        parameter_has_default: false,
+      },
+      {
+        parameter_name: "language",
+        label: "Language",
+        component: "Dropdown",
+        parameter_has_default: true,
+        parameter_default: "Auto",
+        choices: ["Auto", "Korean"],
+      },
+      {
+        parameter_name: "use_xvector_only",
+        label: "Use x-vector only",
+        component: "Checkbox",
+        parameter_has_default: true,
+        parameter_default: false,
+      },
+      {
+        parameter_name: "model_size",
+        label: "Model Size",
+        component: "Dropdown",
+        parameter_has_default: true,
+        parameter_default: "1.7B",
+        choices: ["0.6B", "1.7B"],
+      },
+    ]);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.parameters.inputAudio.binding).toMatchObject({
+      parameterName: "ref_audio",
+      valueType: "file",
+      canonicalKey: "inputAudio",
+      order: 0,
+    });
+    expect(result.parameters.referenceText.binding).toMatchObject({
+      parameterName: "ref_text",
+      canonicalKey: "referenceText",
+    });
+    expect(result.parameters.prompt.binding).toMatchObject({
+      parameterName: "target_text",
+      canonicalKey: "prompt",
+    });
+    expect(result.parameters.language.binding).toMatchObject({
+      parameterName: "language",
+      canonicalKey: "language",
+    });
+    expect(result.parameters["hf:use_xvector_only"]).toMatchObject({
+      ui: "toggle",
+      default: false,
+      binding: {
+        parameterName: "use_xvector_only",
+        valueType: "boolean",
+        order: 4,
+      },
+    });
+    expect(result.parameters["hf:model_size"]).toMatchObject({
+      ui: "select",
+      default: "1.7B",
+      options: [
+        { label: "0.6B", value: "0.6B" },
+        { label: "1.7B", value: "1.7B" },
+      ],
+      binding: {
+        parameterName: "model_size",
+        valueType: "string",
+        order: 5,
+      },
+    });
+  });
+
+  it("이름 의미가 불명확한 공개 파라미터를 generic key로 유지한다", () => {
+    const result = buildHfParameterDescriptors([
+      {
+        parameter_name: "fidelity_profile",
+        label: "Render Profile",
+        component: "Radio",
+        parameter_has_default: true,
+        parameter_default: "studio",
+        choices: ["draft", "studio"],
+      },
+    ]);
+
+    expect(result.parameters["hf:fidelity_profile"]).toMatchObject({
+      ui: "select",
+      label: "Render Profile",
+      default: "studio",
+      binding: {
+        source: "hf_space",
+        parameterName: "fidelity_profile",
+        valueType: "string",
+      },
+    });
+  });
+
+  it("hidden/state 파라미터는 노출하지 않는다", () => {
+    const result = buildHfParameterDescriptors([
+      {
+        parameter_name: "session_state",
+        label: "Session",
+        component: "State",
+      },
+      {
+        parameter_name: "internal_token",
+        label: "Internal",
+        component: "Textbox",
+        hidden: true,
+      },
+    ]);
+
+    expect(result.parameters).toEqual({});
+  });
+});

--- a/src/server/hf-space/parameter-contract.ts
+++ b/src/server/hf-space/parameter-contract.ts
@@ -22,11 +22,12 @@ export type HfEndpointParameter = {
   parameter_has_default?: boolean;
   parameter_default?: unknown;
   choices?: RuntimeParameterOptionInput[];
+  lines?: number;
   hidden?: boolean;
 };
 
 export type HfParameterConfig = {
-  ui: "input" | "textarea" | "select" | "toggle" | "upload";
+  ui: "input" | "textarea" | "select" | "toggle" | "upload" | "range";
   label?: string;
   required?: boolean;
   default?: string | number | boolean;
@@ -80,7 +81,7 @@ function resolveCanonicalKey(parameter: HfEndpointParameter) {
   if (target.includes("target text") || target.includes("prompt")) {
     return "prompt";
   }
-  if (target.trim() === "text text" || target.startsWith("text ")) {
+  if (target.trim() === "text text") {
     return "prompt";
   }
   if (target.includes("language")) return "language";
@@ -140,10 +141,15 @@ function resolveUi(
   const component = parameter.component?.toLowerCase() ?? "";
   if (valueType === "file") return "upload";
   if (valueType === "boolean") return "toggle";
+  if (component.includes("slider")) return "range";
   if (options.length || component.includes("dropdown") || component.includes("radio")) {
     return "select";
   }
-  if (component.includes("textbox") && normalizeLookup(parameter).includes("text")) {
+  if (
+    component.includes("textbox") &&
+    (parameter.lines !== undefined && parameter.lines > 1 ||
+      normalizeLookup(parameter).includes("text"))
+  ) {
     return "textarea";
   }
   return "input";

--- a/src/server/hf-space/parameter-contract.ts
+++ b/src/server/hf-space/parameter-contract.ts
@@ -1,0 +1,204 @@
+import {
+  normalizeRuntimeParameterOptions,
+  type RuntimeParameterOption,
+  type RuntimeParameterOptionInput,
+} from "@/shared/model-catalog/parameter-options";
+
+export type HfParameterValueType = "string" | "number" | "boolean" | "file";
+
+export type HfParameterBinding = {
+  source: "hf_space";
+  parameterName: string;
+  valueType: HfParameterValueType;
+  canonicalKey?: string;
+  order: number;
+};
+
+export type HfEndpointParameter = {
+  parameter_name?: string;
+  label?: string;
+  component?: string;
+  python_type?: { type?: string } | string;
+  parameter_has_default?: boolean;
+  parameter_default?: unknown;
+  choices?: RuntimeParameterOptionInput[];
+  hidden?: boolean;
+};
+
+export type HfParameterConfig = {
+  ui: "input" | "textarea" | "select" | "toggle" | "upload";
+  label?: string;
+  required?: boolean;
+  default?: string | number | boolean;
+  options?: RuntimeParameterOption[];
+  binding: HfParameterBinding;
+};
+
+const canonicalKeys = new Set([
+  "prompt",
+  "inputAudio",
+  "referenceText",
+  "language",
+  "speed",
+  "seed",
+  "voice",
+  "speaker",
+  "modeChoice",
+  "streamMode",
+  "referencePreset",
+  "customInstruction",
+  "voiceInstruction",
+  "xvecOnly",
+  "chunkSize",
+  "temperature",
+  "topK",
+  "repetitionPenalty",
+]);
+
+function normalizeLookup(parameter: HfEndpointParameter) {
+  return `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`
+    .toLowerCase()
+    .replace(/[_-]+/g, " ");
+}
+
+function resolveCanonicalKey(parameter: HfEndpointParameter) {
+  const target = normalizeLookup(parameter);
+  const parameterName = parameter.parameter_name?.trim().toLowerCase() ?? "";
+  if (
+    target.includes("reference transcript") ||
+    target.includes("reference text") ||
+    target.includes("ref text")
+  ) {
+    return "referenceText";
+  }
+  if (
+    target.includes("reference audio") ||
+    target.includes("ref audio")
+  ) {
+    return "inputAudio";
+  }
+  if (target.includes("target text") || target.includes("prompt")) {
+    return "prompt";
+  }
+  if (target.trim() === "text text" || target.startsWith("text ")) {
+    return "prompt";
+  }
+  if (target.includes("language")) return "language";
+  if (target.includes("stream mode") || target.includes("streaming")) {
+    return "streamMode";
+  }
+  if (target.includes("reference preset")) return "referencePreset";
+  if (target.includes("custom instruction")) return "customInstruction";
+  if (target.includes("voice instruction")) return "voiceInstruction";
+  if (parameterName === "xvec_only") return "xvecOnly";
+  if (target.includes("chunk size")) return "chunkSize";
+  if (target.includes("temperature")) return "temperature";
+  if (target.includes("top k")) return "topK";
+  if (target.includes("repetition penalty")) return "repetitionPenalty";
+  if (target.includes("speaker")) return "speaker";
+  if (target.trim() === "voice voice") return "voice";
+  if (target.includes("speed")) return "speed";
+  if (target.includes("generation mode")) return "modeChoice";
+  if (target.includes("seed")) return "seed";
+  return null;
+}
+
+function resolveValueType(parameter: HfEndpointParameter): HfParameterValueType {
+  const component = parameter.component?.toLowerCase() ?? "";
+  const pythonType =
+    typeof parameter.python_type === "string"
+      ? parameter.python_type.toLowerCase()
+      : parameter.python_type?.type?.toLowerCase() ?? "";
+  if (
+    component.includes("audio") ||
+    component.includes("file") ||
+    component.includes("image") ||
+    pythonType.includes("filepath") ||
+    pythonType.includes("filedata")
+  ) {
+    return "file";
+  }
+  if (component.includes("checkbox") || pythonType.includes("bool")) {
+    return "boolean";
+  }
+  if (
+    component.includes("number") ||
+    component.includes("slider") ||
+    pythonType.includes("int") ||
+    pythonType.includes("float")
+  ) {
+    return "number";
+  }
+  return "string";
+}
+
+function resolveUi(
+  parameter: HfEndpointParameter,
+  valueType: HfParameterValueType,
+  options: RuntimeParameterOption[],
+): HfParameterConfig["ui"] {
+  const component = parameter.component?.toLowerCase() ?? "";
+  if (valueType === "file") return "upload";
+  if (valueType === "boolean") return "toggle";
+  if (options.length || component.includes("dropdown") || component.includes("radio")) {
+    return "select";
+  }
+  if (component.includes("textbox") && normalizeLookup(parameter).includes("text")) {
+    return "textarea";
+  }
+  return "input";
+}
+
+function toDefault(value: unknown) {
+  return typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+    ? value
+    : undefined;
+}
+
+export function buildHfParameterDescriptors(
+  parameters: HfEndpointParameter[],
+) {
+  const result: Record<string, HfParameterConfig> = {};
+  const warnings: string[] = [];
+
+  parameters.forEach((parameter, order) => {
+    const parameterName = parameter.parameter_name?.trim() ?? "";
+    const component = parameter.component?.trim().toLowerCase() ?? "";
+    if (!parameterName || parameter.hidden === true || component === "state") {
+      return;
+    }
+
+    const canonicalKey = resolveCanonicalKey(parameter);
+    const catalogKey =
+      canonicalKey && canonicalKeys.has(canonicalKey)
+        ? canonicalKey
+        : `hf:${parameterName}`;
+    if (result[catalogKey]) {
+      warnings.push(`PARAMETER_KEY_COLLISION:${catalogKey}`);
+      return;
+    }
+
+    const options = normalizeRuntimeParameterOptions(parameter.choices) ?? [];
+    const valueType = resolveValueType(parameter);
+    const config: HfParameterConfig = {
+      ui: resolveUi(parameter, valueType, options),
+      label: parameter.label?.trim() || parameterName,
+      required: parameter.parameter_has_default === false,
+      binding: {
+        source: "hf_space",
+        parameterName,
+        valueType,
+        ...(canonicalKey ? { canonicalKey } : {}),
+        order,
+      },
+    };
+    const defaultValue = toDefault(parameter.parameter_default);
+    if (defaultValue !== undefined) config.default = defaultValue;
+    if (options.length) config.options = options;
+    result[catalogKey] = config;
+  });
+
+  return { parameters: result, warnings };
+}

--- a/src/server/model-catalog/catalog-schema.test.ts
+++ b/src/server/model-catalog/catalog-schema.test.ts
@@ -2,6 +2,66 @@ import { describe, expect, it } from "vitest";
 import { modelCatalogInputSchema, modelCatalogSchema } from "@/server/model-catalog/catalog-schema";
 
 describe("model-catalog option normalization", () => {
+  it("HF parameter binding을 검증하고 generic parameter metadata를 보존한다", () => {
+    const base = {
+      type: "audio",
+      key: "dynamic-qwen",
+      label: "Dynamic Qwen",
+      vendor: "HUGGINGFACE",
+      provider: "hf_space",
+      providerConfig: {
+        space_id: "Qwen/Qwen3-TTS",
+        api_name: "/generate_voice_clone",
+      },
+      parameters: {
+        prompt: { ui: "textarea", required: true },
+        "hf:model_size": {
+          ui: "select",
+          options: ["0.6B", "1.7B"],
+          default: "1.7B",
+          binding: {
+            source: "hf_space",
+            parameterName: "model_size",
+            valueType: "string",
+            order: 5,
+          },
+        },
+      },
+      meta: {
+        model_id: "Qwen/Qwen3-TTS",
+        default_speed: 1,
+        supports_input_audio: true,
+      },
+    };
+
+    const parsed = modelCatalogInputSchema.safeParse(base);
+    expect(parsed.success).toBe(true);
+    if (parsed.success && parsed.data.type === "audio") {
+      expect(parsed.data.parameters["hf:model_size"].binding).toEqual({
+        source: "hf_space",
+        parameterName: "model_size",
+        valueType: "string",
+        order: 5,
+      });
+    }
+
+    const invalid = modelCatalogInputSchema.safeParse({
+      ...base,
+      parameters: {
+        ...base.parameters,
+        "hf:model_size": {
+          ...base.parameters["hf:model_size"],
+          binding: {
+            source: "hf_space",
+            parameterName: "model_size",
+            valueType: "object",
+            order: 5,
+          },
+        },
+      },
+    });
+    expect(invalid.success).toBe(false);
+  });
   it("image 모델은 codex_cli provider config를 허용한다", () => {
     const parsed = modelCatalogInputSchema.safeParse({
       type: "image",

--- a/src/server/model-catalog/catalog-schema.ts
+++ b/src/server/model-catalog/catalog-schema.ts
@@ -30,6 +30,16 @@ const parameterOptionInputSchema = z.union([
   parameterOptionSchema,
 ]);
 
+const hfParameterBindingSchema = z
+  .object({
+    source: z.literal("hf_space"),
+    parameterName: z.string().min(1),
+    valueType: z.enum(["string", "number", "boolean", "file"]),
+    canonicalKey: z.string().min(1).optional(),
+    order: z.number().int().nonnegative(),
+  })
+  .strict();
+
 const parameterSchema = z
   .object({
     ui: z.enum(parameterUiOptions),
@@ -40,6 +50,7 @@ const parameterSchema = z
     step: z.number().optional(),
     default: z.union([z.string(), z.number(), z.boolean()]).optional(),
     options: z.array(parameterOptionInputSchema).optional(),
+    binding: hfParameterBindingSchema.optional(),
   })
   .passthrough();
 
@@ -92,7 +103,7 @@ const audioParametersSchema = z
     topK: parameterSchema.optional(),
     repetitionPenalty: parameterSchema.optional(),
   })
-  .passthrough();
+  .catchall(parameterSchema);
 
 const hfSpaceConfigSchema = z
   .object({

--- a/src/server/model-catalog/generation-validation.test.ts
+++ b/src/server/model-catalog/generation-validation.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetModelCatalog = vi.hoisted(() => vi.fn());
+vi.mock("@/server/model-catalog/catalog-service", () => ({
+  getModelCatalog: mockGetModelCatalog,
+}));
+
+describe("validateAudioGenerationPayload dynamicParams", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetModelCatalog.mockResolvedValue([
+      {
+        id: "audio-1",
+        type: "audio",
+        key: "qwen-dynamic",
+        label: "Qwen Dynamic",
+        vendor: "HUGGINGFACE",
+        provider: "hf_space",
+        providerConfig: { space_id: "Qwen/Qwen3-TTS", api_name: "/generate_voice_clone" },
+        parameters: {
+          prompt: { ui: "textarea", required: true },
+          "hf:model_size": {
+            ui: "select",
+            required: true,
+            options: [
+              { label: "0.6B", value: "0.6B" },
+              { label: "1.7B", value: "1.7B" },
+            ],
+            binding: {
+              source: "hf_space",
+              parameterName: "model_size",
+              valueType: "string",
+              order: 5,
+            },
+          },
+          "hf:temperature": {
+            ui: "range",
+            min: 0.1,
+            max: 1,
+            step: 0.1,
+            binding: {
+              source: "hf_space",
+              parameterName: "temperature",
+              valueType: "number",
+              order: 6,
+            },
+          },
+        },
+        meta: { model_id: "Qwen/Qwen3-TTS", default_speed: 1 },
+        isActive: true,
+        isDefault: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+  });
+
+  it("allowlisted dynamic value를 허용한다", async () => {
+    const { validateAudioGenerationPayload } = await import(
+      "@/server/model-catalog/generation-validation"
+    );
+    const result = await validateAudioGenerationPayload({
+      prompt: "hello",
+      model: "qwen-dynamic",
+      dynamicParams: { "hf:model_size": "1.7B" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("unknown key와 지원하지 않는 option을 거부한다", async () => {
+    const { validateAudioGenerationPayload } = await import(
+      "@/server/model-catalog/generation-validation"
+    );
+    const unknown = await validateAudioGenerationPayload({
+      prompt: "hello",
+      model: "qwen-dynamic",
+      dynamicParams: { "hf:unknown": "value", "hf:model_size": "1.7B" },
+    });
+    const invalidOption = await validateAudioGenerationPayload({
+      prompt: "hello",
+      model: "qwen-dynamic",
+      dynamicParams: { "hf:model_size": "9B" },
+    });
+    expect(unknown.success).toBe(false);
+    expect(invalidOption.success).toBe(false);
+  });
+
+  it("동적 number의 range와 step을 검증한다", async () => {
+    const { validateAudioGenerationPayload } = await import(
+      "@/server/model-catalog/generation-validation"
+    );
+    const outOfRange = await validateAudioGenerationPayload({
+      prompt: "hello",
+      model: "qwen-dynamic",
+      dynamicParams: {
+        "hf:model_size": "1.7B",
+        "hf:temperature": 1.1,
+      },
+    });
+    const invalidStep = await validateAudioGenerationPayload({
+      prompt: "hello",
+      model: "qwen-dynamic",
+      dynamicParams: {
+        "hf:model_size": "1.7B",
+        "hf:temperature": 0.15,
+      },
+    });
+
+    expect(outOfRange.success).toBe(false);
+    expect(invalidStep.success).toBe(false);
+  });
+});

--- a/src/server/model-catalog/generation-validation.test.ts
+++ b/src/server/model-catalog/generation-validation.test.ts
@@ -45,6 +45,24 @@ describe("validateAudioGenerationPayload dynamicParams", () => {
               order: 6,
             },
           },
+          "hf:reference_audio": {
+            ui: "upload",
+            binding: {
+              source: "hf_space",
+              parameterName: "reference_audio",
+              valueType: "file",
+              order: 7,
+            },
+          },
+          "hf:use_xvector_only": {
+            ui: "toggle",
+            binding: {
+              source: "hf_space",
+              parameterName: "use_xvector_only",
+              valueType: "boolean",
+              order: 8,
+            },
+          },
         },
         meta: { model_id: "Qwen/Qwen3-TTS", default_speed: 1 },
         isActive: true,
@@ -108,5 +126,45 @@ describe("validateAudioGenerationPayload dynamicParams", () => {
 
     expect(outOfRange.success).toBe(false);
     expect(invalidStep.success).toBe(false);
+  });
+
+  it("동적 file과 boolean 타입을 검증한다", async () => {
+    const { validateAudioGenerationPayload } = await import(
+      "@/server/model-catalog/generation-validation"
+    );
+    const valid = await validateAudioGenerationPayload({
+      prompt: "hello",
+      model: "qwen-dynamic",
+      dynamicParams: {
+        "hf:model_size": "1.7B",
+        "hf:reference_audio": "data:audio/wav;base64,UklGRg==",
+        "hf:use_xvector_only": true,
+      },
+    });
+    const invalid = await validateAudioGenerationPayload({
+      prompt: "hello",
+      model: "qwen-dynamic",
+      dynamicParams: {
+        "hf:model_size": "1.7B",
+        "hf:reference_audio": true,
+        "hf:use_xvector_only": "true",
+      },
+    });
+
+    expect(valid.success).toBe(true);
+    expect(invalid.success).toBe(false);
+  });
+
+  it("required 동적 파라미터 누락을 거부한다", async () => {
+    const { validateAudioGenerationPayload } = await import(
+      "@/server/model-catalog/generation-validation"
+    );
+    const result = await validateAudioGenerationPayload({
+      prompt: "hello",
+      model: "qwen-dynamic",
+      dynamicParams: {},
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/src/server/model-catalog/generation-validation.ts
+++ b/src/server/model-catalog/generation-validation.ts
@@ -613,6 +613,7 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
       labels.repetitionPenalty,
     );
 
+    // Keep these dynamic binding rules in sync with the shared runtime schema.
     const dynamicParams = data.dynamicParams ?? {};
     const dynamicConfigs = Object.entries(parameters).filter(([, value]) => {
       const config = value as ParameterConfig;

--- a/src/server/model-catalog/generation-validation.ts
+++ b/src/server/model-catalog/generation-validation.ts
@@ -26,12 +26,19 @@ type NumericRange = {
 };
 
 type ParameterConfig = {
+  ui?: unknown;
   min?: unknown;
   max?: unknown;
   step?: unknown;
   default?: unknown;
   required?: unknown;
   options?: unknown[];
+  binding?: {
+    source?: unknown;
+    parameterName?: unknown;
+    valueType?: unknown;
+    canonicalKey?: unknown;
+  };
 };
 
 const imageFallbackRanges: Record<
@@ -475,6 +482,9 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
     temperature: z.number().optional(),
     topK: z.number().optional(),
     repetitionPenalty: z.number().optional(),
+    dynamicParams: z
+      .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+      .optional(),
   });
 
   return schema.superRefine((data, ctx) => {
@@ -602,6 +612,91 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
       data.repetitionPenalty,
       labels.repetitionPenalty,
     );
+
+    const dynamicParams = data.dynamicParams ?? {};
+    const dynamicConfigs = Object.entries(parameters).filter(([, value]) => {
+      const config = value as ParameterConfig;
+      return (
+        config?.binding?.source === "hf_space" &&
+        typeof config.binding.parameterName === "string" &&
+        !config.binding.canonicalKey
+      );
+    });
+    const allowedKeys = new Set(dynamicConfigs.map(([key]) => key));
+    for (const key of Object.keys(dynamicParams)) {
+      if (!allowedKeys.has(key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["dynamicParams", key],
+          message: "지원하지 않는 동적 파라미터입니다.",
+        });
+      }
+    }
+    for (const [key, rawConfig] of dynamicConfigs) {
+      const config = rawConfig as ParameterConfig;
+      const value = dynamicParams[key];
+      if (config.required === true && value === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["dynamicParams", key],
+          message: "필수 동적 파라미터입니다.",
+        });
+        continue;
+      }
+      if (value === undefined) continue;
+      const expectedType = config.binding?.valueType;
+      const actualType = typeof value;
+      const typeMatches =
+        expectedType === "file"
+          ? actualType === "string"
+          : expectedType === actualType;
+      if (!typeMatches) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["dynamicParams", key],
+          message: "동적 파라미터 타입이 올바르지 않습니다.",
+        });
+        continue;
+      }
+      if (typeof value === "number") {
+        const min = typeof config.min === "number" ? config.min : undefined;
+        const max = typeof config.max === "number" ? config.max : undefined;
+        const step = typeof config.step === "number" ? config.step : undefined;
+        if (
+          (min !== undefined && value < min) ||
+          (max !== undefined && value > max)
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["dynamicParams", key],
+            message: "동적 파라미터 범위가 올바르지 않습니다.",
+          });
+          continue;
+        }
+        if (step !== undefined && step > 0) {
+          const quotient = (value - (min ?? 0)) / step;
+          if (Math.abs(quotient - Math.round(quotient)) > 1e-6) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["dynamicParams", key],
+              message: "동적 파라미터 입력 단위가 올바르지 않습니다.",
+            });
+            continue;
+          }
+        }
+      }
+      if (
+        config.options?.length &&
+        (typeof value === "string" || typeof value === "number") &&
+        !hasRuntimeParameterOption(config.options, value)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["dynamicParams", key],
+          message: unsupportedSelection,
+        });
+      }
+    }
   });
 }
 

--- a/src/server/model-catalog/space-importer.test.ts
+++ b/src/server/model-catalog/space-importer.test.ts
@@ -84,6 +84,8 @@ describe("importModelDraftFromSpace", () => {
       ],
       binding: { parameterName: "model_size", valueType: "string" },
     });
+    expect(result.draft.parameters.referenceText.ui).toBe("textarea");
+    expect(result.draft.parameters.prompt.ui).toBe("textarea");
   });
 
   it("오디오 생성 endpoint가 여러 개면 run_generation을 우선 선택하고 reference 입력 계약을 반영한다", async () => {

--- a/src/server/model-catalog/space-importer.test.ts
+++ b/src/server/model-catalog/space-importer.test.ts
@@ -14,6 +14,78 @@ describe("importModelDraftFromSpace", () => {
     vi.clearAllMocks();
   });
 
+  it("미지의 Qwen voice clone 파라미터를 원래 API binding과 함께 보존한다", async () => {
+    mockConnect.mockResolvedValue({
+      view_api: vi.fn().mockResolvedValue({
+        named_endpoints: {
+          "/generate_voice_clone": {
+            parameters: [
+              { parameter_name: "ref_audio", label: "Reference Audio", parameter_has_default: false },
+              { parameter_name: "ref_text", label: "Reference Text", parameter_has_default: false },
+              { parameter_name: "target_text", label: "Target Text", parameter_has_default: false },
+              { parameter_name: "use_xvector_only", label: "Use x-vector only", parameter_default: false },
+              { parameter_name: "model_size", label: "Model Size", parameter_default: "1.7B" },
+            ],
+          },
+        },
+      }),
+      config: {
+        space_id: "Qwen/Qwen3-TTS",
+        title: "Qwen3 TTS",
+        components: [
+          { id: 1, type: "audio", props: { label: "Reference Audio" } },
+          { id: 2, type: "textbox", props: { label: "Reference Text", lines: 2 } },
+          { id: 3, type: "textbox", props: { label: "Target Text", lines: 4 } },
+          { id: 4, type: "checkbox", props: { label: "Use x-vector only", value: false } },
+          {
+            id: 5,
+            type: "dropdown",
+            props: { label: "Model Size", choices: ["0.6B", "1.7B"], value: "1.7B" },
+          },
+          { id: 6, type: "audio", props: { label: "Generated Audio" } },
+        ],
+        dependencies: [
+          {
+            api_name: "/generate_voice_clone",
+            inputs: [1, 2, 3, 4, 5],
+            outputs: [6],
+          },
+        ],
+      },
+    });
+
+    const { importModelDraftFromSpace } = await import(
+      "@/server/model-catalog/space-importer"
+    );
+    const result = await importModelDraftFromSpace({
+      spaceUrl: "https://huggingface.co/spaces/Qwen/Qwen3-TTS",
+      apiName: "/generate_voice_clone",
+    });
+
+    expect(result.draft.parameters.inputAudio.binding).toMatchObject({
+      parameterName: "ref_audio",
+      canonicalKey: "inputAudio",
+    });
+    expect(result.draft.parameters.prompt.binding).toMatchObject({
+      parameterName: "target_text",
+      canonicalKey: "prompt",
+    });
+    expect(result.draft.parameters["hf:use_xvector_only"]).toMatchObject({
+      ui: "toggle",
+      default: false,
+      binding: { parameterName: "use_xvector_only", valueType: "boolean" },
+    });
+    expect(result.draft.parameters["hf:model_size"]).toMatchObject({
+      ui: "select",
+      default: "1.7B",
+      options: [
+        { label: "0.6B", value: "0.6B" },
+        { label: "1.7B", value: "1.7B" },
+      ],
+      binding: { parameterName: "model_size", valueType: "string" },
+    });
+  });
+
   it("오디오 생성 endpoint가 여러 개면 run_generation을 우선 선택하고 reference 입력 계약을 반영한다", async () => {
     mockConnect.mockResolvedValue({
       view_api: vi.fn().mockResolvedValue({

--- a/src/server/model-catalog/space-importer.ts
+++ b/src/server/model-catalog/space-importer.ts
@@ -3,6 +3,10 @@ import {
   scoreEndpointCandidate,
 } from "@/server/hf-space/endpoint-scoring";
 import {
+  buildHfParameterDescriptors,
+  type HfParameterBinding,
+} from "@/server/hf-space/parameter-contract";
+import {
   normalizeRuntimeParameterOptions,
   type RuntimeParameterOptionInput,
 } from "@/shared/model-catalog/parameter-options";
@@ -23,6 +27,7 @@ type ParameterConfig = {
   step?: number;
   default?: string | number | boolean;
   options?: RuntimeParameterOptionInput[];
+  binding?: HfParameterBinding;
 };
 
 type DraftPayload = {
@@ -49,7 +54,11 @@ type ImportResult = {
 type EndpointParameter = {
   parameter_name?: string;
   label?: string;
+  parameter_has_default?: boolean;
   parameter_default?: unknown;
+  component?: string;
+  python_type?: { type?: string } | string;
+  hidden?: boolean;
 };
 
 type EndpointInfo = {
@@ -453,6 +462,33 @@ export async function importModelDraftFromSpace(
   let hasImageInput = false;
   let hasAudioInput = false;
   let inputImagesFormat: "file_array" | "gallery" = "file_array";
+  const descriptorResult = buildHfParameterDescriptors(
+    (endpoint.parameters ?? []).map((paramInfo, index) => {
+      const component = inputComponents[index];
+      const componentProps = (component?.props ?? {}) as Record<string, unknown>;
+      return {
+        ...paramInfo,
+        component: resolveComponentType(component, paramInfo.component),
+        label:
+          resolveComponentLabel(componentProps) ||
+          paramInfo.label ||
+          paramInfo.parameter_name,
+        parameter_has_default:
+          paramInfo.parameter_has_default ??
+          (paramInfo.parameter_default !== undefined ||
+            componentProps.value !== undefined ||
+            componentProps.default !== undefined),
+        parameter_default:
+          componentProps.value ??
+          componentProps.default ??
+          paramInfo.parameter_default,
+        choices:
+          (componentProps.choices as RuntimeParameterOptionInput[]) ??
+          (componentProps.options as RuntimeParameterOptionInput[]),
+      };
+    }),
+  );
+  warnings.push(...descriptorResult.warnings);
 
   inputComponents.forEach((component, index) => {
     if (!component) return;
@@ -460,7 +496,10 @@ export async function importModelDraftFromSpace(
     const componentType = resolveComponentType(component);
     const paramInfo = endpoint.parameters?.[index];
     const label = resolveComponentLabel(componentProps) || paramInfo?.label || paramInfo?.parameter_name || "parameter";
-    const paramKey = resolveParamKey(label, paramInfo?.parameter_name, componentType);
+    const descriptorEntry = Object.entries(descriptorResult.parameters).find(
+      ([, config]) => config.binding.order === index,
+    );
+    const paramKey = descriptorEntry?.[0];
 
     if (!paramKey) {
       warnings.push(`UNMAPPED_PARAM:${label}`);
@@ -484,12 +523,15 @@ export async function importModelDraftFromSpace(
       hasAudioInput = true;
     }
 
-    parameters[paramKey] = buildParamConfig(
+    parameters[paramKey] = {
+      ...buildParamConfig(
       componentType,
       componentProps,
       label,
       paramInfo?.parameter_default,
-    );
+      ),
+      binding: descriptorEntry[1].binding,
+    };
   });
 
   outputComponents.forEach((component) => {

--- a/src/server/model-catalog/space-importer.ts
+++ b/src/server/model-catalog/space-importer.ts
@@ -485,6 +485,10 @@ export async function importModelDraftFromSpace(
         choices:
           (componentProps.choices as RuntimeParameterOptionInput[]) ??
           (componentProps.options as RuntimeParameterOptionInput[]),
+        lines:
+          typeof componentProps.lines === "number"
+            ? componentProps.lines
+            : undefined,
       };
     }),
   );
@@ -499,12 +503,12 @@ export async function importModelDraftFromSpace(
     const descriptorEntry = Object.entries(descriptorResult.parameters).find(
       ([, config]) => config.binding.order === index,
     );
-    const paramKey = descriptorEntry?.[0];
 
-    if (!paramKey) {
+    if (!descriptorEntry) {
       warnings.push(`UNMAPPED_PARAM:${label}`);
       return;
     }
+    const [paramKey, descriptorConfig] = descriptorEntry;
 
     if (paramKey === "durationSec" || paramKey === "fps" || paramKey === "resolution" || paramKey === "aspectRatio") {
       hasVideoParam = true;
@@ -525,12 +529,12 @@ export async function importModelDraftFromSpace(
 
     parameters[paramKey] = {
       ...buildParamConfig(
-      componentType,
-      componentProps,
-      label,
-      paramInfo?.parameter_default,
+        componentType,
+        componentProps,
+        label,
+        paramInfo?.parameter_default,
       ),
-      binding: descriptorEntry[1].binding,
+      ...descriptorConfig,
     };
   });
 

--- a/src/shared/model-catalog/runtime-schema.test.ts
+++ b/src/shared/model-catalog/runtime-schema.test.ts
@@ -47,4 +47,122 @@ describe("createRuntimeAudioSchema dynamicParams", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("동적 file과 boolean 타입을 검증한다", () => {
+    const schema = createRuntimeAudioSchema([
+      {
+        ...model,
+        parameters: {
+          ...model.parameters,
+          "hf:reference_audio": {
+            ui: "upload",
+            binding: {
+              source: "hf_space",
+              parameterName: "reference_audio",
+              valueType: "file",
+              order: 2,
+            },
+          },
+          "hf:use_xvector_only": {
+            ui: "toggle",
+            binding: {
+              source: "hf_space",
+              parameterName: "use_xvector_only",
+              valueType: "boolean",
+              order: 3,
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(
+      schema.safeParse({
+        prompt: "hello",
+        model: model.key,
+        dynamicParams: {
+          "hf:reference_audio": "data:audio/wav;base64,UklGRg==",
+          "hf:use_xvector_only": true,
+        },
+      }).success,
+    ).toBe(true);
+    expect(
+      schema.safeParse({
+        prompt: "hello",
+        model: model.key,
+        dynamicParams: {
+          "hf:reference_audio": true,
+          "hf:use_xvector_only": "true",
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("required 동적 파라미터 누락을 거부한다", () => {
+    const schema = createRuntimeAudioSchema([
+      {
+        ...model,
+        parameters: {
+          ...model.parameters,
+          "hf:reference_audio": {
+            ui: "upload",
+            required: true,
+            binding: {
+              source: "hf_space",
+              parameterName: "reference_audio",
+              valueType: "file",
+              order: 2,
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(
+      schema.safeParse({
+        prompt: "hello",
+        model: model.key,
+        dynamicParams: {},
+      }).success,
+    ).toBe(false);
+  });
+
+  it("동적 select options의 유효값만 허용한다", () => {
+    const schema = createRuntimeAudioSchema([
+      {
+        ...model,
+        parameters: {
+          ...model.parameters,
+          "hf:model_size": {
+            ui: "select",
+            options: [
+              { label: "0.6B", value: "0.6B" },
+              { label: "1.7B", value: "1.7B" },
+            ],
+            binding: {
+              source: "hf_space",
+              parameterName: "model_size",
+              valueType: "string",
+              order: 2,
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(
+      schema.safeParse({
+        prompt: "hello",
+        model: model.key,
+        dynamicParams: { "hf:model_size": "1.7B" },
+      }).success,
+    ).toBe(true);
+    expect(
+      schema.safeParse({
+        prompt: "hello",
+        model: model.key,
+        dynamicParams: { "hf:model_size": "9B" },
+      }).success,
+    ).toBe(false);
+  });
 });

--- a/src/shared/model-catalog/runtime-schema.test.ts
+++ b/src/shared/model-catalog/runtime-schema.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { createRuntimeAudioSchema } from "@/shared/model-catalog/runtime-schema";
+import type { RuntimeAudioModel } from "@/shared/model-catalog/runtime-utils";
+
+const model: RuntimeAudioModel = {
+  type: "audio",
+  key: "dynamic-audio",
+  label: "Dynamic Audio",
+  vendor: "HF Space",
+  provider: "huggingface-space",
+  parameters: {
+    prompt: { ui: "textarea", required: true },
+    "hf:temperature": {
+      ui: "range",
+      min: 0.1,
+      max: 1,
+      step: 0.1,
+      binding: {
+        source: "hf_space",
+        parameterName: "temperature",
+        valueType: "number",
+        order: 1,
+      },
+    },
+  },
+  meta: {},
+  isActive: true,
+  isDefault: true,
+};
+
+describe("createRuntimeAudioSchema dynamicParams", () => {
+  it("동적 number의 range와 step을 검증한다", () => {
+    const schema = createRuntimeAudioSchema([model]);
+
+    expect(
+      schema.safeParse({
+        prompt: "hello",
+        model: model.key,
+        dynamicParams: { "hf:temperature": 1.1 },
+      }).success,
+    ).toBe(false);
+    expect(
+      schema.safeParse({
+        prompt: "hello",
+        model: model.key,
+        dynamicParams: { "hf:temperature": 0.15 },
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/shared/model-catalog/runtime-schema.ts
+++ b/src/shared/model-catalog/runtime-schema.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/shared/model-catalog/runtime-utils";
 import {
   getRuntimeAudioParamConfig,
+  getRuntimeAudioDynamicParameters,
   getRuntimeAudioParamRange,
   getRuntimeImageParamConfig,
   getRuntimeImageParamRange,
@@ -407,6 +408,9 @@ export function createRuntimeAudioSchema(
     temperature: z.number().optional(),
     topK: z.number().optional(),
     repetitionPenalty: z.number().optional(),
+    dynamicParams: z
+      .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+      .optional(),
   });
 
   return schema.superRefine((data, ctx) => {
@@ -523,5 +527,81 @@ export function createRuntimeAudioSchema(
       data.repetitionPenalty,
       labels.repetitionPenalty,
     );
+
+    const dynamicParams = data.dynamicParams ?? {};
+    const dynamicParameters = getRuntimeAudioDynamicParameters(model);
+    const allowedKeys = new Set(dynamicParameters.map(({ key }) => key));
+    for (const key of Object.keys(dynamicParams)) {
+      if (!allowedKeys.has(key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["dynamicParams", key],
+          message: "지원하지 않는 동적 파라미터입니다.",
+        });
+      }
+    }
+    for (const { key, config, binding } of dynamicParameters) {
+      const value = dynamicParams[key];
+      if (config.required && value === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["dynamicParams", key],
+          message: "필수 동적 파라미터입니다.",
+        });
+        continue;
+      }
+      if (value === undefined) continue;
+      const actualType = typeof value;
+      const typeMatches =
+        binding.valueType === "file"
+          ? actualType === "string"
+          : binding.valueType === actualType;
+      if (!typeMatches) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["dynamicParams", key],
+          message: "동적 파라미터 타입이 올바르지 않습니다.",
+        });
+        continue;
+      }
+      if (typeof value === "number") {
+        const min = typeof config.min === "number" ? config.min : undefined;
+        const max = typeof config.max === "number" ? config.max : undefined;
+        const step = typeof config.step === "number" ? config.step : undefined;
+        if (
+          (min !== undefined && value < min) ||
+          (max !== undefined && value > max)
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["dynamicParams", key],
+            message: "동적 파라미터 범위가 올바르지 않습니다.",
+          });
+          continue;
+        }
+        if (step !== undefined && step > 0) {
+          const quotient = (value - (min ?? 0)) / step;
+          if (Math.abs(quotient - Math.round(quotient)) > 1e-6) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["dynamicParams", key],
+              message: "동적 파라미터 입력 단위가 올바르지 않습니다.",
+            });
+            continue;
+          }
+        }
+      }
+      if (
+        config.options?.length &&
+        (typeof value === "string" || typeof value === "number") &&
+        !hasRuntimeParameterOption(config.options, value)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["dynamicParams", key],
+          message: unsupportedSelection,
+        });
+      }
+    }
   });
 }

--- a/src/shared/model-catalog/runtime-schema.ts
+++ b/src/shared/model-catalog/runtime-schema.ts
@@ -528,6 +528,7 @@ export function createRuntimeAudioSchema(
       labels.repetitionPenalty,
     );
 
+    // Keep these dynamic binding rules in sync with server generation validation.
     const dynamicParams = data.dynamicParams ?? {};
     const dynamicParameters = getRuntimeAudioDynamicParameters(model);
     const allowedKeys = new Set(dynamicParameters.map(({ key }) => key));

--- a/src/shared/model-catalog/runtime-utils.ts
+++ b/src/shared/model-catalog/runtime-utils.ts
@@ -9,6 +9,14 @@ export type RuntimeModelType = "image" | "video" | "audio";
 
 export type RuntimeParameterValue = string | number | boolean;
 
+export type RuntimeHfParameterBinding = {
+  source: "hf_space";
+  parameterName: string;
+  valueType: "string" | "number" | "boolean" | "file";
+  canonicalKey?: string;
+  order: number;
+};
+
 export type RuntimeParameterConfig = {
   ui?: string;
   label?: string;
@@ -18,14 +26,21 @@ export type RuntimeParameterConfig = {
   step?: number;
   default?: RuntimeParameterValue;
   options?: RuntimeParameterOptionInput[];
+  binding?: RuntimeHfParameterBinding;
   [key: string]: unknown;
 };
 
-export type NormalizedRuntimeParameterConfig = Omit<
-  RuntimeParameterConfig,
-  "options"
-> & {
+export type NormalizedRuntimeParameterConfig = {
+  ui?: string;
+  label?: string;
+  required?: boolean;
+  min?: number;
+  max?: number;
+  step?: number;
+  default?: RuntimeParameterValue;
   options?: RuntimeParameterOption[];
+  binding?: RuntimeHfParameterBinding;
+  [key: string]: unknown;
 };
 
 export type RuntimeImageParameterKey =
@@ -331,6 +346,27 @@ export function getRuntimeAudioParamConfig(
   key: RuntimeAudioParameterKey,
 ) {
   return resolveParamConfig(model?.parameters, key);
+}
+
+export function getRuntimeAudioDynamicParameters(
+  model: RuntimeAudioModel | undefined,
+) {
+  return Object.entries(model?.parameters ?? {})
+    .flatMap(([key, value]) => {
+      const config = resolveParamConfig({ [key]: value }, key);
+      const binding = config?.binding;
+      if (
+        !config ||
+        binding?.source !== "hf_space" ||
+        typeof binding.parameterName !== "string" ||
+        binding.canonicalKey ||
+        config.ui === "hidden"
+      ) {
+        return [];
+      }
+      return [{ key, config, binding }];
+    })
+    .sort((left, right) => left.binding.order - right.binding.order);
 }
 
 export function getRuntimeAudioParamRange(


### PR DESCRIPTION
# PR Draft: hf-space-dynamic-parameter-contract

## 개요

- 변경 목적: HF Space마다 다른 공개 파라미터를 특정 모델 하드코딩 없이 view_api metadata 기반으로 가져오고 실제 생성 요청까지 전달한다.
- 사용자 영향: Qwen3-TTS voice clone의 reference audio/text, model size, x-vector 옵션 등 자동 생성된 입력값이 UI와 HF API 호출에 반영된다.

## 변경 사항

- [x] canonical로 확정할 수 없는 공개 입력을 `hf:*` generic parameter와 원래 provider binding으로 보존
- [x] 동적 text/textarea/number/range/toggle/select/file UI, multipart 직렬화, client/server allowlist 검증 구현
- [x] requestParams에서 worker와 HF adapter까지 scalar map을 보존하고 원래 `parameter_name`과 Gradio file 값으로 복원
- [x] endpoint parameter drift를 `HF_SPACE_PARAMETER_INVALID`로 진단하고 기존 endpoint fallback 유지

## 테스트

- [x] feature 관련 Vitest 10 files / 61 tests PASS
- [x] `pnpm typecheck` PASS
- [x] `pnpm lint` PASS (0 errors, 기존 warnings 10개)
- [x] live `Qwen/Qwen3-TTS` `/generate_voice_clone` view_api 6개 공개 파라미터 fixture 일치 확인

## 아키텍처 다이어그램

```mermaid
sequenceDiagram
  participant Admin as Model Admin
  participant Importer as HF Space Importer
  participant Catalog as Model Catalog
  participant Form as Audio Form
  participant API as Generation API
  participant Worker as Generation Worker
  participant Adapter as HF Space Adapter

  Admin->>Importer: Space URL + API name
  Importer->>Importer: Normalize view_api parameters
  Importer->>Catalog: Save canonical and hf:* bindings
  Catalog-->>Form: Runtime parameter descriptors
  Form->>API: canonical fields + dynamicParams
  API->>API: Validate model allowlist and types
  API->>Worker: Persist and restore requestParams
  Worker->>Adapter: Preserve dynamic scalar map
  Adapter->>Adapter: Resolve original parameter_name and files
  Adapter->>Admin: Submit Gradio payload and return audio
```

## 관련 문서

- Spec: `features/F049-hf-space-dynamic-parameter-contract/spec.md`
- Tasks: `features/F049-hf-space-dynamic-parameter-contract/tasks.md`
- Decisions: `features/F049-hf-space-dynamic-parameter-contract/decisions.md`
- Issue: https://github.com/leey00nsu/leesfield/issues/95

Closes #95


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 오디오 생성 모델의 동적 파라미터 지원을 추가했습니다. 사용자는 이제 선택한 모델에 맞는 슬라이더, 토글, 드롭다운, 텍스트 입력, 파일 업로드 등의 모델별 설정을 오디오 생성 폼에서 직접 구성할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->