### PR TITLE
feat(#99): audio-generation-form-ui-fixes (이미지·비디오·오디오 공통 생성 폼의 prompt 오류 배치와 설정 popover 내부 select 메뉴 레이어 문제를 수정한다)

### DIFF
--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -261,6 +261,23 @@ async function openModelPicker(user: ReturnType<typeof userEvent.setup>) {
   );
 }
 
+function getLabelElement(label: string) {
+  const element = screen.getByText(label);
+  const labelElement = element.closest("label");
+  expect(labelElement).not.toBeNull();
+  return labelElement!;
+}
+
+function expectLabelToBeRequired(label: string) {
+  const marker = within(getLabelElement(label)).getByText("*");
+  expect(marker).toHaveAttribute("aria-hidden", "true");
+  expect(marker).toHaveClass("text-red-400");
+}
+
+function expectLabelNotToBeRequired(label: string) {
+  expect(within(getLabelElement(label)).queryByText("*")).toBeNull();
+}
+
 describe("AudioGenerationForm", () => {
   beforeEach(() => {
     navigationMocks.push.mockReset();
@@ -416,6 +433,7 @@ describe("AudioGenerationForm", () => {
     expect(
       screen.getByRole("slider", { name: "Playback Rate" }),
     ).toBeInTheDocument();
+    expectLabelNotToBeRequired("Playback Rate");
     expect(screen.queryByText("속도")).not.toBeInTheDocument();
   });
 
@@ -628,6 +646,8 @@ describe("AudioGenerationForm", () => {
       "hello clone",
     );
     await user.click(screen.getByRole("button", { name: /설정/i }));
+    expectLabelToBeRequired("Sample audio");
+    expectLabelToBeRequired("샘플 문장");
     await user.upload(
       await screen.findByLabelText("Sample audio"),
       new File([Uint8Array.from([82, 73, 70, 70])], "ref.wav", {
@@ -777,6 +797,8 @@ describe("AudioGenerationForm", () => {
     expect(
       screen.getByRole("combobox", { name: "Model Size" }),
     ).toHaveTextContent("1.7B");
+    expectLabelNotToBeRequired("Model Size");
+    expectLabelToBeRequired("Reference Sample");
     Element.prototype.scrollIntoView = vi.fn();
     screen.getByRole("combobox", { name: "Quality Level" }).focus();
     await user.keyboard("{ArrowDown}{Home}{Enter}");

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -418,7 +418,7 @@ describe("AudioGenerationForm", () => {
     expect(screen.queryByText("VOICE TAKE")).toBeNull();
   });
 
-  it("완료된 결과 오디오 플레이어와 액션을 표시한다", async () => {
+  it("완료된 결과는 메인 오디오 플레이어만 표시한다", async () => {
     mockUseAudioGeneration.mockReturnValue({
       state: {
         status: "completed",
@@ -443,40 +443,8 @@ describe("AudioGenerationForm", () => {
     await waitForModels();
 
     expect(container.querySelector("audio")).not.toBeNull();
-    expect(screen.getByText(/#1/i)).not.toBeNull();
-    const openLink = container.querySelector('a[title="열기"]');
-    const downloadLink = container.querySelector('a[title="다운로드"]');
-
-    expect(openLink?.getAttribute("href")).toBe("https://example.com/generated.mp3");
-    expect(downloadLink?.getAttribute("href")).toBe(
-      "/api/audio-generation/request-id/download?index=0",
-    );
-  });
-
-  it("requestId가 없으면 다운로드 링크를 직접 자산 URL로 노출하지 않는다", async () => {
-    mockUseAudioGeneration.mockReturnValue({
-      state: {
-        status: "completed",
-        progress: 100,
-        result: {
-          audios: [
-            {
-              url: "https://example.com/generated.mp3",
-              durationSec: 7,
-            },
-          ],
-        },
-      },
-      startGeneration: vi.fn(),
-      reset: vi.fn(),
-    });
-
-    const { container } = renderWithIntl(
-      <AudioGenerationForm isAuthenticated />,
-    );
-    await waitForModels();
-
-    expect(container.querySelector('a[title="열기"]')).not.toBeNull();
+    expect(screen.queryByText(/#1/i)).not.toBeInTheDocument();
+    expect(container.querySelector('a[title="열기"]')).toBeNull();
     expect(container.querySelector('a[title="다운로드"]')).toBeNull();
   });
 

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -338,15 +338,19 @@ describe("AudioGenerationForm", () => {
     renderWithIntl(<AudioGenerationForm isAuthenticated />);
     await waitForModels();
 
+    expect(screen.queryByTestId("shared-prompt-feedback")).toBeNull();
+
     const dock = screen.getByRole("region", { name: "작업 입력" });
     const form = dock.closest("form");
     expect(form).not.toBeNull();
     fireEvent.submit(form!);
 
     const message = await screen.findByText("프롬프트를 입력해주세요.");
+    const feedback = screen.getByTestId("shared-prompt-feedback");
     expect(screen.getByTestId("shared-prompt-form-surface")).toContainElement(
-      message,
+      feedback,
     );
+    expect(feedback).toContainElement(message);
     expect(startGeneration).not.toHaveBeenCalled();
   });
 

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -36,10 +36,19 @@ const runtimeAudioModelsFixture: RuntimeAudioModel[] = [
         default: "alloy",
       },
       speed: {
+        ui: "range",
+        label: "Playback Rate",
         min: 0.25,
         max: 4,
         step: 0.05,
         default: 1,
+        binding: {
+          source: "hf_space",
+          parameterName: "speed",
+          valueType: "number",
+          canonicalKey: "speed",
+          order: 1,
+        },
       },
       seed: {
         ui: "text",
@@ -390,6 +399,24 @@ describe("AudioGenerationForm", () => {
       screen.getByRole("button", { name: /Qwen 3\.5 TTS/i }),
     ).toHaveAttribute("aria-haspopup", "dialog");
     expect(screen.getByRole("button", { name: "생성" })).toBeInTheDocument();
+  });
+
+  it("HF-bound canonical 필드는 provider label을 그대로 표시한다", async () => {
+    mockUseAudioGeneration.mockReturnValue({
+      state: { status: "idle", progress: 0 },
+      startGeneration: vi.fn(),
+      reset: vi.fn(),
+    });
+
+    const user = userEvent.setup();
+    renderWithIntl(<AudioGenerationForm isAuthenticated />);
+    await waitForModels();
+    await user.click(screen.getByRole("button", { name: /설정/i }));
+
+    expect(
+      screen.getByRole("slider", { name: "Playback Rate" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("속도")).not.toBeInTheDocument();
   });
 
   it("renders a text-first audio studio preview without mock media cards", async () => {

--- a/src/features/audio-generation/ui/audio-generation-form.test.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AudioGenerationForm } from "@/features/audio-generation/ui/audio-generation-form";
 import { renderWithIntl } from "@/test-utils/intl";
 import type { RuntimeAudioModel } from "@/shared/model-catalog/runtime-utils";
@@ -325,6 +325,29 @@ describe("AudioGenerationForm", () => {
         model: "qwen-tts",
       }),
     );
+  });
+
+  it("빈 prompt 오류를 공통 입력 dock 내부에 표시한다", async () => {
+    const startGeneration = vi.fn();
+    mockUseAudioGeneration.mockReturnValue({
+      state: { status: "idle", progress: 0 },
+      startGeneration,
+      reset: vi.fn(),
+    });
+
+    renderWithIntl(<AudioGenerationForm isAuthenticated />);
+    await waitForModels();
+
+    const dock = screen.getByRole("region", { name: "작업 입력" });
+    const form = dock.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    const message = await screen.findByText("프롬프트를 입력해주세요.");
+    expect(screen.getByTestId("shared-prompt-form-surface")).toContainElement(
+      message,
+    );
+    expect(startGeneration).not.toHaveBeenCalled();
   });
 
   it("renders the shared creation input with audio-specific control chips", async () => {

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -2,8 +2,6 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
-  Download,
-  ExternalLink,
   SlidersHorizontal,
   Sparkles,
 } from "lucide-react";
@@ -1049,55 +1047,6 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
           {hasResults && state.errorMessage ? (
             <div className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs text-amber-200">
               {state.errorMessage}
-            </div>
-          ) : null}
-
-          {hasResults && resultAudios.length > 0 ? (
-            <div className="flex flex-col gap-2">
-              {resultAudios.map((audio, index) => {
-                const downloadUrl = state.requestId
-                  ? `/api/audio-generation/${state.requestId}/download?index=${index}`
-                  : null;
-
-                return (
-                  <div
-                    key={`${audio.url}-${index}`}
-                    className="flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-surface-dark/60 px-3 py-2"
-                  >
-                    <div className="text-xs font-mono uppercase tracking-widest text-gray-500">
-                      #{index + 1}
-                      {typeof audio.durationSec === "number"
-                        ? ` • ${audio.durationSec}s`
-                        : ""}
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <AppButton asChild variant="surface" size="icon-sm">
-                        <a
-                          href={audio.url}
-                          target="_blank"
-                          rel="noreferrer"
-                          title={tActions("open")}
-                          aria-label={tActions("open")}
-                        >
-                          <ExternalLink className="h-4 w-4" />
-                        </a>
-                      </AppButton>
-                      {downloadUrl ? (
-                        <AppButton asChild variant="surface" size="icon-sm">
-                          <a
-                            href={downloadUrl}
-                            download
-                            title={tActions("download")}
-                            aria-label={tActions("download")}
-                          >
-                            <Download className="h-4 w-4" />
-                          </a>
-                        </AppButton>
-                      ) : null}
-                    </div>
-                  </div>
-                );
-              })}
             </div>
           ) : null}
 

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -1120,6 +1120,9 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
                     </AppFormControl>
                   }
                   promptMeta={tLabels("chars", { count: promptValue.length })}
+                  feedback={
+                    <AppFormMessage className="text-xs text-red-400" />
+                  }
                   footerLeft={
                     <>
                       {!isGuest && hasModels ? (
@@ -1210,7 +1213,6 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
                     </>
                   }
                 />
-                <AppFormMessage className="text-xs text-red-400" />
               </AppFormItem>
             )}
           />

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -56,6 +56,7 @@ import {
   getRuntimeAudioParamConfig,
   getRuntimeAudioDynamicParameters,
   getRuntimeAudioParamRange,
+  resolveRuntimeParameterLabel,
   resolveRuntimeAudioDefaults,
   resolveRuntimeAudioSupportsInputAudio,
   resolveRuntimeDefaultModelKey,
@@ -471,46 +472,47 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
 
   const getFieldLabel = (key: AudioFieldName) => {
     const config = getRuntimeAudioParamConfig(activeRuntimeModel, key);
-    switch (key) {
-      case "voice":
-        return tAudio("voiceLabel");
-      case "referenceText":
-        return tAudio("referenceTextLabel");
-      case "speed":
-        return tAudio("speedLabel");
-      case "seed":
-        return tLabels("seed");
-      case "modeChoice":
-        return "Mode";
-      case "language":
-        return "Language";
-      case "speaker":
-        return "Speaker";
-      case "streamMode":
-        return "Live output";
-      case "referencePreset":
-        return "Voice sample";
-      case "customInstruction":
-        return "Notes";
-      case "voiceInstruction":
-        return "Voice style";
-      case "xvecOnly":
-        return "Voice match";
-      case "chunkSize":
-        return "Detail";
-      case "temperature":
-        return "Variation";
-      case "topK":
-        return "Clarity";
-      case "repetitionPenalty":
-        return "Repetition";
-      case "inputAudio":
-        return "Sample audio";
-      default:
-        return typeof config?.label === "string" && config.label.trim()
-          ? config.label
-          : key;
-    }
+    const fallback = (() => {
+      switch (key) {
+        case "voice":
+          return tAudio("voiceLabel");
+        case "referenceText":
+          return tAudio("referenceTextLabel");
+        case "speed":
+          return tAudio("speedLabel");
+        case "seed":
+          return tLabels("seed");
+        case "modeChoice":
+          return "Mode";
+        case "language":
+          return "Language";
+        case "speaker":
+          return "Speaker";
+        case "streamMode":
+          return "Live output";
+        case "referencePreset":
+          return "Voice sample";
+        case "customInstruction":
+          return "Notes";
+        case "voiceInstruction":
+          return "Voice style";
+        case "xvecOnly":
+          return "Voice match";
+        case "chunkSize":
+          return "Detail";
+        case "temperature":
+          return "Variation";
+        case "topK":
+          return "Clarity";
+        case "repetitionPenalty":
+          return "Repetition";
+        case "inputAudio":
+          return "Sample audio";
+        default:
+          return key;
+      }
+    })();
+    return resolveRuntimeParameterLabel(config, fallback);
   };
 
   const getFieldTextareaPlaceholder = () => "";
@@ -782,10 +784,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
     config: (typeof dynamicParameters)[number]["config"],
   ) => {
     const fieldName = `dynamicParams.${key}` as const;
-    const label =
-      typeof config.label === "string" && config.label.trim()
-        ? config.label
-        : key;
+    const label = resolveRuntimeParameterLabel(config, key);
 
     if (config.ui === "range") {
       const min = typeof config.min === "number" ? config.min : 0;

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -117,6 +117,25 @@ const studioPreviewShellClass =
 const studioResultFrameClass =
   "mt-10 min-h-[18rem] w-full max-w-6xl rounded-[1.75rem] border border-white/10 bg-[#0b0d0c]/72 shadow-[0_24px_90px_rgba(0,0,0,0.46)] sm:min-h-[24rem]";
 
+function RequiredFieldLabel({
+  label,
+  required,
+}: {
+  label: string;
+  required: boolean;
+}) {
+  return (
+    <>
+      <span>{label}</span>
+      {required ? (
+        <span aria-hidden="true" className="ml-1 text-red-400">
+          *
+        </span>
+      ) : null}
+    </>
+  );
+}
+
 export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProps) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
@@ -552,6 +571,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
     const config = getRuntimeAudioParamConfig(activeRuntimeModel, key);
     if (!config || config.ui === "hidden") return null;
     const label = getFieldLabel(key);
+    const isRequired = config.required === true;
 
     if (key === "inputAudio") {
       return (
@@ -562,7 +582,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
           render={() => (
             <AppFormItem className="flex flex-col gap-3">
               <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                {label}
+                <RequiredFieldLabel label={label} required={isRequired} />
               </AppFormLabel>
               <AppFormControl>
                 <input
@@ -619,7 +639,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
                   <>
               <div className="flex items-center justify-between">
                 <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                  {label}
+                  <RequiredFieldLabel label={label} required={isRequired} />
                 </AppFormLabel>
                 <span className="rounded border border-white/10 bg-surface-lighter px-2 py-0.5 text-xs font-bold text-white font-mono">
                   {effectiveValue}
@@ -656,7 +676,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
           render={({ field }) => (
             <AppFormItem className="flex flex-col gap-2">
               <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                {label}
+                <RequiredFieldLabel label={label} required={isRequired} />
               </AppFormLabel>
               <AppSelectRoot
                 value={
@@ -705,7 +725,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
             return (
               <AppFormItem className="flex items-center justify-between gap-4">
                 <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                  {label}
+                  <RequiredFieldLabel label={label} required={isRequired} />
                 </AppFormLabel>
                 <AppFormControl>
                   <AppButton
@@ -738,7 +758,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
           render={({ field }) => (
             <AppFormItem className="flex flex-col gap-2">
               <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                {label}
+                <RequiredFieldLabel label={label} required={isRequired} />
               </AppFormLabel>
               <AppFormControl>
                 <AppTextarea
@@ -763,7 +783,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
         render={({ field }) => (
           <AppFormItem className="flex flex-col gap-2">
             <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-              {label}
+              <RequiredFieldLabel label={label} required={isRequired} />
             </AppFormLabel>
             <AppFormControl>
               <AppInput
@@ -785,6 +805,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
   ) => {
     const fieldName = `dynamicParams.${key}` as const;
     const label = resolveRuntimeParameterLabel(config, key);
+    const isRequired = config.required === true;
 
     if (config.ui === "range") {
       const min = typeof config.min === "number" ? config.min : 0;
@@ -806,7 +827,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
               <AppFormItem className="flex flex-col gap-3">
                 <div className="flex items-center justify-between">
                   <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                    {label}
+                    <RequiredFieldLabel label={label} required={isRequired} />
                   </AppFormLabel>
                   <span className="rounded border border-white/10 bg-surface-lighter px-2 py-0.5 text-xs font-bold text-white font-mono">
                     {value}
@@ -843,7 +864,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
           render={({ field }) => (
             <AppFormItem className="flex flex-col gap-3">
               <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                {label}
+                <RequiredFieldLabel label={label} required={isRequired} />
               </AppFormLabel>
               <AppFormControl>
                 <input
@@ -881,7 +902,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
           render={({ field }) => (
             <AppFormItem className="flex flex-col gap-2">
               <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                {label}
+                <RequiredFieldLabel label={label} required={isRequired} />
               </AppFormLabel>
               <AppSelectRoot
                 value={field.value === undefined ? "" : String(field.value)}
@@ -927,7 +948,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
             return (
               <AppFormItem className="flex items-center justify-between gap-4">
                 <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                  {label}
+                  <RequiredFieldLabel label={label} required={isRequired} />
                 </AppFormLabel>
                 <AppFormControl>
                   <AppButton
@@ -957,7 +978,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
           render={({ field }) => (
             <AppFormItem className="flex flex-col gap-2">
               <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-                {label}
+                <RequiredFieldLabel label={label} required={isRequired} />
               </AppFormLabel>
               <AppFormControl>
                 <AppTextarea
@@ -982,7 +1003,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
         render={({ field }) => (
           <AppFormItem className="flex flex-col gap-2">
             <AppFormLabel className="text-[10px] font-bold uppercase tracking-widest text-gray-500 font-mono">
-              {label}
+              <RequiredFieldLabel label={label} required={isRequired} />
             </AppFormLabel>
             <AppFormControl>
               <AppInput

--- a/src/features/audio-generation/ui/audio-generation-form.tsx
+++ b/src/features/audio-generation/ui/audio-generation-form.tsx
@@ -1053,7 +1053,7 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
           <AppFormControllerField
             control={form.control}
             name="prompt"
-            render={({ field }) => (
+            render={({ field, fieldState }) => (
               <AppFormItem className="flex-1">
                 <GenerationPromptField
                   ariaLabel={tGeneration("promptDock.label")}
@@ -1069,9 +1069,9 @@ export function AudioGenerationForm({ isAuthenticated }: AudioGenerationFormProp
                     </AppFormControl>
                   }
                   promptMeta={tLabels("chars", { count: promptValue.length })}
-                  feedback={
+                  feedback={fieldState.error ? (
                     <AppFormMessage className="text-xs text-red-400" />
-                  }
+                  ) : undefined}
                   footerLeft={
                     <>
                       {!isGuest && hasModels ? (

--- a/src/features/image-generation/ui/image-generation-form.test.tsx
+++ b/src/features/image-generation/ui/image-generation-form.test.tsx
@@ -213,6 +213,9 @@ describe("ImageGenerationForm", () => {
     expect(
       await screen.findByText("프롬프트를 입력해주세요."),
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("shared-prompt-form-surface"),
+    ).toContainElement(screen.getByText("프롬프트를 입력해주세요."));
     expect(startGeneration).not.toHaveBeenCalled();
   });
 

--- a/src/features/image-generation/ui/image-generation-form.test.tsx
+++ b/src/features/image-generation/ui/image-generation-form.test.tsx
@@ -208,14 +208,20 @@ describe("ImageGenerationForm", () => {
     renderWithIntl(<ImageGenerationForm isAuthenticated />);
     await waitForModels();
 
+    expect(screen.queryByTestId("shared-prompt-feedback")).toBeNull();
+
     await user.click(screen.getByRole("button", { name: "생성" }));
 
     expect(
       await screen.findByText("프롬프트를 입력해주세요."),
     ).toBeInTheDocument();
+    const feedback = screen.getByTestId("shared-prompt-feedback");
     expect(
       screen.getByTestId("shared-prompt-form-surface"),
-    ).toContainElement(screen.getByText("프롬프트를 입력해주세요."));
+    ).toContainElement(feedback);
+    expect(feedback).toContainElement(
+      screen.getByText("프롬프트를 입력해주세요."),
+    );
     expect(startGeneration).not.toHaveBeenCalled();
   });
 

--- a/src/features/image-generation/ui/image-generation-form.tsx
+++ b/src/features/image-generation/ui/image-generation-form.tsx
@@ -511,6 +511,9 @@ export function ImageGenerationForm({ isAuthenticated }: ImageGenerationFormProp
                         promptMeta={tLabels("chars", {
                           count: promptValue.length,
                         })}
+                        feedback={
+                          <AppFormMessage className="text-xs text-red-400" />
+                        }
                         attachments={
                           initImagePreviews.length > 0 ? (
                             <div className="flex flex-wrap gap-2 px-4 pb-3">
@@ -916,7 +919,6 @@ export function ImageGenerationForm({ isAuthenticated }: ImageGenerationFormProp
                         className="hidden"
                         onChange={handleImageSelection}
                       />
-                      <AppFormMessage className="text-xs text-red-400" />
                     </AppFormItem>
                   )}
                 />

--- a/src/features/image-generation/ui/image-generation-form.tsx
+++ b/src/features/image-generation/ui/image-generation-form.tsx
@@ -493,7 +493,7 @@ export function ImageGenerationForm({ isAuthenticated }: ImageGenerationFormProp
                 <AppFormControllerField
                   control={form.control}
                   name="prompt"
-                  render={({ field }) => (
+                  render={({ field, fieldState }) => (
                     <AppFormItem className="flex-1">
                       <GenerationPromptField
                         ariaLabel={tGeneration("promptDock.label")}
@@ -511,9 +511,9 @@ export function ImageGenerationForm({ isAuthenticated }: ImageGenerationFormProp
                         promptMeta={tLabels("chars", {
                           count: promptValue.length,
                         })}
-                        feedback={
+                        feedback={fieldState.error ? (
                           <AppFormMessage className="text-xs text-red-400" />
-                        }
+                        ) : undefined}
                         attachments={
                           initImagePreviews.length > 0 ? (
                             <div className="flex flex-wrap gap-2 px-4 pb-3">

--- a/src/features/video-generation/ui/video-generation-form.test.tsx
+++ b/src/features/video-generation/ui/video-generation-form.test.tsx
@@ -210,15 +210,19 @@ describe("VideoGenerationForm", () => {
     renderWithIntl(<VideoGenerationForm isAuthenticated />);
     await waitForModels();
 
+    expect(screen.queryByTestId("shared-prompt-feedback")).toBeNull();
+
     const dock = screen.getByRole("region", { name: "작업 입력" });
     const form = dock.closest("form");
     expect(form).not.toBeNull();
     fireEvent.submit(form!);
 
     const message = await screen.findByText("프롬프트를 입력해주세요.");
+    const feedback = screen.getByTestId("shared-prompt-feedback");
     expect(screen.getByTestId("shared-prompt-form-surface")).toContainElement(
-      message,
+      feedback,
     );
+    expect(feedback).toContainElement(message);
     expect(startGenerationMock).not.toHaveBeenCalled();
   });
 

--- a/src/features/video-generation/ui/video-generation-form.test.tsx
+++ b/src/features/video-generation/ui/video-generation-form.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from "@testing-library/react";
+import { fireEvent, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VideoGenerationForm } from "@/features/video-generation/ui/video-generation-form";
@@ -204,6 +204,22 @@ describe("VideoGenerationForm", () => {
         initImage: "data:image/png;base64,AAAA",
       }),
     );
+  });
+
+  it("빈 prompt 오류를 공통 입력 dock 내부에 표시한다", async () => {
+    renderWithIntl(<VideoGenerationForm isAuthenticated />);
+    await waitForModels();
+
+    const dock = screen.getByRole("region", { name: "작업 입력" });
+    const form = dock.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    const message = await screen.findByText("프롬프트를 입력해주세요.");
+    expect(screen.getByTestId("shared-prompt-form-surface")).toContainElement(
+      message,
+    );
+    expect(startGenerationMock).not.toHaveBeenCalled();
   });
 
   it("모델 카드에서 기술 배지와 설명을 제거하고 기본 모델만 표시한다", async () => {

--- a/src/features/video-generation/ui/video-generation-form.tsx
+++ b/src/features/video-generation/ui/video-generation-form.tsx
@@ -375,7 +375,7 @@ export function VideoGenerationForm({ isAuthenticated }: VideoGenerationFormProp
           <AppFormControllerField
             control={form.control}
             name="prompt"
-            render={({ field }) => (
+            render={({ field, fieldState }) => (
               <AppFormItem className="flex-1">
                 <GenerationPromptField
                   ariaLabel={tGeneration("promptDock.label")}
@@ -391,9 +391,9 @@ export function VideoGenerationForm({ isAuthenticated }: VideoGenerationFormProp
                     </AppFormControl>
                   }
                   promptMeta={tLabels("chars", { count: promptValue.length })}
-                  feedback={
+                  feedback={fieldState.error ? (
                     <AppFormMessage className="text-xs text-red-400" />
-                  }
+                  ) : undefined}
                   attachments={
                     initImageValue ? (
                       <div className="flex flex-wrap gap-2 px-4 pb-3">

--- a/src/features/video-generation/ui/video-generation-form.tsx
+++ b/src/features/video-generation/ui/video-generation-form.tsx
@@ -391,6 +391,9 @@ export function VideoGenerationForm({ isAuthenticated }: VideoGenerationFormProp
                     </AppFormControl>
                   }
                   promptMeta={tLabels("chars", { count: promptValue.length })}
+                  feedback={
+                    <AppFormMessage className="text-xs text-red-400" />
+                  }
                   attachments={
                     initImageValue ? (
                       <div className="flex flex-wrap gap-2 px-4 pb-3">
@@ -560,7 +563,6 @@ export function VideoGenerationForm({ isAuthenticated }: VideoGenerationFormProp
                   className="hidden"
                   onChange={handleImageSelection}
                 />
-                <AppFormMessage className="text-xs text-red-400" />
               </AppFormItem>
             )}
           />

--- a/src/server/model-catalog/generation-validation.test.ts
+++ b/src/server/model-catalog/generation-validation.test.ts
@@ -19,6 +19,20 @@ describe("validateAudioGenerationPayload dynamicParams", () => {
         providerConfig: { space_id: "Qwen/Qwen3-TTS", api_name: "/generate_voice_clone" },
         parameters: {
           prompt: { ui: "textarea", required: true },
+          speed: {
+            ui: "range",
+            label: "Playback Rate",
+            min: 0.25,
+            max: 4,
+            step: 0.05,
+            binding: {
+              source: "hf_space",
+              parameterName: "speed",
+              valueType: "number",
+              canonicalKey: "speed",
+              order: 4,
+            },
+          },
           "hf:model_size": {
             ui: "select",
             required: true,
@@ -83,6 +97,27 @@ describe("validateAudioGenerationPayload dynamicParams", () => {
       dynamicParams: { "hf:model_size": "1.7B" },
     });
     expect(result.success).toBe(true);
+  });
+
+  it("HF-bound canonical step 오류에 provider label을 사용한다", async () => {
+    const { validateAudioGenerationPayload } = await import(
+      "@/server/model-catalog/generation-validation"
+    );
+    const result = await validateAudioGenerationPayload(
+      {
+        prompt: "hello",
+        model: "qwen-dynamic",
+        speed: 1.025,
+      },
+      (key, values) =>
+        key === "step" ? `${values?.label} step ${values?.step}` : key,
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("Expected HF-bound speed step validation to fail");
+    }
+    expect(result.error.issues[0]?.message).toBe("Playback Rate step 0.05");
   });
 
   it("unknown key와 지원하지 않는 option을 거부한다", async () => {

--- a/src/server/model-catalog/generation-validation.ts
+++ b/src/server/model-catalog/generation-validation.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { hasRuntimeParameterOption } from "@/shared/model-catalog/parameter-options";
+import { resolveRuntimeParameterLabel } from "@/shared/model-catalog/runtime-utils";
 import type { AudioGenerationFormValues } from "@/features/audio-generation/model/audio-generation-schema";
 import type { ImageGenerationFormValues } from "@/features/image-generation/model/image-generation-schema";
 import type { VideoGenerationFormValues } from "@/features/video-generation/model/video-generation-schema";
@@ -27,6 +28,7 @@ type NumericRange = {
 
 type ParameterConfig = {
   ui?: unknown;
+  label?: unknown;
   min?: unknown;
   max?: unknown;
   step?: unknown;
@@ -505,11 +507,15 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
     );
 
     if (typeof data.speed === "number") {
+      const speedLabel = resolveRuntimeParameterLabel(
+        getParamConfig(parameters, "speed"),
+        labels.speed,
+      );
       if (data.speed < speedRange.min || data.speed > speedRange.max) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["speed"],
-          message: rangeMessage(labels.speed, speedRange.min, speedRange.max),
+          message: rangeMessage(speedLabel, speedRange.min, speedRange.max),
         });
       } else if (speedRange.step > 0) {
         const offset = data.speed - speedRange.min;
@@ -518,7 +524,7 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: ["speed"],
-            message: stepMessage(labels.speed, speedRange.step),
+            message: stepMessage(speedLabel, speedRange.step),
           });
         }
       }
@@ -570,9 +576,13 @@ function buildAudioSchema(models: AudioModelCatalogItem[], t?: TranslationFn) {
     const validateNumeric = (
       key: "chunkSize" | "temperature" | "topK" | "repetitionPenalty",
       value: number | undefined,
-      label: string,
+      fallbackLabel: string,
     ) => {
       if (typeof value !== "number") return;
+      const label = resolveRuntimeParameterLabel(
+        getParamConfig(parameters, key),
+        fallbackLabel,
+      );
       const range = resolveRange(
         getParamConfig(parameters, key),
         key === "chunkSize"

--- a/src/server/model-catalog/space-importer.test.ts
+++ b/src/server/model-catalog/space-importer.test.ts
@@ -138,6 +138,9 @@ describe("importModelDraftFromSpace", () => {
         "hf:model_size",
       ]),
     );
+    expect(Object.keys(result.draft.parameters)).not.toEqual(
+      expect.arrayContaining(["speed", "seed"]),
+    );
     expect(result.warnings).not.toContain(
       "PARAMETER_KEY_COLLISION:referenceText",
     );
@@ -220,6 +223,8 @@ describe("importModelDraftFromSpace", () => {
     expect(result.draft.providerConfig.api_name).toBe("/run_generation");
     expect(result.draft.meta.supports_input_audio).toBe(true);
     expect(result.draft.parameters.voice).toBeUndefined();
+    expect(result.draft.parameters.speed).toBeUndefined();
+    expect(result.draft.parameters.seed).toBeUndefined();
     expect(result.draft.parameters.inputAudio).toMatchObject({
       ui: "upload",
     });

--- a/src/server/model-catalog/space-importer.ts
+++ b/src/server/model-catalog/space-importer.ts
@@ -575,7 +575,7 @@ export async function importModelDraftFromSpace(
       ? { ...FALLBACK_IMAGE_PARAMETERS, ...parameters }
       : modelType === "video"
         ? { ...FALLBACK_VIDEO_PARAMETERS, ...parameters }
-        : { ...FALLBACK_AUDIO_PARAMETERS, ...parameters };
+        : parameters;
 
   const width = resolveNumber(
     getDefaultFromParam(normalizedParameters.width),

--- a/src/shared/i18n/messages/en.json
+++ b/src/shared/i18n/messages/en.json
@@ -409,6 +409,7 @@
         "invalidModel": "Unsupported model.",
         "noModels": "No audio models are registered.",
         "range": "{label} must be between {min} and {max}.",
+        "step": "{label} must be in increments of {step}.",
         "unsupportedVoice": "Unsupported voice.",
         "inputAudioUnsupported": "The selected model does not support audio input.",
         "referenceTextRequired": "Please enter the reference text.",

--- a/src/shared/i18n/messages/ko.json
+++ b/src/shared/i18n/messages/ko.json
@@ -409,6 +409,7 @@
         "invalidModel": "지원하지 않는 모델입니다.",
         "noModels": "등록된 오디오 모델이 없습니다.",
         "range": "{label}는 {min}~{max} 범위여야 합니다.",
+        "step": "{label}는 {step} 단위로 입력해야 합니다.",
         "unsupportedVoice": "지원하지 않는 음성입니다.",
         "inputAudioUnsupported": "선택한 모델은 오디오 입력을 지원하지 않습니다.",
         "referenceTextRequired": "레퍼런스 텍스트를 입력해주세요.",

--- a/src/shared/model-catalog/runtime-schema.test.ts
+++ b/src/shared/model-catalog/runtime-schema.test.ts
@@ -29,6 +29,41 @@ const model: RuntimeAudioModel = {
 };
 
 describe("createRuntimeAudioSchema dynamicParams", () => {
+  it("HF-bound canonical step 오류에 provider label을 사용한다", () => {
+    const providerModel: RuntimeAudioModel = {
+      ...model,
+      parameters: {
+        ...model.parameters,
+        speed: {
+          ui: "range",
+          label: "Playback Rate",
+          min: 0.25,
+          max: 4,
+          step: 0.05,
+          binding: {
+            source: "hf_space",
+            parameterName: "speed",
+            valueType: "number",
+            canonicalKey: "speed",
+            order: 0,
+          },
+        },
+      },
+    };
+    const t = (key: string, values?: Record<string, string | number | Date>) =>
+      key === "step"
+        ? `${values?.label} step ${values?.step}`
+        : key;
+    const result = createRuntimeAudioSchema([providerModel], t).safeParse({
+      prompt: "hello",
+      model: providerModel.key,
+      speed: 1.025,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe("Playback Rate step 0.05");
+  });
+
   it("동적 number의 range와 step을 검증한다", () => {
     const schema = createRuntimeAudioSchema([model]);
 

--- a/src/shared/model-catalog/runtime-schema.ts
+++ b/src/shared/model-catalog/runtime-schema.ts
@@ -12,6 +12,7 @@ import {
   getRuntimeImageParamRange,
   getRuntimeVideoParamConfig,
   getRuntimeVideoParamRange,
+  resolveRuntimeParameterLabel,
   resolveRuntimeAudioSupportsInputAudio,
   resolveRuntimeImageMaxInputImages,
   resolveRuntimeVideoSupportsInitImage,
@@ -425,12 +426,16 @@ export function createRuntimeAudioSchema(
     }
 
     if (typeof data.speed === "number") {
+      const speedLabel = resolveRuntimeParameterLabel(
+        getRuntimeAudioParamConfig(model, "speed"),
+        labels.speed,
+      );
       const speedRange = getRuntimeAudioParamRange(model, "speed");
       if (data.speed < speedRange.min || data.speed > speedRange.max) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["speed"],
-          message: rangeMessage(labels.speed, speedRange.min, speedRange.max),
+          message: rangeMessage(speedLabel, speedRange.min, speedRange.max),
         });
       } else if (speedRange.step > 0) {
         const offset = data.speed - speedRange.min;
@@ -439,7 +444,7 @@ export function createRuntimeAudioSchema(
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: ["speed"],
-            message: stepMessage(labels.speed, speedRange.step),
+            message: stepMessage(speedLabel, speedRange.step),
           });
         }
       }
@@ -494,9 +499,13 @@ export function createRuntimeAudioSchema(
     const validateNumeric = (
       key: "chunkSize" | "temperature" | "topK" | "repetitionPenalty",
       value: number | undefined,
-      label: string,
+      fallbackLabel: string,
     ) => {
       if (typeof value !== "number") return;
+      const label = resolveRuntimeParameterLabel(
+        getRuntimeAudioParamConfig(model, key),
+        fallbackLabel,
+      );
       const range = getRuntimeAudioParamRange(model, key);
       if (value < range.min || value > range.max) {
         ctx.addIssue({

--- a/src/shared/model-catalog/runtime-utils.test.ts
+++ b/src/shared/model-catalog/runtime-utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolveRuntimeParameterLabel } from "@/shared/model-catalog/runtime-utils";
+
+describe("resolveRuntimeParameterLabel", () => {
+  it("HF binding이면 provider label을 우선한다", () => {
+    expect(
+      resolveRuntimeParameterLabel(
+        {
+          label: "Playback Rate",
+          binding: {
+            source: "hf_space",
+            parameterName: "speed",
+          },
+        },
+        "속도",
+      ),
+    ).toBe("Playback Rate");
+  });
+
+  it("provider label이 없으면 parameterName을 사용한다", () => {
+    expect(
+      resolveRuntimeParameterLabel(
+        {
+          binding: {
+            source: "hf_space",
+            parameterName: "model_size",
+          },
+        },
+        "Model",
+      ),
+    ).toBe("model_size");
+  });
+
+  it("HF binding이 없으면 앱 fallback label을 유지한다", () => {
+    expect(
+      resolveRuntimeParameterLabel(
+        {
+          label: "Legacy Speed",
+        },
+        "속도",
+      ),
+    ).toBe("속도");
+  });
+});

--- a/src/shared/model-catalog/runtime-utils.ts
+++ b/src/shared/model-catalog/runtime-utils.ts
@@ -30,6 +30,33 @@ export type RuntimeParameterConfig = {
   [key: string]: unknown;
 };
 
+type RuntimeParameterLabelConfig = {
+  label?: unknown;
+  binding?: {
+    source?: unknown;
+    parameterName?: unknown;
+  };
+};
+
+export function resolveRuntimeParameterLabel(
+  config: RuntimeParameterLabelConfig | undefined,
+  fallback: string,
+) {
+  if (config?.binding?.source !== "hf_space") {
+    return fallback;
+  }
+  if (typeof config.label === "string" && config.label.trim()) {
+    return config.label;
+  }
+  if (
+    typeof config.binding.parameterName === "string" &&
+    config.binding.parameterName.trim()
+  ) {
+    return config.binding.parameterName;
+  }
+  return fallback;
+}
+
 export type NormalizedRuntimeParameterConfig = {
   ui?: string;
   label?: string;

--- a/src/shared/ui/app-prompt-surface.tsx
+++ b/src/shared/ui/app-prompt-surface.tsx
@@ -6,6 +6,7 @@ interface AppPromptSurfaceProps {
   textarea: ReactNode;
   attachments?: ReactNode;
   header?: ReactNode;
+  feedback?: ReactNode;
   footer?: ReactNode;
   footerLeft?: ReactNode;
   footerRight?: ReactNode;
@@ -17,6 +18,7 @@ interface AppPromptFieldProps {
   textarea: ReactNode;
   attachments?: ReactNode;
   header?: ReactNode;
+  feedback?: ReactNode;
   footer?: ReactNode;
   footerLeft?: ReactNode;
   footerRight?: ReactNode;
@@ -41,6 +43,7 @@ export function AppPromptSurface({
   textarea,
   attachments,
   header,
+  feedback,
   footer,
   footerLeft,
   footerRight,
@@ -66,6 +69,14 @@ export function AppPromptSurface({
         ) : null}
       </div>
       {attachments}
+      {feedback ? (
+        <div
+          data-testid="shared-prompt-feedback"
+          className="border-t border-white/8 px-4 py-2"
+        >
+          {feedback}
+        </div>
+      ) : null}
       {footer ?? (
         <div className="flex flex-col gap-3 border-t border-white/12 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -82,6 +93,7 @@ export function AppPromptField({
   textarea,
   attachments,
   header,
+  feedback,
   footer,
   footerLeft,
   footerRight,
@@ -97,6 +109,7 @@ export function AppPromptField({
       textarea={textarea}
       attachments={attachments}
       header={header}
+      feedback={feedback}
       footer={footer}
       footerLeft={footerLeft}
       footerRight={footerRight}

--- a/src/shared/ui/app-select.test.tsx
+++ b/src/shared/ui/app-select.test.tsx
@@ -1,0 +1,28 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  AppSelectContent,
+  AppSelectItem,
+  AppSelectRoot,
+  AppSelectTrigger,
+  AppSelectValue,
+} from "@/shared/ui/app-select";
+import { renderWithIntl } from "@/test-utils/intl";
+
+describe("AppSelect", () => {
+  it("renders portal content above generation settings popovers", () => {
+    renderWithIntl(
+      <AppSelectRoot defaultOpen defaultValue="auto">
+        <AppSelectTrigger aria-label="Language">
+          <AppSelectValue />
+        </AppSelectTrigger>
+        <AppSelectContent>
+          <AppSelectItem value="auto">Auto</AppSelectItem>
+          <AppSelectItem value="korean">Korean</AppSelectItem>
+        </AppSelectContent>
+      </AppSelectRoot>,
+    );
+
+    expect(screen.getByRole("listbox")).toHaveClass("z-[100]");
+  });
+});

--- a/src/shared/ui/generation-prompt-field.test.tsx
+++ b/src/shared/ui/generation-prompt-field.test.tsx
@@ -57,4 +57,29 @@ describe("GenerationPromptField", () => {
     expect(field).toContainElement(wrapper);
     expect(wrapper).toContainElement(surface);
   });
+
+  it("renders feedback between the prompt textarea and footer controls", () => {
+    renderWithIntl(
+      <GenerationPromptField
+        textarea={<textarea aria-label="Prompt" />}
+        feedback={<p role="alert">Prompt is required</p>}
+        footerLeft={<button type="button">Model</button>}
+      />,
+    );
+
+    const surface = screen.getByTestId("shared-prompt-form-surface");
+    const textarea = screen.getByRole("textbox", { name: "Prompt" });
+    const feedback = screen.getByRole("alert");
+    const footerControl = screen.getByRole("button", { name: "Model" });
+
+    expect(surface).toContainElement(feedback);
+    expect(
+      textarea.compareDocumentPosition(feedback) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      feedback.compareDocumentPosition(footerControl) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
 });

--- a/src/shared/ui/generation-prompt-field.tsx
+++ b/src/shared/ui/generation-prompt-field.tsx
@@ -8,6 +8,7 @@ interface GenerationPromptFieldProps {
   textarea: ReactNode;
   attachments?: ReactNode;
   header?: ReactNode;
+  feedback?: ReactNode;
   footer?: ReactNode;
   footerLeft?: ReactNode;
   footerRight?: ReactNode;
@@ -23,6 +24,7 @@ interface GenerationPromptSurfaceProps {
   textarea: ReactNode;
   attachments?: ReactNode;
   header?: ReactNode;
+  feedback?: ReactNode;
   footer?: ReactNode;
   footerLeft?: ReactNode;
   footerRight?: ReactNode;
@@ -32,6 +34,7 @@ export function GenerationPromptSurface({
   textarea,
   attachments,
   header,
+  feedback,
   footer,
   footerLeft,
   footerRight,
@@ -41,6 +44,7 @@ export function GenerationPromptSurface({
       textarea={textarea}
       attachments={attachments}
       header={header}
+      feedback={feedback}
       footer={footer}
       footerLeft={footerLeft}
       footerRight={footerRight}
@@ -52,6 +56,7 @@ export function GenerationPromptField({
   textarea,
   attachments,
   header,
+  feedback,
   footer,
   footerLeft,
   footerRight,
@@ -67,6 +72,7 @@ export function GenerationPromptField({
       textarea={textarea}
       attachments={attachments}
       header={header}
+      feedback={feedback}
       footer={footer}
       footerLeft={footerLeft}
       footerRight={footerRight}

--- a/src/shared/ui/select.tsx
+++ b/src/shared/ui/select.tsx
@@ -44,7 +44,7 @@ const SelectContent = React.forwardRef<
       ref={ref}
       data-slot="select-content"
       className={cn(
-        "relative z-50 min-w-[8rem] overflow-hidden rounded-xl border border-white/10 bg-popover text-popover-foreground shadow-lg",
+        "relative z-[100] min-w-[8rem] overflow-hidden rounded-xl border border-white/10 bg-popover text-popover-foreground shadow-lg",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",


### PR DESCRIPTION
# PR Draft: audio-generation-form-ui-fixes

## 개요

- 변경 목적: 이미지·비디오·오디오 공통 생성 폼에서 prompt 오류가 dock 바깥에 표시되고 settings popover의 select option이 가려지는 문제를 수정한다. 오디오 생성 완료 후 동일 결과가 별도 action row로 중복 표시되는 문제도 제거한다.
- 사용자 영향: prompt 오류를 입력 바로 아래에서 확인할 수 있고 Language, Model Size 등 설정 옵션이 popover 위에 정상 표시된다. 오디오 결과는 하나의 player로 간결하게 표시된다.

## 변경 사항

- [x] 공통 prompt surface에 feedback slot을 추가하고 이미지·비디오·오디오 폼의 validation 메시지를 textarea 아래로 이동
- [x] 실제 validation 오류가 있을 때만 feedback wrapper를 렌더링해 정상 상태의 빈 strip 제거
- [x] HF-bound canonical 오디오 파라미터의 provider label을 UI와 검증에서 보존
- [x] HF Space import에서 API에 없는 fallback audio 파라미터 자동 추가 제거
- [x] required 오디오 설정 필드 label에 별도 빨간 `*` 마커 표시
- [x] 공통 Select portal layer를 settings popover보다 높은 `z-[100]`으로 조정
- [x] 오디오 `GenerationCanvas` player는 유지하면서 중복 결과 action row와 관련 아이콘 제거
- [x] 공통 컴포넌트와 세 생성 폼 회귀 테스트 추가

## 테스트

- [x] `pnpm vitest run src/shared/ui/generation-prompt-field.test.tsx src/shared/ui/app-select.test.tsx src/features/image-generation/ui/image-generation-form.test.tsx src/features/video-generation/ui/video-generation-form.test.tsx src/features/audio-generation/ui/audio-generation-form.test.tsx` (`5 files, 39 tests`)
- [x] `pnpm db:generate && pnpm typecheck`
- [x] 변경 파일 대상 `pnpm eslint ...`
- [x] 로컬 `/audio`, `/image`, `/video` 공통 prompt surface DOM 순서 확인
- [x] HF provider label resolver 관련 8 files / 53 tests, typecheck, ESLint, 번역 JSON 검증
- [x] HF Space audio importer fallback 제거 관련 5 files / 31 tests, typecheck, ESLint
- [x] required 오디오 설정 label marker 관련 audio form test, typecheck, ESLint

## 아키텍처 다이어그램

```mermaid
sequenceDiagram
  participant User as 생성 폼 사용자
  participant Form as Audio/Image/Video Form
  participant Prompt as GenerationPromptField
  participant Select as AppSelectContent
  participant HF as HF Runtime Metadata

  User->>Form: prompt와 설정 입력
  Form->>Prompt: validation feedback slot 전달
  Prompt-->>User: textarea 아래 오류 표시
  Form->>Select: settings select option open
  Select-->>User: popover 위 z-index로 option 표시
  HF->>Form: provider parameter label/required metadata
  Form-->>User: provider label 유지 및 required * 표시
```

## 관련 문서

- Spec: `features/F051-audio-generation-form-ui-fixes/spec.md`
- Tasks: `features/F051-audio-generation-form-ui-fixes/tasks.md`
- Decisions: `features/F051-audio-generation-form-ui-fixes/decisions.md`

Closes #99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 필수 입력 필드에 표시 마커 추가
  * 파라미터 라벨이 제공자 설정에 따라 동적으로 표시됨 (예: "재생 속도")
  * 프롬프트 오류 메시지가 입력 영역 내에 통합 표시

* **Bug Fixes**
  * 오디오/이미지/비디오 생성 폼의 에러 피드백 위치 개선
  * 검증 메시지에 올바른 파라미터 라벨 표시
  * 드롭다운 표시 순서 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->