### PR TITLE
feat(#97): hf-space-canonical-matching-hardening (HF parameter canonical 오탐과 입력 누락 방지)

### DIFF
--- a/src/server/hf-space/parameter-contract.test.ts
+++ b/src/server/hf-space/parameter-contract.test.ts
@@ -130,6 +130,45 @@ describe("buildHfParameterDescriptors", () => {
     });
   });
 
+  it("타입과 모순되는 직접 name 후보를 label로 다른 canonical field에 재매칭하지 않는다", () => {
+    const result = buildHfParameterDescriptors([
+      {
+        parameter_name: "ref_audio",
+        label: "Reference Text",
+        component: "Textbox",
+      },
+      {
+        parameter_name: "voice",
+        label: "Voice",
+        component: "Checkbox",
+        parameter_default: false,
+      },
+      {
+        parameter_name: "seed",
+        label: "Seed",
+        component: "Checkbox",
+        parameter_default: false,
+      },
+    ]);
+
+    expect(result.parameters.inputAudio).toBeUndefined();
+    expect(result.parameters.referenceText).toBeUndefined();
+    expect(result.parameters.voice).toBeUndefined();
+    expect(result.parameters.seed).toBeUndefined();
+    expect(result.parameters["hf:ref_audio"].binding).toMatchObject({
+      parameterName: "ref_audio",
+      valueType: "string",
+    });
+    expect(result.parameters["hf:voice"].binding).toMatchObject({
+      parameterName: "voice",
+      valueType: "boolean",
+    });
+    expect(result.parameters["hf:seed"].binding).toMatchObject({
+      parameterName: "seed",
+      valueType: "boolean",
+    });
+  });
+
   it("모호한 parameter name은 호환 가능한 명확한 label로 canonical 매칭한다", () => {
     const result = buildHfParameterDescriptors([
       {

--- a/src/server/hf-space/parameter-contract.test.ts
+++ b/src/server/hf-space/parameter-contract.test.ts
@@ -111,6 +111,12 @@ describe("buildHfParameterDescriptors", () => {
         component: "Textbox",
         parameter_default: "",
       },
+      {
+        parameter_name: "context_window",
+        label: "Context window",
+        component: "Textbox",
+        parameter_default: "",
+      },
     ]);
 
     expect(result.parameters.prompt).toBeUndefined();
@@ -127,6 +133,13 @@ describe("buildHfParameterDescriptors", () => {
     expect(result.parameters["hf:language_notes"].binding).toMatchObject({
       parameterName: "language_notes",
       valueType: "string",
+    });
+    expect(result.parameters["hf:context_window"]).toMatchObject({
+      ui: "input",
+      binding: {
+        parameterName: "context_window",
+        valueType: "string",
+      },
     });
   });
 

--- a/src/server/hf-space/parameter-contract.test.ts
+++ b/src/server/hf-space/parameter-contract.test.ts
@@ -32,7 +32,8 @@ describe("buildHfParameterDescriptors", () => {
       },
       {
         parameter_name: "use_xvector_only",
-        label: "Use x-vector only",
+        label:
+          "Use x-vector only (No reference text needed, but lower quality)",
         component: "Checkbox",
         parameter_has_default: true,
         parameter_default: false,
@@ -87,6 +88,61 @@ describe("buildHfParameterDescriptors", () => {
         valueType: "string",
         order: 5,
       },
+    });
+  });
+
+  it("label 설명의 canonical 키워드가 component 타입과 모순되면 generic으로 유지한다", () => {
+    const result = buildHfParameterDescriptors([
+      {
+        parameter_name: "enable_prompt_cleanup",
+        label: "Disable prompt cleanup",
+        component: "Checkbox",
+        parameter_default: false,
+      },
+      {
+        parameter_name: "audio_quality",
+        label: "Reference audio quality",
+        component: "Slider",
+        parameter_default: 0.8,
+      },
+      {
+        parameter_name: "language_notes",
+        label: "Language-specific instructions",
+        component: "Textbox",
+        parameter_default: "",
+      },
+    ]);
+
+    expect(result.parameters.prompt).toBeUndefined();
+    expect(result.parameters.inputAudio).toBeUndefined();
+    expect(result.parameters.language).toBeUndefined();
+    expect(result.parameters["hf:enable_prompt_cleanup"].binding).toMatchObject({
+      parameterName: "enable_prompt_cleanup",
+      valueType: "boolean",
+    });
+    expect(result.parameters["hf:audio_quality"].binding).toMatchObject({
+      parameterName: "audio_quality",
+      valueType: "number",
+    });
+    expect(result.parameters["hf:language_notes"].binding).toMatchObject({
+      parameterName: "language_notes",
+      valueType: "string",
+    });
+  });
+
+  it("모호한 parameter name은 호환 가능한 명확한 label로 canonical 매칭한다", () => {
+    const result = buildHfParameterDescriptors([
+      {
+        parameter_name: "field_1",
+        label: "Reference Text",
+        component: "Textbox",
+      },
+    ]);
+
+    expect(result.parameters.referenceText.binding).toMatchObject({
+      parameterName: "field_1",
+      canonicalKey: "referenceText",
+      valueType: "string",
     });
   });
 

--- a/src/server/hf-space/parameter-contract.test.ts
+++ b/src/server/hf-space/parameter-contract.test.ts
@@ -146,6 +146,62 @@ describe("buildHfParameterDescriptors", () => {
     });
   });
 
+  it("canonical key가 충돌하면 후속 파라미터를 generic binding으로 보존한다", () => {
+    const result = buildHfParameterDescriptors([
+      {
+        parameter_name: "ref_text",
+        label: "Reference Text",
+        component: "Textbox",
+      },
+      {
+        parameter_name: "transcript_copy",
+        label: "Reference Text",
+        component: "Textbox",
+        parameter_default: "fallback",
+      },
+    ]);
+
+    expect(result.parameters.referenceText.binding.parameterName).toBe(
+      "ref_text",
+    );
+    expect(result.parameters["hf:transcript_copy"]).toMatchObject({
+      default: "fallback",
+      binding: {
+        parameterName: "transcript_copy",
+        valueType: "string",
+        order: 1,
+      },
+    });
+    expect(
+      result.parameters["hf:transcript_copy"].binding,
+    ).not.toHaveProperty("canonicalKey");
+    expect(result.warnings).toContain(
+      "PARAMETER_CANONICAL_FALLBACK:referenceText:transcript_copy",
+    );
+  });
+
+  it("generic key 자체가 충돌하면 기존 값을 덮어쓰지 않는다", () => {
+    const result = buildHfParameterDescriptors([
+      {
+        parameter_name: "fidelity_profile",
+        label: "First Profile",
+        component: "Textbox",
+        parameter_default: "first",
+      },
+      {
+        parameter_name: "fidelity_profile",
+        label: "Second Profile",
+        component: "Textbox",
+        parameter_default: "second",
+      },
+    ]);
+
+    expect(result.parameters["hf:fidelity_profile"].default).toBe("first");
+    expect(result.warnings).toContain(
+      "PARAMETER_KEY_COLLISION:hf:fidelity_profile",
+    );
+  });
+
   it("이름 의미가 불명확한 공개 파라미터를 generic key로 유지한다", () => {
     const result = buildHfParameterDescriptors([
       {

--- a/src/server/hf-space/parameter-contract.ts
+++ b/src/server/hf-space/parameter-contract.ts
@@ -124,6 +124,10 @@ function isCanonicalTypeCompatible(
   ) {
     return valueType === "string" && options.length > 0;
   }
+  if (canonicalKey === "voice") return valueType === "string";
+  if (canonicalKey === "seed") {
+    return valueType === "string" || valueType === "number";
+  }
   if (canonicalKey === "streamMode" || canonicalKey === "xvecOnly") {
     return valueType === "boolean";
   }
@@ -147,11 +151,10 @@ function resolveCanonicalKey(
   const nameMatch = matchCanonicalSignal(
     normalizeSignal(parameter.parameter_name),
   );
-  if (
-    nameMatch &&
-    isCanonicalTypeCompatible(nameMatch, valueType, options)
-  ) {
-    return nameMatch;
+  if (nameMatch) {
+    return isCanonicalTypeCompatible(nameMatch, valueType, options)
+      ? nameMatch
+      : null;
   }
 
   const labelMatch = matchCanonicalSignal(

--- a/src/server/hf-space/parameter-contract.ts
+++ b/src/server/hf-space/parameter-contract.ts
@@ -204,6 +204,10 @@ function resolveUi(
   options: RuntimeParameterOption[],
 ): HfParameterConfig["ui"] {
   const component = parameter.component?.toLowerCase() ?? "";
+  const signalTokens =
+    `${normalizeSignal(parameter.parameter_name)} ${normalizeSignal(parameter.label)}`.split(
+      " ",
+    );
   if (valueType === "file") return "upload";
   if (valueType === "boolean") return "toggle";
   if (component.includes("slider")) return "range";
@@ -213,7 +217,7 @@ function resolveUi(
   if (
     component.includes("textbox") &&
     (parameter.lines !== undefined && parameter.lines > 1 ||
-      `${normalizeSignal(parameter.parameter_name)} ${normalizeSignal(parameter.label)}`.includes("text"))
+      signalTokens.includes("text"))
   ) {
     return "textarea";
   }

--- a/src/server/hf-space/parameter-contract.ts
+++ b/src/server/hf-space/parameter-contract.ts
@@ -240,11 +240,23 @@ export function buildHfParameterDescriptors(
 
     const options = normalizeRuntimeParameterOptions(parameter.choices) ?? [];
     const valueType = resolveValueType(parameter);
-    const canonicalKey = resolveCanonicalKey(parameter, valueType, options);
-    const catalogKey =
-      canonicalKey && canonicalKeys.has(canonicalKey)
-        ? canonicalKey
-        : `hf:${parameterName}`;
+    const matchedCanonicalKey = resolveCanonicalKey(
+      parameter,
+      valueType,
+      options,
+    );
+    let canonicalKey =
+      matchedCanonicalKey && canonicalKeys.has(matchedCanonicalKey)
+        ? matchedCanonicalKey
+        : null;
+    let catalogKey = canonicalKey ?? `hf:${parameterName}`;
+    if (canonicalKey && result[catalogKey]) {
+      warnings.push(
+        `PARAMETER_CANONICAL_FALLBACK:${canonicalKey}:${parameterName}`,
+      );
+      canonicalKey = null;
+      catalogKey = `hf:${parameterName}`;
+    }
     if (result[catalogKey]) {
       warnings.push(`PARAMETER_KEY_COLLISION:${catalogKey}`);
       return;

--- a/src/server/hf-space/parameter-contract.ts
+++ b/src/server/hf-space/parameter-contract.ts
@@ -56,51 +56,113 @@ const canonicalKeys = new Set([
   "repetitionPenalty",
 ]);
 
-function normalizeLookup(parameter: HfEndpointParameter) {
-  return `${parameter.parameter_name ?? ""} ${parameter.label ?? ""}`
+function normalizeSignal(value: string | undefined) {
+  return (value ?? "")
+    .trim()
     .toLowerCase()
-    .replace(/[_-]+/g, " ");
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ");
 }
 
-function resolveCanonicalKey(parameter: HfEndpointParameter) {
-  const target = normalizeLookup(parameter);
-  const parameterName = parameter.parameter_name?.trim().toLowerCase() ?? "";
-  if (
-    target.includes("reference transcript") ||
-    target.includes("reference text") ||
-    target.includes("ref text")
-  ) {
+function normalizePrimaryLabel(label: string | undefined) {
+  return normalizeSignal(label?.replace(/\([^)]*\)/g, " "));
+}
+
+function matchCanonicalSignal(signal: string) {
+  if (/^(ref|reference) (text|transcript)( path)?$/.test(signal)) {
     return "referenceText";
   }
-  if (
-    target.includes("reference audio") ||
-    target.includes("ref audio")
-  ) {
+  if (/^(ref|reference|input) audio( path)?$/.test(signal)) {
     return "inputAudio";
   }
-  if (target.includes("target text") || target.includes("prompt")) {
+  if (signal === "target text" || signal === "prompt" || signal === "text") {
     return "prompt";
   }
-  if (target.trim() === "text text") {
-    return "prompt";
+  if (signal === "language") return "language";
+  if (signal === "stream mode" || signal === "streaming") return "streamMode";
+  if (signal === "reference preset" || signal === "ref preset") {
+    return "referencePreset";
   }
-  if (target.includes("language")) return "language";
-  if (target.includes("stream mode") || target.includes("streaming")) {
-    return "streamMode";
+  if (signal === "custom instruction" || signal === "custom instruct") {
+    return "customInstruction";
   }
-  if (target.includes("reference preset")) return "referencePreset";
-  if (target.includes("custom instruction")) return "customInstruction";
-  if (target.includes("voice instruction")) return "voiceInstruction";
-  if (parameterName === "xvec_only") return "xvecOnly";
-  if (target.includes("chunk size")) return "chunkSize";
-  if (target.includes("temperature")) return "temperature";
-  if (target.includes("top k")) return "topK";
-  if (target.includes("repetition penalty")) return "repetitionPenalty";
-  if (target.includes("speaker")) return "speaker";
-  if (target.trim() === "voice voice") return "voice";
-  if (target.includes("speed")) return "speed";
-  if (target.includes("generation mode")) return "modeChoice";
-  if (target.includes("seed")) return "seed";
+  if (signal === "voice instruction" || signal === "voice instruct") {
+    return "voiceInstruction";
+  }
+  if (signal === "xvec only") return "xvecOnly";
+  if (signal === "chunk size") return "chunkSize";
+  if (signal === "temperature") return "temperature";
+  if (signal === "top k") return "topK";
+  if (signal === "repetition penalty") return "repetitionPenalty";
+  if (signal === "speaker") return "speaker";
+  if (signal === "voice") return "voice";
+  if (signal === "speed") return "speed";
+  if (signal === "generation mode" || signal === "mode") return "modeChoice";
+  if (signal === "seed") return "seed";
+  return null;
+}
+
+function isCanonicalTypeCompatible(
+  canonicalKey: string,
+  valueType: HfParameterValueType,
+  options: RuntimeParameterOption[],
+) {
+  if (canonicalKey === "inputAudio") return valueType === "file";
+  if (
+    canonicalKey === "prompt" ||
+    canonicalKey === "referenceText" ||
+    canonicalKey === "customInstruction" ||
+    canonicalKey === "voiceInstruction"
+  ) {
+    return valueType === "string" && options.length === 0;
+  }
+  if (
+    canonicalKey === "language" ||
+    canonicalKey === "modeChoice" ||
+    canonicalKey === "referencePreset" ||
+    canonicalKey === "speaker"
+  ) {
+    return valueType === "string" && options.length > 0;
+  }
+  if (canonicalKey === "streamMode" || canonicalKey === "xvecOnly") {
+    return valueType === "boolean";
+  }
+  if (
+    canonicalKey === "speed" ||
+    canonicalKey === "chunkSize" ||
+    canonicalKey === "temperature" ||
+    canonicalKey === "topK" ||
+    canonicalKey === "repetitionPenalty"
+  ) {
+    return valueType === "number";
+  }
+  return true;
+}
+
+function resolveCanonicalKey(
+  parameter: HfEndpointParameter,
+  valueType: HfParameterValueType,
+  options: RuntimeParameterOption[],
+) {
+  const nameMatch = matchCanonicalSignal(
+    normalizeSignal(parameter.parameter_name),
+  );
+  if (
+    nameMatch &&
+    isCanonicalTypeCompatible(nameMatch, valueType, options)
+  ) {
+    return nameMatch;
+  }
+
+  const labelMatch = matchCanonicalSignal(
+    normalizePrimaryLabel(parameter.label),
+  );
+  if (
+    labelMatch &&
+    isCanonicalTypeCompatible(labelMatch, valueType, options)
+  ) {
+    return labelMatch;
+  }
   return null;
 }
 
@@ -148,7 +210,7 @@ function resolveUi(
   if (
     component.includes("textbox") &&
     (parameter.lines !== undefined && parameter.lines > 1 ||
-      normalizeLookup(parameter).includes("text"))
+      `${normalizeSignal(parameter.parameter_name)} ${normalizeSignal(parameter.label)}`.includes("text"))
   ) {
     return "textarea";
   }
@@ -176,7 +238,9 @@ export function buildHfParameterDescriptors(
       return;
     }
 
-    const canonicalKey = resolveCanonicalKey(parameter);
+    const options = normalizeRuntimeParameterOptions(parameter.choices) ?? [];
+    const valueType = resolveValueType(parameter);
+    const canonicalKey = resolveCanonicalKey(parameter, valueType, options);
     const catalogKey =
       canonicalKey && canonicalKeys.has(canonicalKey)
         ? canonicalKey
@@ -186,8 +250,6 @@ export function buildHfParameterDescriptors(
       return;
     }
 
-    const options = normalizeRuntimeParameterOptions(parameter.choices) ?? [];
-    const valueType = resolveValueType(parameter);
     const config: HfParameterConfig = {
       ui: resolveUi(parameter, valueType, options),
       label: parameter.label?.trim() || parameterName,

--- a/src/server/model-catalog/space-importer.test.ts
+++ b/src/server/model-catalog/space-importer.test.ts
@@ -146,6 +146,11 @@ describe("importModelDraftFromSpace", () => {
         warning.startsWith("UNMAPPED_PARAM:Use x-vector only"),
       ),
     ).toBe(false);
+    expect(
+      result.warnings.some((warning) =>
+        warning.startsWith("PARAMETER_CANONICAL_FALLBACK:"),
+      ),
+    ).toBe(false);
     expect(result.draft.parameters.referenceText.ui).toBe("textarea");
     expect(result.draft.parameters.prompt.ui).toBe("textarea");
   });

--- a/src/server/model-catalog/space-importer.test.ts
+++ b/src/server/model-catalog/space-importer.test.ts
@@ -23,7 +23,17 @@ describe("importModelDraftFromSpace", () => {
               { parameter_name: "ref_audio", label: "Reference Audio", parameter_has_default: false },
               { parameter_name: "ref_text", label: "Reference Text", parameter_has_default: false },
               { parameter_name: "target_text", label: "Target Text", parameter_has_default: false },
-              { parameter_name: "use_xvector_only", label: "Use x-vector only", parameter_default: false },
+              {
+                parameter_name: "language",
+                label: "Language",
+                parameter_default: "Auto",
+              },
+              {
+                parameter_name: "use_xvector_only",
+                label:
+                  "Use x-vector only (No reference text needed, but lower quality)",
+                parameter_default: false,
+              },
               { parameter_name: "model_size", label: "Model Size", parameter_default: "1.7B" },
             ],
           },
@@ -36,19 +46,36 @@ describe("importModelDraftFromSpace", () => {
           { id: 1, type: "audio", props: { label: "Reference Audio" } },
           { id: 2, type: "textbox", props: { label: "Reference Text", lines: 2 } },
           { id: 3, type: "textbox", props: { label: "Target Text", lines: 4 } },
-          { id: 4, type: "checkbox", props: { label: "Use x-vector only", value: false } },
+          {
+            id: 4,
+            type: "dropdown",
+            props: {
+              label: "Language",
+              choices: ["Auto", "Korean"],
+              value: "Auto",
+            },
+          },
           {
             id: 5,
+            type: "checkbox",
+            props: {
+              label:
+                "Use x-vector only (No reference text needed, but lower quality)",
+              value: false,
+            },
+          },
+          {
+            id: 6,
             type: "dropdown",
             props: { label: "Model Size", choices: ["0.6B", "1.7B"], value: "1.7B" },
           },
-          { id: 6, type: "audio", props: { label: "Generated Audio" } },
+          { id: 7, type: "audio", props: { label: "Generated Audio" } },
         ],
         dependencies: [
           {
             api_name: "/generate_voice_clone",
-            inputs: [1, 2, 3, 4, 5],
-            outputs: [6],
+            inputs: [1, 2, 3, 4, 5, 6],
+            outputs: [7],
           },
         ],
       },
@@ -70,10 +97,23 @@ describe("importModelDraftFromSpace", () => {
       parameterName: "target_text",
       canonicalKey: "prompt",
     });
+    expect(result.draft.parameters.language).toMatchObject({
+      ui: "select",
+      default: "Auto",
+      binding: {
+        parameterName: "language",
+        canonicalKey: "language",
+        order: 3,
+      },
+    });
     expect(result.draft.parameters["hf:use_xvector_only"]).toMatchObject({
       ui: "toggle",
       default: false,
-      binding: { parameterName: "use_xvector_only", valueType: "boolean" },
+      binding: {
+        parameterName: "use_xvector_only",
+        valueType: "boolean",
+        order: 4,
+      },
     });
     expect(result.draft.parameters["hf:model_size"]).toMatchObject({
       ui: "select",
@@ -82,8 +122,30 @@ describe("importModelDraftFromSpace", () => {
         { label: "0.6B", value: "0.6B" },
         { label: "1.7B", value: "1.7B" },
       ],
-      binding: { parameterName: "model_size", valueType: "string" },
+      binding: {
+        parameterName: "model_size",
+        valueType: "string",
+        order: 5,
+      },
     });
+    expect(Object.keys(result.draft.parameters)).toEqual(
+      expect.arrayContaining([
+        "inputAudio",
+        "referenceText",
+        "prompt",
+        "language",
+        "hf:use_xvector_only",
+        "hf:model_size",
+      ]),
+    );
+    expect(result.warnings).not.toContain(
+      "PARAMETER_KEY_COLLISION:referenceText",
+    );
+    expect(
+      result.warnings.some((warning) =>
+        warning.startsWith("UNMAPPED_PARAM:Use x-vector only"),
+      ),
+    ).toBe(false);
     expect(result.draft.parameters.referenceText.ui).toBe("textarea");
     expect(result.draft.parameters.prompt.ui).toBe("textarea");
   });


### PR DESCRIPTION
# PR Draft: hf-space-canonical-matching-hardening

## 개요

- 변경 목적: parameter name과 component 타입을 우선해 label 설명 문구의 canonical 오탐을 방지하고, key 충돌 시 공개 파라미터를 generic binding으로 보존한다.
- 사용자 영향: Qwen voice clone의 `use_xvector_only`를 포함한 Space 공개 입력이 자동 모델 추가 결과에서 누락되지 않는다.

## 변경 사항

- [x] parameter name과 primary label 신호 분리 및 name-first canonical matcher 적용
- [x] canonical field별 component/value type 적합성 guard 추가
- [x] canonical key 충돌 시 `hf:<parameter_name>` generic fallback 적용
- [x] 실제 Qwen 6개 parameter fixture와 유사 label 오탐 회귀 테스트 추가

## 테스트

- [x] 관련 Vitest 6 files / 45 tests PASS
- [x] `pnpm db:generate && pnpm typecheck` PASS
- [x] 변경 파일 ESLint 0 errors
- [x] live Qwen `/generate_voice_clone` import 진단 PASS

## 아키텍처 다이어그램

- UI 변경 없음

```mermaid
sequenceDiagram
  participant Importer as HF Space Importer
  participant Matcher as Canonical Matcher
  participant Catalog as Model Parameters
  Importer->>Matcher: parameter_name, label, component, default
  Matcher->>Matcher: direct name alias + value type 검증
  alt direct name이 호환됨
    Matcher-->>Catalog: canonical binding
  else direct name이 타입과 모순됨
    Matcher-->>Catalog: hf:parameter_name generic binding
  else direct name alias가 없음
    Matcher->>Matcher: primary label fallback + type 검증
    alt label이 호환되고 canonical key가 비어 있음
      Matcher-->>Catalog: canonical binding
    else 모호하거나 canonical key가 충돌함
      Matcher-->>Catalog: hf:parameter_name generic binding
    end
  end
```

## 관련 문서

- Spec: `features/F050-hf-space-canonical-matching-hardening/spec.md`
- Tasks: `features/F050-hf-space-canonical-matching-hardening/tasks.md`
- Decisions: `features/F050-hf-space-canonical-matching-hardening/decisions.md`

Closes #97


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 파라미터 매칭 로직을 개선하여 라벨과 파라미터 이름의 호환성 검증을 강화했습니다.
  * 타입 및 옵션 기반 파라미터 바인딩의 정확도를 향상시켰습니다.

* **테스트**
  * 파라미터 해석 규칙에 대한 포괄적인 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->